### PR TITLE
fix: Add missing placement fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -164,7 +164,7 @@ Array [
                   }
                 }
               >
-                version: 0.12.1
+                version: 0.12.2
               </span>
             </a>
           </li>

--- a/src/components/profile/placements/PlacementPanel.tsx
+++ b/src/components/profile/placements/PlacementPanel.tsx
@@ -16,6 +16,10 @@ export const PlacementPanel = (props: IPlacementPanelProps) => {
         <SummaryList.Key>Site</SummaryList.Key>
         <SummaryList.Value>{data.site}</SummaryList.Value>
       </SummaryList.Row>
+      <SummaryList.Row>
+        <SummaryList.Key>Site Location</SummaryList.Key>
+        <SummaryList.Value>{data.siteLocation}</SummaryList.Value>
+      </SummaryList.Row>
 
       <SummaryList.Row>
         <SummaryList.Key>
@@ -25,7 +29,6 @@ export const PlacementPanel = (props: IPlacementPanelProps) => {
           {DateUtilities.ToLocalDate(data.startDate)}
         </SummaryList.Value>
       </SummaryList.Row>
-
       <SummaryList.Row>
         <SummaryList.Key>Ends</SummaryList.Key>
         <SummaryList.Value>
@@ -33,10 +36,24 @@ export const PlacementPanel = (props: IPlacementPanelProps) => {
         </SummaryList.Value>
       </SummaryList.Row>
       <SummaryList.Row>
+        <SummaryList.Key>Whole Time Equivalent</SummaryList.Key>
+        <SummaryList.Value>{data.wholeTimeEquivalent}</SummaryList.Value>
+      </SummaryList.Row>
+
+      <SummaryList.Row>
         <SummaryList.Key>
           <span className="noWrap">Specialty</span>
         </SummaryList.Key>
         <SummaryList.Value>{data.specialty}</SummaryList.Value>
+      </SummaryList.Row>
+
+      <SummaryList.Row>
+        <SummaryList.Key>Employing Body</SummaryList.Key>
+        <SummaryList.Value>{data.employingBody}</SummaryList.Value>
+      </SummaryList.Row>
+      <SummaryList.Row>
+        <SummaryList.Key>Training Body</SummaryList.Key>
+        <SummaryList.Value>{data.trainingBody}</SummaryList.Value>
       </SummaryList.Row>
     </SummaryList>
   );

--- a/src/components/profile/placements/Placements.tsx
+++ b/src/components/profile/placements/Placements.tsx
@@ -9,10 +9,10 @@ interface IPlacementProps {
 }
 
 const Placements: React.FC<IPlacementProps> = ({ placements }) => {
-  const columnWidths: any[] = ["full", "full", "one-half", "one-third"];
+  const columnWidths: any[] = ["full", "full", "one-half"];
   let columnWidth = columnWidths[placements.length]
     ? columnWidths[placements.length]
-    : "one-third";
+    : "one-half";
 
   return (
     placements && (

--- a/src/mock-data/trainee-profile.ts
+++ b/src/mock-data/trainee-profile.ts
@@ -112,7 +112,10 @@ export const mockPlacements = [
     siteLocation: "Site location",
     specialty: "Dermatology",
     startDate: new Date("2020-01-01"),
-    status: Status.Current
+    status: Status.Current,
+    employingBody: "Employing body",
+    trainingBody: "Training body",
+    wholeTimeEquivalent: "0.5"
   }
 ];
 

--- a/src/models/Placement.ts
+++ b/src/models/Placement.ts
@@ -9,5 +9,8 @@ export interface Placement {
   grade: string;
   specialty: string;
   placementType: string;
+  employingBody: string;
+  trainingBody: string;
+  wholeTimeEquivalent: string;
   status: Status;
 }


### PR DESCRIPTION
Add `employingBody`, `trainingBody`, `wholeTimeEquivlent` and
`siteLocation` fields to the placement panel.

Update the placements to be displayed as halves instead of thirds as the
new data becomes too cramped with thirds.

TIS21-1032