### PR TITLE
fix: Rename placementTisId field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -164,7 +164,7 @@ Array [
                   }
                 }
               >
-                version: 0.12.2
+                version: 0.12.3
               </span>
             </a>
           </li>

--- a/src/mock-data/trainee-profile.ts
+++ b/src/mock-data/trainee-profile.ts
@@ -106,7 +106,7 @@ export const mockPlacements = [
   {
     endDate: new Date("2020-12-31"),
     grade: "ST1",
-    placementTisId: "315",
+    tisId: "315",
     placementType: "In Post",
     site: "Addenbrookes Hospital",
     siteLocation: "Site location",

--- a/src/models/Placement.ts
+++ b/src/models/Placement.ts
@@ -1,7 +1,7 @@
 import { Status } from "./Status";
 
 export interface Placement {
-  placementTisId: string;
+  tisId: string;
   startDate: Date;
   endDate: Date;
   site: string;


### PR DESCRIPTION
The `placementTisId` field was renamed to `tisId` in the backend and
needs updating here.

TIS21-1032