### PR TITLE
fix: so e2e task shows as failed in github

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,10 +81,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Get workflow
+        run: |
+          echo "workflow=$(echo ${{ github.workflow }} | sed -e 's/\W/-/g' -e 's/\(.*\)/\L\1/')" >> $GITHUB_ENV
 
       - name: Cypress run
         uses: cypress-io/github-action@v2
-        continue-on-error: true
         env:
           CYPRESS_baseUrl: https://trainee.tis.nhs.uk
           CYPRESS_password: ${{ secrets.E2E_TEST_PASS }}
@@ -93,34 +95,66 @@ jobs:
           browser: chrome
 
       - name: Merge test results into one
+        if: always()
         run: npm run report:merge
 
       - name: Generate HTML report
+        if: always()
         run: npm run report:generate
 
       - name: Create report artifact
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: cypress-reports
           path: cypress/reports
 
       - name: Create screenshot artifact
-        uses: actions/upload-artifact@v2
-        # No screenshots generated if tests pass.
         if: failure()
+        uses: actions/upload-artifact@v2
+
         with:
           name: cypress-screenshots
           path: cypress/screenshots
 
       - name: Create video artifact
-        uses: actions/upload-artifact@v2
         # Test run video was always captured, so this action uses "always()" condition
         if: always()
+        uses: actions/upload-artifact@v2
         with:
           name: cypress-videos
           path: cypress/videos
 
+      - name: Slack Notify - Test Fails
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2.1.2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: TIS-Self-Service
+          SLACK_TITLE: "TISSS E2E TESTS FAILED."
+          SLACK_CHANNEL: notifications-e2e-test-results
+          SLACK_ICON_EMOJI: ":test_tube_red:"
+          SLACK_MESSAGE: Cypress reports for TIS Self Service available at https://tis-build-artifacts/${{ github.event.repository.name }}/${{env.workflow}}/${{ github.run_number }}/cypress-reports
+          SLACK_COLOR: FF0000
+          SLACK_FOOTER: I have not failed. I have just found 10,000 ways that won't work.
+          MSG_MINIMAL: true
+
+      - name: Slack Notify - Tests Pass
+        if: success()
+        uses: rtCamp/action-slack-notify@v2.1.2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: TIS-Self-Service
+          SLACK_TITLE: "TISSS E2E TESTS PASSED."
+          SLACK_CHANNEL: notifications-e2e-test-results
+          SLACK_ICON_EMOJI: ":test_tube:"
+          SLACK_MESSAGE: Cypress reports for TIS Self Service available at https://tis-build-artifacts/${{ github.event.repository.name }}/${{env.workflow}}/${{ github.run_number }}/cypress-reports
+          SLACK_COLOR: 00CC00
+          SLACK_FOOTER: It's impossible to be unhappy in a poncho.
+          MSG_MINIMAL: true
+
   backup-artifacts:
+    if: always()
     needs: [cypress-e2e]
     name: Backup build artifacts
     runs-on: ubuntu-latest
@@ -142,26 +176,6 @@ jobs:
         run: |
           workflow=$(echo ${{ github.workflow }} | sed -e 's/\W/-/g' -e 's/\(.*\)/\L\1/')
           aws s3 sync build-artifacts s3://tis-build-artifacts/${{ github.event.repository.name }}/$workflow/${{ github.run_number }}
-
-  send-slack:
-    needs: [backup-artifacts]
-    name: Send notification to Slack
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get workflow
-        run: |
-          echo "workflow=$(echo ${{ github.workflow }} | sed -e 's/\W/-/g' -e 's/\(.*\)/\L\1/')" >> $GITHUB_ENV
-      - name: Slack Notify
-        uses: rtCamp/action-slack-notify@v2.1.2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_USERNAME: TIS-Self-Service
-          SLACK_CHANNEL: notifications-e2e-test-results
-          SLACK_ICON_EMOJI: ":test_tube:"
-          SLACK_MESSAGE: Cypress reports for TIS Self Service available at https://tis-build-artifacts/${{ github.event.repository.name }}/${{env.workflow}}/${{ github.run_number }}/cypress-reports
-          SLACK_FOOTER: It's impossible to be unhappy in a poncho.
-          MSG_MINIMAL: true
 
   deploy-prod:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,6 +81,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Get workflow
         run: |
           echo "workflow=$(echo ${{ github.workflow }} | sed -e 's/\W/-/g' -e 's/\(.*\)/\L\1/')" >> $GITHUB_ENV


### PR DESCRIPTION
The E2E task in the deploy action included a continue-on-error flag so fails were not showing in GitHub. This flag has been removed and additional conditionals have been added to make sure the artifacts are still generated and backed-up and Slack message sent. The Slack messaging has been separated for success and failures and styled accordingly.  

NO TICKET