### PR TITLE
test:remove other immigration status test

### DIFF
--- a/cypress/integration/formr-a/formr-a.spec.ts
+++ b/cypress/integration/formr-a/formr-a.spec.ts
@@ -58,20 +58,10 @@ describe("Form R (Part A)", () => {
             .should("not.be.empty");
 
           cy.get("#gender").should("exist").should("have.value", "Male");
-          //Test for 'Other' immigration status
           cy.get("#immigrationStatus")
             .should("exist")
-            .select(
-              "Other immigration categories i.e. overseas government employees, innovators etc."
-            )
-            .should(
-              "have.value",
-              "Other immigration categories i.e. overseas government employees, innovators etc."
-            );
-          cy.get("#otherImmigrationStatus")
-            .should("exist")
-            .type("My special status")
-            .should("have.value", "My special status");
+            .select("Tier 1")
+            .should("have.value", "Tier 1");
           cy.get("#qualification")
             .should("exist")
             .invoke("val")
@@ -197,21 +187,10 @@ describe("Form R (Part A)", () => {
             .type("1991-11-11");
 
           cy.get("#gender").should("exist").select("Male");
-          //Test for 'Other' immigration status
           cy.get("#immigrationStatus")
             .should("exist")
-            .select(
-              "Other immigration categories i.e. overseas government employees, innovators etc."
-            )
-            .should(
-              "have.value",
-              "Other immigration categories i.e. overseas government employees, innovators etc."
-            );
-          cy.get("#otherImmigrationStatus")
-            .should("exist")
-            .clear()
-            .type("My special status")
-            .should("have.value", "My special status");
+            .select("Tier 1")
+            .should("have.value", "Tier 1");
 
           cy.get("#qualification")
             .should("exist")

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,19 +37,11 @@ Cypress.Commands.add(
     cy.get("#dateOfBirth").should("exist").invoke("val").should("not.be.empty");
 
     cy.get("#gender").should("exist").should("have.value", "Male");
-    //Test for 'Other' immigration status
     cy.get("#immigrationStatus")
       .should("exist")
-      .select(
-        "Other immigration categories i.e. overseas government employees, innovators etc."
-      )
-      .should(
-        "have.value",
-        "Other immigration categories i.e. overseas government employees, innovators etc."
-      );
-    cy.get("#otherImmigrationStatus")
-      .should("exist")
-      .should("have.value", "My special status");
+      .select("Tier 1")
+      .should("have.value", "Tier 1");
+
     cy.get("#qualification")
       .should("exist")
       .should("not.have.value", "--Please select--");


### PR DESCRIPTION
Immigration status of other is no longer required so test removed from E2E. This status will need to be removed from the code and the field otherImmigrationStatus removed from data model. However, leaving this does not impact the application and in the spirit of E2EDD, wanted to commit this change first so tests pass and refactor code later.  