### PR TITLE
fix:update container to defined tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
     needs: [deploy-pre-prod]
     name: Run Cypress E2E tests
     runs-on: ubuntu-latest
-    container: cypress/browsers:latest
+    container: cypress/browsers:node14.16.0-chrome89-ff86
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
E2E tests were failing due to running against a version of Chrome that was greater than 3 versions behind the current, resulting in the banner being displayed and concealing some inputs. The container `cypress/browser:latest` appears not to be latest having been updated 5 months ago and runs Chrome 83 so I have set this as a the actual latest container tag. Going forward, I don't think we should rewrite the tests to accommodate the presence of the banner since we don't support that browser version, but we will need to update the container tag periodically as the version of chrome is updated, or find an alternative approach.