### PR TITLE
fix: error when non medical curriculum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.3",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -57,7 +57,7 @@ Array [
           </p>
           <p>
             For further information and support, visit the
-
+             
             <a
               href="https://tis-support.hee.nhs.uk"
               style={
@@ -141,7 +141,7 @@ Array [
         <p
           className="nhsuk-footer__copyright"
         >
-          ©
+          © 
           <a
             href="https://www.hee.nhs.uk"
           >
@@ -193,7 +193,7 @@ Array [
         </h3>
         <p>
           We use necessary cookies to make our site work and analytics cookies to help us improve it. In order use this site, you must agree to the storing of such cookies on your device by clicking 'Accept and close'. To learn more about how we use cookies and your data, please see our
-
+           
           <a
             href="https://www.hee.nhs.uk/about/privacy-notice"
             rel="noopener noreferrer nofollow"

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -57,7 +57,7 @@ Array [
           </p>
           <p>
             For further information and support, visit the
-             
+
             <a
               href="https://tis-support.hee.nhs.uk"
               style={
@@ -141,7 +141,7 @@ Array [
         <p
           className="nhsuk-footer__copyright"
         >
-          © 
+          ©
           <a
             href="https://www.hee.nhs.uk"
           >
@@ -164,7 +164,7 @@ Array [
                   }
                 }
               >
-                version: 0.15.0
+                version: 0.15.1
               </span>
             </a>
           </li>
@@ -193,7 +193,7 @@ Array [
         </h3>
         <p>
           We use necessary cookies to make our site work and analytics cookies to help us improve it. In order use this site, you must agree to the storing of such cookies on your device by clicking 'Accept and close'. To learn more about how we use cookies and your data, please see our
-           
+
           <a
             href="https://www.hee.nhs.uk/about/privacy-notice"
             rel="noopener noreferrer nofollow"

--- a/src/mock-data/trainee-profile.ts
+++ b/src/mock-data/trainee-profile.ts
@@ -102,6 +102,51 @@ export const mockProgrammeMemberships = [
   }
 ];
 
+export const mockProgrammeMembershipNoCurricula = {
+  startDate: new Date("2020-01-01"),
+  endDate: new Date("2022-01-01"),
+  programmeCompletionDate: new Date("2019-12-31"),
+  programmeTisId: "1",
+  programmeName: "Cardiology",
+  programmeNumber: "EOE8945",
+  managingDeanery: "Health Education England East of England",
+  programmeMembershipType: "SUBSTANTIVE",
+  status: Status.Current,
+  curricula: []
+};
+
+export const mockProgrammeMembershipNoMedicalCurricula = {
+  startDate: new Date("2020-01-01"),
+  endDate: new Date("2022-01-01"),
+  programmeCompletionDate: new Date("2019-12-31"),
+  programmeTisId: "1",
+  programmeName: "Cardiology",
+  programmeNumber: "EOE8945",
+  managingDeanery: "Health Education England East of England",
+  programmeMembershipType: "SUBSTANTIVE",
+  status: Status.Current,
+  curricula: [
+    {
+      curriculumTisId: "4",
+      curriculumName: "ST4",
+      curriculumSubType: "DENTAL_CURRICULUM",
+      curriculumStartDate: new Date("2022-01-01")
+    },
+    {
+      curriculumTisId: "5",
+      curriculumName: "ST5",
+      curriculumSubType: "ACF_OTHER_FUNDING",
+      curriculumStartDate: new Date("2022-06-01")
+    },
+    {
+      curriculumTisId: "6",
+      curriculumName: "ST6",
+      curriculumSubType: "DENTAL_CURRICULUM",
+      curriculumStartDate: new Date("2022-08-01")
+    }
+  ]
+};
+
 export const mockPlacements = [
   {
     endDate: new Date("2020-12-31"),

--- a/src/models/ProfileToFormRPartAInitialValues.ts
+++ b/src/models/ProfileToFormRPartAInitialValues.ts
@@ -22,9 +22,12 @@ export function ProfileToFormRPartAInitialValues(
     programme && programme.curricula.length > 0
       ? programme.curricula
           .filter(c => c.curriculumSubType === MEDICAL_CURRICULUM)
-          .reduce(function (a, b) {
-            return a.curriculumStartDate > b.curriculumStartDate ? a : b;
-          })
+          .sort(
+            (a, b) =>
+              new Date(b.curriculumStartDate).getTime() -
+              new Date(a.curriculumStartDate).getTime()
+          )
+          .shift()
       : null;
 
   const model: FormRPartA = {

--- a/src/models/ProfileToFormRPartBInitialValues.ts
+++ b/src/models/ProfileToFormRPartBInitialValues.ts
@@ -22,9 +22,12 @@ export function ProfileToFormRPartBInitialValues(
     programme && programme.curricula.length > 0
       ? programme.curricula
           .filter(c => c.curriculumSubType === MEDICAL_CURRICULUM)
-          .reduce(function (a, b) {
-            return a.curriculumStartDate > b.curriculumStartDate ? a : b;
-          })
+          .sort(
+            (a, b) =>
+              new Date(b.curriculumStartDate).getTime() -
+              new Date(a.curriculumStartDate).getTime()
+          )
+          .shift()
       : null;
 
   const work = traineeProfile.placements.map<Work>(placement => ({

--- a/src/models/__test__/ProfileToFormRPartAInitialValues.test.ts
+++ b/src/models/__test__/ProfileToFormRPartAInitialValues.test.ts
@@ -1,5 +1,9 @@
 import { ProfileToFormRPartAInitialValues } from "./../ProfileToFormRPartAInitialValues";
-import { mockTraineeProfile } from "../../mock-data/trainee-profile";
+import {
+  mockProgrammeMembershipNoCurricula,
+  mockProgrammeMembershipNoMedicalCurricula,
+  mockTraineeProfile
+} from "../../mock-data/trainee-profile";
 import { FormRPartA } from "../FormRPartA";
 import { LifeCycleState } from "../LifeCycleState";
 
@@ -57,6 +61,28 @@ describe("ProfileToFormRPartAInitialValues", () => {
 
   it("should return formRPartA with empty programmespeciality when no programmeMemberships available", () => {
     const traineeProfile = { ...mockTraineeProfile, programmeMemberships: [] };
+    expect(
+      ProfileToFormRPartAInitialValues(traineeProfile)?.programmeSpecialty
+    ).toEqual("");
+  });
+
+  it("should return formRPartA with empty programmeSpecialty when no curriculum", () => {
+    const traineeProfile = {
+      ...mockTraineeProfile,
+      programmeMemberships: [mockProgrammeMembershipNoCurricula]
+    };
+
+    expect(
+      ProfileToFormRPartAInitialValues(traineeProfile)?.programmeSpecialty
+    ).toEqual("");
+  });
+
+  it("should return formRPartA with empty programmeSpecialty when no medical curriculum", () => {
+    const traineeProfile = {
+      ...mockTraineeProfile,
+      programmeMemberships: [mockProgrammeMembershipNoMedicalCurricula]
+    };
+
     expect(
       ProfileToFormRPartAInitialValues(traineeProfile)?.programmeSpecialty
     ).toEqual("");

--- a/src/models/__test__/ProfileToFormRPartBInitialValues.test.ts
+++ b/src/models/__test__/ProfileToFormRPartBInitialValues.test.ts
@@ -1,5 +1,9 @@
 import { ProfileToFormRPartBInitialValues } from "./../ProfileToFormRPartBInitialValues";
-import { mockTraineeProfile } from "../../mock-data/trainee-profile";
+import {
+  mockProgrammeMembershipNoCurricula,
+  mockProgrammeMembershipNoMedicalCurricula,
+  mockTraineeProfile
+} from "../../mock-data/trainee-profile";
 import { FormRPartB } from "../FormRPartB";
 import { LifeCycleState } from "../LifeCycleState";
 
@@ -68,14 +72,36 @@ describe("ProfileToFormRPartBInitialValues", () => {
     ).toEqual("ST6");
   });
 
-  it("should return formRPartA with empty programmespeciality when no programmeMemberships available", () => {
+  it("should return formRPartB with empty programmespeciality when no programmeMemberships available", () => {
     const traineeProfile = { ...mockTraineeProfile, programmeMemberships: [] };
     expect(
       ProfileToFormRPartBInitialValues(traineeProfile)?.programmeSpecialty
     ).toEqual("");
   });
 
-  it("should return formRPartA with empty strings when no personal details available", () => {
+  it("should return formRPartB with empty programmeSpecialty when no curriculum", () => {
+    const traineeProfile = {
+      ...mockTraineeProfile,
+      programmeMemberships: [mockProgrammeMembershipNoCurricula]
+    };
+
+    expect(
+      ProfileToFormRPartBInitialValues(traineeProfile)?.programmeSpecialty
+    ).toEqual("");
+  });
+
+  it("should return formRPartB with empty programmeSpecialty when no medical curriculum", () => {
+    const traineeProfile = {
+      ...mockTraineeProfile,
+      programmeMemberships: [mockProgrammeMembershipNoMedicalCurricula]
+    };
+
+    expect(
+      ProfileToFormRPartBInitialValues(traineeProfile)?.programmeSpecialty
+    ).toEqual("");
+  });
+
+  it("should return formRPartB with empty strings when no personal details available", () => {
     const traineeProfile = { ...mockTraineeProfile, personalDetails: null };
     expect(ProfileToFormRPartBInitialValues(traineeProfile)?.forename).toEqual(
       ""


### PR DESCRIPTION
When the trainee's latest programme had no medical curriculums the
FormA/B failed to load, due to a TypeError on the `reduce()` function
called on the empty array.

Perform a sort instead of reduce to get the latest curriculum as it
better handles the empty array.

TIS21-1327