### PR TITLE
fix: Breaking change after updating aws-amplify-react from 3 to 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7137,9 +7137,9 @@
       }
     },
     "aws-amplify-react": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/aws-amplify-react/-/aws-amplify-react-3.1.9.tgz",
-      "integrity": "sha512-kDPfoW0QoyfUfpL0dP8OO8xZIbO3n/RSCQ4HkzbGOvUYUDOD7ghoWWOw3qNHSbcdOylTZsat0wKuBiTlkCHV+A==",
+      "version": "4.2.30",
+      "resolved": "https://registry.npmjs.org/aws-amplify-react/-/aws-amplify-react-4.2.30.tgz",
+      "integrity": "sha512-fitvtcBMrogDNVd1grqcu7bWRhriAmJl6X9dn6w5OuJ3TsZLZG6Rfg9CH4pI42oa3tzvQJuibq3qQfyYcBatDA==",
       "requires": {
         "qrcode.react": "^0.8.0",
         "regenerator-runtime": "^0.11.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "private": true,
   "dependencies": {
     "@sentry/browser": "^5.20.1",
@@ -12,7 +12,7 @@
     "@types/react-router-dom": "^5.1.5",
     "@types/yup": "0.29.11",
     "aws-amplify": "^3.3.13",
-    "aws-amplify-react": "^3.1.5",
+    "aws-amplify-react": "^4.2.30",
     "axios": "^0.21.1",
     "browser-update": "^3.3.25",
     "eslint-plugin-cypress": "^2.11.2",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -147,7 +147,7 @@ Array [
                   }
                 }
               >
-                version: 0.19.2
+                version: 0.19.3
               </span>
             </a>
           </li>

--- a/src/components/authentication/Login.tsx
+++ b/src/components/authentication/Login.tsx
@@ -6,6 +6,7 @@ import {
   ForgotPassword,
   RequireNewPassword
 } from "aws-amplify-react";
+import "@aws-amplify/ui/dist/style.css";
 
 import styles from "./Login.module.scss";
 import { LoginTheme } from "./LoginTheme";


### PR DESCRIPTION
**Problem**
As of aws-amplify-react@4, the Authenticator is not styled

Solution
Manually import default css to provide a base for our custom css changes.

NOTE: The next step (new tech improvement ticket) will be to replace **aws-amplify-react** (legacy) with **@aws-amplify/ui-react** (although from a brief look at the new library, the API doesn't look to be as user-friendly)

TIS21-1445   

