### PR TITLE
Change Sensitive data heading and labels

### DIFF
--- a/cypress/integration/profile/profile.spec.ts
+++ b/cypress/integration/profile/profile.spec.ts
@@ -3,10 +3,10 @@ describe("Profile", () => {
   it("should click expand to show all personal information then toggle close", () => {
     cy.contains("Personal details").should("exist").click();
     cy.contains("Gender").should("exist");
-    cy.contains("Sensitive data").should("exist");
+    cy.contains("Registration details").should("exist");
     cy.contains("Personal details").click();
     cy.contains("Gender").should("not.be.visible");
-    cy.contains("Sensitive data").should("not.be.visible");
+    cy.contains("Registration details").should("not.be.visible");
   });
 
   it("should click expand to show placement information then toggle close", () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "private": true,
   "dependencies": {
     "@sentry/browser": "^5.20.1",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -147,7 +147,7 @@ Array [
                   }
                 }
               >
-                version: 0.19.4
+                version: 0.19.5
               </span>
             </a>
           </li>

--- a/src/components/profile/personal-details/PersonalDetailsComponent.tsx
+++ b/src/components/profile/personal-details/PersonalDetailsComponent.tsx
@@ -26,12 +26,24 @@ const PersonalDetailsComponent: React.FC<IProps> = ({ personalDetails }) => {
     { label: "Mobile", value: personalDetails.mobileNumber }
   ];
 
-  const sensitiveData: KeyValue[] = [
-    { label: "GMC", value: personalDetails.gmcNumber },
-    { label: "GDC", value: personalDetails.gdcNumber },
-    { label: "PH", value: personalDetails.publicHealthNumber },
-    { label: "GMC status", value: personalDetails.gmcStatus },
-    { label: "GDC status", value: personalDetails.gdcStatus },
+  const registrationDetails: KeyValue[] = [
+    {
+      label: "General Medical Council (GMC)",
+      value: personalDetails.gmcNumber
+    },
+    { label: "General Dental Council (GDC)", value: personalDetails.gdcNumber },
+    {
+      label: "Public Health Number",
+      value: personalDetails.publicHealthNumber
+    },
+    {
+      label: "GMC status",
+      value: personalDetails.gmcStatus
+    },
+    {
+      label: "GDC status",
+      value: personalDetails.gdcStatus
+    },
     { label: "Permit to Work", value: personalDetails.permitToWork },
     { label: "Settled", value: personalDetails.settled },
     { label: "Visa Issued", value: personalDetails.visaIssued },
@@ -68,14 +80,14 @@ const PersonalDetailsComponent: React.FC<IProps> = ({ personalDetails }) => {
             </SummaryList.Value>
           </SummaryList.Row>
           <div className="nhsuk-heading-m nhsuk-u-margin-top-4">
-            Sensitive data
+            Registration details
           </div>
-          {sensitiveData.map(
-            sd =>
-              sd.value && (
-                <SummaryList.Row key={sd.label}>
-                  <SummaryList.Key>{sd.label}</SummaryList.Key>
-                  <SummaryList.Value>{sd.value}</SummaryList.Value>
+          {registrationDetails.map(
+            rd =>
+              rd.value && (
+                <SummaryList.Row key={rd.label}>
+                  <SummaryList.Key>{rd.label}</SummaryList.Key>
+                  <SummaryList.Value>{rd.value}</SummaryList.Value>
                 </SummaryList.Row>
               )
           )}


### PR DESCRIPTION
- Rename the Sensitive data heading to Registration details. 

- Instead of GMC, GDC, PH, to have the full label or registration bodies visible to make the fields more explicit.

TIS21-1348