### PR TITLE
Fix/persistent spinner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "private": true,
   "dependencies": {
     "@sentry/browser": "^5.20.1",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -147,7 +147,7 @@ Array [
                   }
                 }
               >
-                version: 0.21.2
+                version: 0.21.3
               </span>
             </a>
           </li>

--- a/src/components/forms/CreateList.tsx
+++ b/src/components/forms/CreateList.tsx
@@ -121,7 +121,7 @@ export const CreateList = (
         );
       }
 
-      if (draftForm.length === 1) {
+      if (draftForm.length >= 1) {
         return (
           <Button
             id="btnOpenForm"
@@ -135,9 +135,6 @@ export const CreateList = (
         );
       }
 
-      if (draftForm.length > 1) {
-        return <Loading />;
-      }
       return (
         <Button
           id="btnOpenForm"


### PR DESCRIPTION
The displaying of the spinner instead of the create new/edit draft button on forms list page was happening when the number of drafts returned was greater than one. The edit draft button now displays when drafts is >= 1 and the first draft form saved is displayed. 

https://hee-tis.atlassian.net/browse/TIS21-1492
