### PR TITLE
feat:add confirm signin component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "private": true,
   "dependencies": {
     "@sentry/browser": "^5.20.1",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -147,7 +147,7 @@ Array [
                   }
                 }
               >
-                version: 0.22.0
+                version: 0.23.0
               </span>
             </a>
           </li>

--- a/src/components/authentication/Login.tsx
+++ b/src/components/authentication/Login.tsx
@@ -4,7 +4,8 @@ import {
   Authenticator,
   SignIn,
   ForgotPassword,
-  RequireNewPassword
+  RequireNewPassword,
+  ConfirmSignIn
 } from "aws-amplify-react";
 import "@aws-amplify/ui/dist/style.css";
 
@@ -50,6 +51,7 @@ const Login = (props: LoginProps) => {
               <SignIn />
               <ForgotPassword />
               <RequireNewPassword />
+              <ConfirmSignIn />
             </Authenticator>
           </div>
         </div>


### PR DESCRIPTION
- Add SMS MFA support to existing version of amplify UI components
- SMS MFA must be enabled for each user in relevant Cognito user pool assuming pool has MFA set to optional
- Phone number must be verified. If not, the confirm box is displayed and SMS message is sent but authentication will fail.
- Users without SMS MFA enabled will be able to login as before.

https://hee-tis.atlassian.net/browse/TIS21-1459