### PR TITLE
chore: Bump react and react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "private": true,
   "dependencies": {
     "@sentry/browser": "^5.20.1",
@@ -22,9 +22,9 @@
     "nhsuk-frontend": "^3.1.0",
     "nhsuk-react-components": "^1.2.5",
     "prettier": "^2.2.1",
-    "react": "^17.0.1",
+    "react": "^17.0.2",
     "react-cookie-consent": "^5.2.0",
-    "react-dom": "^17.0.1",
+    "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
     "react-loading": "^2.0.3",
     "react-redux": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@sentry/browser": "^5.20.1",
     "@types/node": "^14.14.32",
     "@types/react": "^17.0.3",
-    "@types/react-dom": "^17.0.0",
+    "@types/react-dom": "^17.0.3",
     "@types/react-helmet": "^6.1.0",
     "@types/react-router-dom": "^5.1.5",
     "@types/yup": "0.29.11",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -147,7 +147,7 @@ Array [
                   }
                 }
               >
-                version: 0.23.1
+                version: 0.23.2
               </span>
             </a>
           </li>


### PR DESCRIPTION
This should get rid of sharedArrayBuffer cross-origin console warning
https://github.com/facebook/react/issues/20829

TIS21-1527
