### PR TITLE
Unregister sw

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "private": true,
   "dependencies": {
     "@sentry/browser": "^5.20.1",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -147,7 +147,7 @@ Array [
                   }
                 }
               >
-                version: 0.23.2
+                version: 0.23.3
               </span>
             </a>
           </li>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,7 +50,7 @@ async function fetchData(): Promise<any> {
     </Provider>,
     document.getElementById("root")
   );
-  serviceWorker.register();
+  serviceWorker.unregister();
 })();
 
 Sentry.init({


### PR DESCRIPTION
**Problem**
Console error `Error during service worker registration: DOMException: Failed to register a ServiceWorker for scope ('https://trainee.tis-selfservice.nhs.uk/') with script ('https://trainee.tis-selfservice.nhs.uk/service-worker.js'): The script has an unsupported MIME type ('text/html')` when the preprod and prod versions run - following a recent CRA (create-react-app) upgrade.

**Quick fix(es)**
Given we're not deploying a PWA at present, there is no need to register a service worker.
- unregister service worker
(if this doesn't fix the error then we can delete the serviceWorker.ts file and related files in index.ts) 

**Longer-term fix**
If we do plan to develop a PWA then this error relating to service worker registration needs to be fixed. Latest suggestions involve moving the serviceWorker.ts file to the public folder


TIS21-1511