### PR TITLE
fix:add IE specific message to index.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "private": true,
   "dependencies": {
     "@sentry/browser": "^5.20.1",

--- a/public/index.html
+++ b/public/index.html
@@ -4,11 +4,32 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Trainee UI web application" />
+    <meta
+      name="description"
+      content="Health Education England Trainee Self-Service web application"
+    />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="stylesheet" media="print" href="%PUBLIC_URL%/print.css" />
-    <title>Trainee UI</title>
+    <title>Trainee Self-Service</title>
+
+    <div id="ieMsg" hidden>
+      <h1>
+        Your web browser Internet Explorer is not supported by TIS Self Service.
+      </h1>
+      <p>
+        TIS Self Service application has been designed to work with modern web
+        browsers, such as the latest versions of Google Chrome or Microsoft
+        Edge. The site will not open in your current browser and it will be
+        necessary to update your browser or use a modern alternative in order to
+        run this application.
+      </p>
+    </div>
+    <script>
+      if (document.documentMode) {
+        document.getElementById("ieMsg").hidden = false;
+      }
+    </script>
 
     <!-- Hotjar Tracking Code for http://trainee.tis.nhs.uk/ -->
     <script>

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -147,7 +147,7 @@ Array [
                   }
                 }
               >
-                version: 0.23.3
+                version: 0.23.4
               </span>
             </a>
           </li>


### PR DESCRIPTION
- Although TISSS has been developed for evergreen browsers, loading the app on IE11 displays a blank screen due to errors caused by unsupported scripts. With IE still present within NHS organisations and in some cases the default browser, a fix is required to display a message to users explaining that the browser is unsupported. 
- Since IE11 is no longer supported by MS (and it's a pile of poo), a quick fix approach was preferred, adding a basic message into the static index.html that is conditionally displayed when accessed via IE. 
- `document.documentMode` property is only supported by IE hence why its used to determine the browser.
  
