### PR TITLE
feat:add GA4 tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "private": true,
   "dependencies": {
     "@sentry/browser": "^6.3.4",

--- a/public/index.html
+++ b/public/index.html
@@ -61,6 +61,7 @@
       }
       gtag("js", new Date());
       gtag("config", "UA-40570867-12");
+      gtag("config", "G-HZVN2JNJEQ");
     </script>
   </head>
   <body>

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -147,7 +147,7 @@ Array [
                   }
                 }
               >
-                version: 0.24.4
+                version: 0.24.5
               </span>
             </a>
           </li>


### PR DESCRIPTION
Add Google Analytics 4 tagging in parallel with GA3 tagging. SPA page routes are tagged with GA4 but not in GA3 without Google Tag Manager. With the pilot starting 24 May, wanted to get tagging of page routes enabled.     