### PR TITLE
feat:add GTM for improved event tagging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "private": true,
   "dependencies": {
     "@sentry/browser": "^6.3.4",
@@ -25,6 +25,7 @@
     "react": "^17.0.2",
     "react-cookie-consent": "^5.2.0",
     "react-dom": "^17.0.2",
+    "react-gtm-module": "^2.0.11",
     "react-helmet": "^6.1.0",
     "react-loading": "^2.0.3",
     "react-redux": "^7.2.3",
@@ -76,6 +77,7 @@
   "devDependencies": {
     "@types/enzyme": "^3.10.8",
     "@types/jest": "^26.0.23",
+    "@types/react-gtm-module": "^2.0.0",
     "@types/react-test-renderer": "^16.9.3",
     "@types/redux-mock-store": "^1.0.2",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.4.1",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -147,7 +147,7 @@ Array [
                   }
                 }
               >
-                version: 0.25.1
+                version: 0.25.2
               </span>
             </a>
           </li>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,13 @@ import config from "./aws-amplify/config";
 import store from "./redux/store/store";
 import browserUpdate from "browser-update";
 import browserUpdateConfig from "./browser-update-config.json";
+import TagManager from "react-gtm-module";
 
+const tagManagerArgs = {
+  gtmId: "GTM-5PWDC87"
+};
+
+TagManager.initialize(tagManagerArgs);
 browserUpdate(browserUpdateConfig);
 
 async function fetchData(): Promise<any> {


### PR DESCRIPTION
Add Google tag manager via npm package to collect custom event data for pilot.  