### PR TITLE
add package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.25.0",
+  "version": "0.25.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6618,6 +6618,11 @@
       "requires": {
         "@types/react": "*"
       }
+    },
+    "@types/react-gtm-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-gtm-module/-/react-gtm-module-2.0.0.tgz",
+      "integrity": "sha512-2d7TUhOQBG6cSVSSSWaoSu+Ds84VQFTuVKLeGNc2GtfA7JDr+z3ujl4n/rezaRRNEhjn+9SllwHy1iNxxP8jDg=="
     },
     "@types/react-helmet": {
       "version": "6.1.1",
@@ -20767,6 +20772,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "react-gtm-module": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/react-gtm-module/-/react-gtm-module-2.0.11.tgz",
+      "integrity": "sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw=="
     },
     "react-helmet": {
       "version": "6.1.0",


### PR DESCRIPTION
Try and make a small change in a hurry last think on Friday afternoon is not a good idea. E2E fail `npm ERR! cipm can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync.` Added package-lock.json to try and fix.