### PR TITLE
Revert "chore(deps): bump SonarSource/sonarcloud-github-action from 1.4 to 1.6"

### DIFF
--- a/.github/workflows/analyze-with-sonarqube.yml
+++ b/.github/workflows/analyze-with-sonarqube.yml
@@ -18,7 +18,7 @@ jobs:
       - run: npm run lint -- -f json -o eslint-report.json
       - run: npm test
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v1.6
+        uses: SonarSource/sonarcloud-github-action@v1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Reverts Health-Education-England/tis-trainee-ui#449

Getting cypress error which needs further investigation:
 1) Form R (Part A)
       Should complete a new Form R Part A.:
     CypressError: `cy.select()` can only be called on a `<select>`. Your subject is a: `<input class="nhsuk-input nhsuk-input--width-20" aria-labelledby="qualification--label" name="qualification" id="qualification" formik="[object Object]" min="1920-01-01" max="2119-31-12" data-cy="qualification" type="text" value="Degree">`