### PR TITLE
fix:update organisation removing select references

### DIFF
--- a/cypress/integration/formr-a/formr-a.spec.ts
+++ b/cypress/integration/formr-a/formr-a.spec.ts
@@ -194,7 +194,8 @@ describe("Form R (Part A)", () => {
 
           cy.get("#qualification")
             .should("exist")
-            .select("MBBS Bachelor of Medicine and Bachelor of Surgery");
+            .clear()
+            .type("MBBS Bachelor of Medicine and Bachelor of Surgery");
 
           cy.get("#dateAttained")
             .should("exist")

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -44,7 +44,8 @@ Cypress.Commands.add(
 
     cy.get("#qualification")
       .should("exist")
-      .should("not.have.value", "--Please select--");
+      .invoke("val")
+      .should("not.be.empty");
 
     cy.get("#dateAttained").should("exist").should("have.value", dateAttained);
     cy.get("#medicalSchool")


### PR DESCRIPTION
This fix is in prep for dependabot update https://github.com/Health-Education-England/tis-trainee-ui/pull/469. This PR was previously merged and subsequently reverted following the failure of E2E tests.

Previously, the organisation field was a dropdown. E2E tests hadn't been updated following changing this to free text so were still using select() method. These tests now fail following an update to the latest version of sonarcloud.     