### PR TITLE
fix: e2e test

### DIFF
--- a/cypress/integration/formr-a/formr-a.spec.ts
+++ b/cypress/integration/formr-a/formr-a.spec.ts
@@ -1,18 +1,17 @@
 /// <reference types="cypress" />
 /// <reference path="../../support/index.d.ts" />
+import dayjs from "dayjs";
+import * as duration from "dayjs/plugin/duration";
+dayjs.extend(duration);
 
-const todaysDate = Cypress.moment().format("YYYY-MM-DD");
-
-const dateAttained = Cypress.moment(todaysDate)
-  .subtract({ years: 1, months: 6, days: 12 })
+const dateAttained = dayjs()
+  .subtract(dayjs.duration({ years: 1, months: 6, days: 12 }))
   .format("YYYY-MM-DD");
-
-const completionDate = Cypress.moment(todaysDate)
-  .add(6, "M")
+const completionDate = dayjs()
+  .add(dayjs.duration({ months: 6 }))
   .format("YYYY-MM-DD");
-
-const startDate = Cypress.moment(todaysDate)
-  .subtract({ months: 9, days: 30 })
+const startDate = dayjs()
+  .subtract(dayjs.duration({ months: 9, days: 30 }))
   .format("YYYY-MM-DD");
 
 describe("Form R (Part A)", () => {

--- a/cypress/integration/formr-b/formr-b.spec.ts
+++ b/cypress/integration/formr-b/formr-b.spec.ts
@@ -1,5 +1,6 @@
 /// <reference types="cypress" />
 /// <reference path="../../support/index.d.ts" />
+import dayjs from "dayjs";
 
 let isCovid = false;
 
@@ -7,23 +8,20 @@ before(() => {
   isCovid = true;
 });
 
-let currentDate = Cypress.moment().format("YYYY-MM-DD");
-let futureDate = Cypress.moment(currentDate).add(6, "M").format("YYYY-MM-DD");
-let pastDate = Cypress.moment(currentDate)
-  .subtract(6, "M")
+const currentDate = dayjs().format("YYYY-MM-DD");
+const futureDate = dayjs()
+  .add(dayjs.duration({ months: 6 }))
+  .format("YYYY-MM-DD");
+const pastDate = dayjs()
+  .subtract(dayjs.duration({ months: 6 }))
+  .format("YYYY-MM-DD");
+const outOfRangeFutureDate = dayjs(futureDate)
+  .add(dayjs.duration({ years: 20 }))
   .format("YYYY-MM-DD");
 
-let outOfRangeFutureDate = Cypress.moment(futureDate)
-  .add({ years: 20 })
-  .format("YYYY-MM-DD");
+const currRevalDate = dayjs().add(3, "month").format("YYYY-MM-DD");
 
-const currRevalDate = Cypress.moment(currentDate)
-  .add(3, "M")
-  .format("YYYY-MM-DD");
-
-const prevRevalDate = Cypress.moment(currentDate)
-  .subtract({ years: 5 })
-  .format("YYYY-MM-DD");
+const prevRevalDate = dayjs().subtract(5, "years").format("YYYY-MM-DD");
 
 describe("Form R (Part B)", () => {
   it("Should complete a new Form R Part B.", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7554,9 +7554,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
-      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.5.tgz",
+      "integrity": "sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g=="
     },
     "debug": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "private": true,
   "dependencies": {
     "@cypress/react": "^5.8.0",
@@ -18,6 +18,7 @@
     "axios": "^0.21.1",
     "browser-update": "^3.3.25",
     "cypress": "^7.3.0",
+    "dayjs": "^1.10.5",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-cypress": "^2.11.3",
     "eslint-plugin-prettier": "^3.4.0",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -147,7 +147,7 @@ Array [
                   }
                 }
               >
-                version: 0.25.4
+                version: 0.25.5
               </span>
             </a>
           </li>


### PR DESCRIPTION
Cypress.moment is now deprecated so using Dayjs instead.
Moment is on its way out so next step is to remove it completely and replace with Dayjs.