### PR TITLE
Fix/dayjs duration error

### DIFF
--- a/cypress/integration/formr-a/formr-a.spec.ts
+++ b/cypress/integration/formr-a/formr-a.spec.ts
@@ -1,17 +1,14 @@
 /// <reference types="cypress" />
 /// <reference path="../../support/index.d.ts" />
-import dayjs from "dayjs";
-import duration from "dayjs/plugin/duration";
-dayjs.extend(duration);
 
-const dateAttained = dayjs()
-  .subtract(dayjs.duration({ years: 1, months: 6, days: 12 }))
+const dateAttained = Cypress.dayjs()
+  .subtract(Cypress.dayjs.duration({ years: 1, months: 6, days: 12 }))
   .format("YYYY-MM-DD");
-const completionDate = dayjs()
-  .add(dayjs.duration({ months: 6 }))
+const completionDate = Cypress.dayjs()
+  .add(Cypress.dayjs.duration({ months: 6 }))
   .format("YYYY-MM-DD");
-const startDate = dayjs()
-  .subtract(dayjs.duration({ months: 9, days: 30 }))
+const startDate = Cypress.dayjs()
+  .subtract(Cypress.dayjs.duration({ months: 9, days: 30 }))
   .format("YYYY-MM-DD");
 
 describe("Form R (Part A)", () => {

--- a/cypress/integration/formr-a/formr-a.spec.ts
+++ b/cypress/integration/formr-a/formr-a.spec.ts
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 /// <reference path="../../support/index.d.ts" />
 import dayjs from "dayjs";
-import * as duration from "dayjs/plugin/duration";
+import duration from "dayjs/plugin/duration";
 dayjs.extend(duration);
 
 const dateAttained = dayjs()

--- a/cypress/integration/formr-b/formr-b.spec.ts
+++ b/cypress/integration/formr-b/formr-b.spec.ts
@@ -1,8 +1,5 @@
 /// <reference types="cypress" />
 /// <reference path="../../support/index.d.ts" />
-import dayjs from "dayjs";
-import duration from "dayjs/plugin/duration";
-dayjs.extend(duration);
 
 let isCovid = false;
 
@@ -10,20 +7,20 @@ before(() => {
   isCovid = true;
 });
 
-const currentDate = dayjs().format("YYYY-MM-DD");
-const futureDate = dayjs()
-  .add(dayjs.duration({ months: 6 }))
+const currentDate = Cypress.dayjs().format("YYYY-MM-DD");
+const futureDate = Cypress.dayjs()
+  .add(Cypress.dayjs.duration({ months: 6 }))
   .format("YYYY-MM-DD");
-const pastDate = dayjs()
-  .subtract(dayjs.duration({ months: 6 }))
+const pastDate = Cypress.dayjs()
+  .subtract(Cypress.dayjs.duration({ months: 6 }))
   .format("YYYY-MM-DD");
-const outOfRangeFutureDate = dayjs(futureDate)
-  .add(dayjs.duration({ years: 20 }))
+const outOfRangeFutureDate = Cypress.dayjs(futureDate)
+  .add(Cypress.dayjs.duration({ years: 20 }))
   .format("YYYY-MM-DD");
 
-const currRevalDate = dayjs().add(3, "month").format("YYYY-MM-DD");
+const currRevalDate = Cypress.dayjs().add(3, "month").format("YYYY-MM-DD");
 
-const prevRevalDate = dayjs().subtract(5, "years").format("YYYY-MM-DD");
+const prevRevalDate = Cypress.dayjs().subtract(5, "years").format("YYYY-MM-DD");
 
 describe("Form R (Part B)", () => {
   it("Should complete a new Form R Part B.", () => {

--- a/cypress/integration/formr-b/formr-b.spec.ts
+++ b/cypress/integration/formr-b/formr-b.spec.ts
@@ -1,6 +1,8 @@
 /// <reference types="cypress" />
 /// <reference path="../../support/index.d.ts" />
 import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+dayjs.extend(duration);
 
 let isCovid = false;
 

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -17,4 +17,9 @@ declare namespace Cypress {
     login: any;
     checkFlags: any;
   }
+
+  import dayjs from "dayjs";
+  interface Cypress {
+    dayjs: dayjs.Dayjs;
+  }
 }

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,5 +1,12 @@
 import "./commands";
 
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+dayjs.extend(duration);
+
+Cypress.dayjs = dayjs;
+Cypress.duration = duration;
+
 beforeEach(() => {
   cy.visit("./");
   if (cy.get("button#rcc-confirm-button")) {


### PR DESCRIPTION
Did what I should have done in the last commit and added dayjs to the global Cypress object so it can be used (and not forgotten!) in any spec file.   

