### PR TITLE
fix: Checkbox bug

### DIFF
--- a/cypress/integration/formr-b/formr-b.spec.ts
+++ b/cypress/integration/formr-b/formr-b.spec.ts
@@ -169,11 +169,9 @@ describe("Form R (Part B)", () => {
     //Toggle error message when clicked
     cy.get("[data-cy=isDeclarationAccepted0]").click().should("be.checked");
     cy.get("[data-cy=isDeclarationAccepted0]").click().should("not.be.checked");
-
-    // todo Fix Yup bug in component that is causing this to test fail since Cypress 7.3.0 update
-    // cy.get("[data-cy=isDeclarationAccepted] .nhsuk-error-message").should(
-    //   "exist"
-    // );
+    cy.get("[data-cy=isDeclarationAccepted] .nhsuk-error-message").should(
+      "exist"
+    );
 
     cy.get("[data-cy=isConsentAccepted0]").click().should("be.checked");
     cy.get("[data-cy=isDeclarationAccepted0]").click().should("be.checked");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.25.6",
+  "version": "0.25.7",
   "private": true,
   "dependencies": {
     "@cypress/react": "^5.8.0",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -147,7 +147,7 @@ Array [
                   }
                 }
               >
-                version: 0.25.6
+                version: 0.25.7
               </span>
             </a>
           </li>

--- a/src/components/forms/MultiChoiceInputField.tsx
+++ b/src/components/forms/MultiChoiceInputField.tsx
@@ -54,7 +54,9 @@ const MultiChoiceInputField: React.FC<Props> = props => {
                       false
                 }
                 onChange={() => {
-                  helpers.setValue(item.value);
+                  props.type === "checkbox"
+                    ? helpers.setValue(!item.value)
+                    : helpers.setValue(item.value);
                 }}
                 conditional={props.conditional}
               >


### PR DESCRIPTION
**Problem**
A bug recently surfaced whereby toggling a checkbox in Form R Part B (Section 7) will not always show the validation error message when the checkbox is unchecked. It works fine in Section 3 where other fields are present. 

**Solution**
Tweak the onChange event in the MultiChoiceInputField component to make sure the error message is always displayed when a Checkbox is unchecked.

TIS21-1743