### PR TITLE
feat: Add 'other' option to prevRevalBody options

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,11 @@
   ],
   "plugins": ["jsx-a11y", "prettier"],
   "rules": {
-    "prettier/prettier": ["error"]
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -132,12 +132,12 @@ Cypress.Commands.add("checkAndFillSection1", (currRevalDate, prevRevalDate) => {
     .focus()
     .select("Health Education England Wessex");
   cy.get("#prevRevalBody > option")
-    .eq(1)
+    .last()
     .then(element => {
       const selectedItem = element.val().toString();
       cy.get("#prevRevalBody")
         .select(selectedItem)
-        .should("not.have.value", "--Please select--");
+        .should("have.value", "other");
     });
   cy.get("#currRevalDate").should("exist").clear().type(currRevalDate);
   cy.get("#prevRevalDate").should("exist").clear().type(prevRevalDate);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "private": true,
   "dependencies": {
     "@cypress/react": "^5.8.0",
@@ -56,6 +56,7 @@
     "cypress": "cypress run",
     "cypress:open": "cypress open",
     "ct:open": "npx cypress open-ct",
+    "ct": "npx cypress run-ct",
     "eject": "react-scripts eject",
     "lint": "eslint . --ext .ts,.tsx,.js --fix",
     "stylelint": "stylelint \"src/**/*.scss\" \"src/**/*.css\" --fix",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -147,7 +147,7 @@ Array [
                   }
                 }
               >
-                version: 0.26.1
+                version: 0.27.0
               </span>
             </a>
           </li>

--- a/src/components/forms/formr-part-b/Create.tsx
+++ b/src/components/forms/formr-part-b/Create.tsx
@@ -124,7 +124,7 @@ class Create extends React.PureComponent<
         formData.localOfficeName
       );
       formData.prevRevalBody = ReferenceDataUtilities.checkDataProp(
-        designatedBodies,
+        [...designatedBodies, { label: "other", value: "other" }],
         formData.prevRevalBody
       );
     }

--- a/src/components/forms/formr-part-b/Sections/Section1.tsx
+++ b/src/components/forms/formr-part-b/Sections/Section1.tsx
@@ -96,7 +96,10 @@ const Section1: FunctionComponent<CombinedSectionProps> = (
               />
               <SelectInputField
                 label="Previous Designated Body for Revalidation (if applicable)"
-                options={designatedBodies}
+                options={[
+                  ...designatedBodies,
+                  { label: "other", value: "other" }
+                ]}
                 name="prevRevalBody"
               />
               <TextInputField


### PR DESCRIPTION
This is the first iteration to allow the user to select 'other' when their
previous Designated Body is non-Deanery. Next steps include allowing the user
to choose from a list of non-Deanery designated bodies after they select 'other'.

TIS21-1838