### PR TITLE
Style/restyle authenticator components

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,7 +37,7 @@ Cypress.Commands.add("signIn", () => {
         .type(Cypress.env("username"), { log: false, force: true });
 
       cy.get("[slot='sign-in']")
-        .get("#password")
+        .find("#password")
         .type(`${Cypress.env("password")}{enter}`, {
           log: false,
           force: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.32.4",
+  "version": "0.32.5",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-components": "^1.7.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,11 @@ const App: React.FunctionComponent = () => {
     <BrowserRouter>
       <PageTitle />
       <HEEHeader authState={authState} user={user} />
-      {authState === AuthState.SignedIn ? <Main /> : <LoginNew />}
+      {authState === AuthState.SignedIn ? (
+        <Main />
+      ) : (
+        <LoginNew authState={authState} user={user} />
+      )}
       <HEEFooter appVersion={appVersion} authState={authState} user={user} />
     </BrowserRouter>
   );

--- a/src/components/authentication/Login.module.scss
+++ b/src/components/authentication/Login.module.scss
@@ -30,6 +30,14 @@
   }
 }
 
+.callout {
+  padding: 2em !important;
+  margin: 0 0 10px 0;
+  border-radius: 4px;
+  box-shadow: 2px 2px 4px #dbdfe0;
+  align-items: center;
+}
+
 @media (max-width: 940px) {
   .row {
     flex-direction: column;

--- a/src/components/authentication/Login.module.scss
+++ b/src/components/authentication/Login.module.scss
@@ -1,0 +1,40 @@
+.header {
+  width: 100%;
+  position: sticky;
+  top: 0px;
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+}
+
+.col {
+  flex: 1;
+  width: 50%;
+  padding: 1em;
+}
+
+.colText {
+  @extend .col;
+  @media (max-width: 940px) {
+    order: 2;
+  }
+}
+
+.colForm {
+  @extend .col;
+  position: relative;
+  @media (max-width: 940px) {
+    order: 1;
+  }
+}
+
+@media (max-width: 940px) {
+  .row {
+    flex-direction: column;
+  }
+  .col {
+    width: 100%;
+  }
+}

--- a/src/components/authentication/Login.scss
+++ b/src/components/authentication/Login.scss
@@ -1,0 +1,63 @@
+:root {
+  --amplify-primary-color: #005eb8;
+  --amplify-primary-tint: #0069ce;
+  --amplify-primary-shade: #0057ab;
+  --amplify-font-family: "Frutiger W01", Arial, sans-serif;
+}
+
+amplify-authenticator {
+  --container-align: top;
+  --container-display: flex;
+  --container-height: auto;
+  --container-justify: center;
+  --margin-bottom: 0;
+  --min-width: 100%;
+  --width: 100%;
+}
+
+amplify-sign-in {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+amplify-confirm-sign-in {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}
+amplify-sign-up {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+amplify-confirm-sign-up {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+amplify-forgot-password {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+amplify-require-new-password {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+amplify-verify-contact {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+amplify-totp-setup {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}

--- a/src/components/authentication/LoginNew.tsx
+++ b/src/components/authentication/LoginNew.tsx
@@ -7,7 +7,7 @@ import {
   AmplifyForgotPassword,
   AmplifyRequireNewPassword
 } from "@aws-amplify/ui-react";
-import { Container } from "nhsuk-react-components";
+import { Container, WarningCallout } from "nhsuk-react-components";
 import { AuthState, CognitoUserInterface } from "@aws-amplify/ui-components";
 import "./Login.scss";
 import styles from "./Login.module.scss";
@@ -42,6 +42,21 @@ export const LoginNew = ({ user, authState }: LoginNewProps) => {
             </p>
           </div>
           <div className={styles.colForm}>
+            {authState === AuthState.TOTPSetup && (
+              <WarningCallout className={styles.callout}>
+                <p>
+                  For further guidance on setting up an authenticator app, visit
+                  the{" "}
+                  <a
+                    href="https://tis-support.hee.nhs.uk/trainees/enhancing-the-security-of-the-trainee-self-service-application/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    TIS Support website.
+                  </a>
+                </p>
+              </WarningCallout>
+            )}
             <AmplifyAuthContainer>
               <AmplifyAuthenticator>
                 {authState === AuthState.TOTPSetup ? (

--- a/src/components/authentication/LoginNew.tsx
+++ b/src/components/authentication/LoginNew.tsx
@@ -1,22 +1,77 @@
 import {
   AmplifyAuthContainer,
   AmplifyAuthenticator,
-  AmplifySignIn
+  AmplifySignIn,
+  AmplifyTotpSetup,
+  AmplifyConfirmSignIn,
+  AmplifyForgotPassword,
+  AmplifyRequireNewPassword
 } from "@aws-amplify/ui-react";
 import { Container } from "nhsuk-react-components";
-
-export const LoginNew = () => {
+import { AuthState, CognitoUserInterface } from "@aws-amplify/ui-components";
+import "./Login.scss";
+import styles from "./Login.module.scss";
+interface LoginNewProps {
+  user: CognitoUserInterface | undefined;
+  authState: AuthState | undefined;
+}
+export const LoginNew = ({ user, authState }: LoginNewProps) => {
   return (
-    <Container>
-      <AmplifyAuthContainer>
-        <AmplifyAuthenticator>
-          <AmplifySignIn
-            headerText="Trainee Self-Service Sign-In"
-            slot="sign-in"
-            hideSignUp
-          ></AmplifySignIn>
-        </AmplifyAuthenticator>
-      </AmplifyAuthContainer>
-    </Container>
+    <main className="nhsuk-main-wrapper" id="maincontent">
+      <Container>
+        <div className={styles.row}>
+          <div className={styles.colText}>
+            <h1 className="nhsuk-u-padding-0 nhsuk-u-margin-bottom-2">
+              Trainee Self-Service
+            </h1>
+            <hr className="nhsuk-u-padding-0 nhsuk-u-margin-3" />
+            <p>
+              Trainee Self-Service enables trainees to log in and see some data
+              HEE hold about them and undertake the Form R process for junior
+              doctors.
+            </p>
+            <p>
+              For further information and support, visit the{" "}
+              <a
+                style={{ whiteSpace: "nowrap" }}
+                href="https://tis-support.hee.nhs.uk"
+              >
+                TIS Support website
+              </a>
+              .
+            </p>
+          </div>
+          <div className={styles.colForm}>
+            <AmplifyAuthContainer>
+              <AmplifyAuthenticator>
+                {authState === AuthState.TOTPSetup ? (
+                  <AmplifyTotpSetup
+                    headerText="Scan the barcode below using your preferred authenicator application."
+                    slot="totp-setup"
+                    user={user}
+                    standalone
+                  />
+                ) : null}
+                {authState === AuthState.ConfirmSignIn ? (
+                  <AmplifyConfirmSignIn
+                    headerText="Confirm 6-digit Authenticator code"
+                    slot="confirm-sign-in"
+                    user={user}
+                  />
+                ) : null}
+
+                <AmplifySignIn
+                  headerText="Sign in to Trainee Self-Service."
+                  slot="sign-in"
+                  hideSignUp
+                ></AmplifySignIn>
+                <AmplifyForgotPassword slot="forgot-password"></AmplifyForgotPassword>
+                <AmplifyRequireNewPassword slot="require-new-password"></AmplifyRequireNewPassword>
+              </AmplifyAuthenticator>
+            </AmplifyAuthContainer>
+          </div>
+        </div>
+      </Container>
+    </main>
   );
 };


### PR DESCRIPTION
- Add styling to the amplify ui components to meet NHS style guidelines.
- Restore the 2 column layout of login page with introduction text
- Add TOTP components conditionally to allow custom headers whilst avoiding error message
- Add ForgotPassword and ResetPassword components so they can be targeted for restyling
- Add link from TOTP setup section to guidance page on TIS Support website 

https://hee-tis.atlassian.net/browse/TIS21-2022