### PR TITLE
Change issuer name on auth app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.32.5",
+  "version": "0.32.6",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-components": "^1.7.3",

--- a/src/components/authentication/LoginNew.tsx
+++ b/src/components/authentication/LoginNew.tsx
@@ -61,8 +61,9 @@ export const LoginNew = ({ user, authState }: LoginNewProps) => {
               <AmplifyAuthenticator>
                 {authState === AuthState.TOTPSetup ? (
                   <AmplifyTotpSetup
-                    headerText="Scan the barcode below using your preferred authenicator application."
+                    headerText="Scan the barcode below using your preferred authenticator application."
                     slot="totp-setup"
+                    issuer="Trainee Self-Service"
                     user={user}
                     standalone
                   />


### PR DESCRIPTION
- Currently, when a user has TOTP on their device, the issuer name on their authenticator app is AWSCognito
- The new name is Trainee Self-Service