### PR TITLE
chore/Add full LCOV report

### DIFF
--- a/mergeCoverage.js
+++ b/mergeCoverage.js
@@ -27,5 +27,5 @@ run([
   // "nyc merge" will create a "coverage.json" file on the root, we move it to .nyc_output
   `nyc merge ${REPORTS_FOLDER} && mv coverage.json .nyc_output/out.json`,
   `nyc report --reporter lcov --report-dir ${FINAL_OUTPUT_FOLDER}`,
-  `nyc report --reporter=text`
+  `nyc report --reporter=text --reporter=lcov`
 ]);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "formik": "^2.2.6",
     "html-webpack-plugin": "^4.5.2",
-    "istanbul-lib-coverage": "^3.0.0",
+    "istanbul-lib-coverage": "^3.0.1",
     "nhsuk-frontend": "^3.1.0",
     "nhsuk-react-components": "^1.2.8",
     "nyc": "^15.1.0",


### PR DESCRIPTION
Config line needed to create another lcov file with info from the merged report generated after creating the Jest and the CT reports.
This should help Sonarcloud have all the necessary info to display.

**TIS21-2017**: Cypress transition