### PR TITLE
remove '|| "item_" + index' which points to the wrong checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^2.1.4",

--- a/src/components/forms/MultiChoiceInputField.tsx
+++ b/src/components/forms/MultiChoiceInputField.tsx
@@ -43,7 +43,7 @@ const MultiChoiceInputField: React.FC<Props> = props => {
             <FormChildElement
               key={item.value}
               value={item.value}
-              id={item.id || "item_" + index}
+              id={item.id}
               data-cy={`${props.name}${index}`}
               checked={setCheckedStatus(field, item)}
               onChange={() => setOnChangeValue(props, helpers, item)}


### PR DESCRIPTION
When there are multiple checkboxes in a single panel clicking on the text for any of the checkboxes selects the first box, instead of the box belonging to the label you clicked. 

TIS21-2455