### PR TITLE
Feat/set totp issuer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^2.1.5",

--- a/src/components/authentication/mfa/SetupTOTP.tsx
+++ b/src/components/authentication/mfa/SetupTOTP.tsx
@@ -31,12 +31,10 @@ const SetupTOTP = ({ user, mfaStatus, incrementStep }: ISetupMFA) => {
     const getUser = async () => {
       try {
         const totpCode: string = await Auth.setupTOTP(user);
-        const authCode: string =
-          "otpauth://totp/AWSCognito:" +
-          user.getUsername() +
-          "?secret=" +
-          totpCode +
-          "&issuer=AWSCognito";
+        const name = "NHS Trainee Self-Service";
+        const authCode: string = `otpauth://totp/${encodeURI(
+          name
+        )}:${user.getUsername()}?secret=${totpCode}`;
         setCode(totpCode);
         setQRCode(authCode);
         let timeOut = setTimeout(() => setExpired(true), 180000);

--- a/src/components/authentication/mfa/SetupTOTP.tsx
+++ b/src/components/authentication/mfa/SetupTOTP.tsx
@@ -34,7 +34,7 @@ const SetupTOTP = ({ user, mfaStatus, incrementStep }: ISetupMFA) => {
         const name = "NHS Trainee Self-Service";
         const authCode: string = `otpauth://totp/${encodeURI(
           name
-        )}:${user.getUsername()}?secret=${totpCode}`;
+        )}:${user.getUsername()}?secret=${totpCode}&issuer=${encodeURI(name)}`;
         setCode(totpCode);
         setQRCode(authCode);
         let timeOut = setTimeout(() => setExpired(true), 180000);


### PR DESCRIPTION
- Add suitable issuer title for TSS TOTP account in authenticator apps.
- In Authy, each account includes an icon, which is set based on Google Image Search, apparently. When the issuer title is set to Trainee Self-Service, the icon chosen is currently a stressed zebra! To remedy this, I've added 'NHS' at start which changes the the icon to something less inappropriate.    