### PR TITLE
Fix/redux console error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^2.1.5",

--- a/src/components/forms/ProgressBar.scss
+++ b/src/components/forms/ProgressBar.scss
@@ -18,10 +18,8 @@
     z-index: 2;
   }
 
-  // active step
   .progress-step-active {
     background-color: #ae2573;
-    color: #ffffff;
     border: none;
   }
 }
@@ -34,7 +32,7 @@
   top: 50%;
   transform: translateY(-50%);
   height: 3px;
-  width: 100%;
+  width: 99%;
   background-color: #003087;
   z-index: 1;
 }

--- a/src/components/forms/formr-part-a/Confirm.tsx
+++ b/src/components/forms/formr-part-a/Confirm.tsx
@@ -14,7 +14,7 @@ import store from "../../../redux/store/store";
 import { LifeCycleState } from "../../../models/LifeCycleState";
 import { fetchForms } from "../../../redux/slices/formsSlice";
 import { Redirect } from "react-router-dom";
-
+import { FormRUtilities } from "../../../utilities/FormRUtilities";
 interface IConfirm {
   history: any;
 }
@@ -25,24 +25,6 @@ const Confirm = ({ history }: IConfirm) => {
   const formData = useAppSelector(selectSavedFormA);
 
   const handleEdit = () => history.push("/formr-a/create");
-
-  const saveDraft = async (formDataSave: FormRPartA) => {
-    if (formDataSave.lifecycleState !== LifeCycleState.Unsubmitted) {
-      dispatch(
-        updatedFormA({
-          ...formDataSave,
-          submissionDate: null,
-          lifecycleState: LifeCycleState.Draft,
-          lastModifiedDate: new Date()
-        })
-      );
-    } else
-      dispatch(updatedFormA({ ...formDataSave, lastModifiedDate: new Date() }));
-    const updatedFormAData = store.getState().formA.formAData;
-    await dispatch(updateFormA(updatedFormAData));
-    dispatch(fetchForms("/formr-a"));
-    history.push("/formr-a");
-  };
 
   const handleSubmit = async (formDataSubmit: FormRPartA) => {
     dispatch(
@@ -87,7 +69,9 @@ const Confirm = ({ history }: IConfirm) => {
             <div className="nhsuk-grid-column-one-third">
               <SubmitButton
                 label="Save & Exit"
-                clickHandler={() => saveDraft(formData)}
+                clickHandler={() => {
+                  FormRUtilities.saveDraftA(formData, history);
+                }}
                 data-cy="BtnSaveDraft"
               />
             </div>

--- a/src/components/forms/formr-part-a/Create.tsx
+++ b/src/components/forms/formr-part-a/Create.tsx
@@ -14,10 +14,8 @@ import SelectInputField from "../SelectInputField";
 import TextInputField from "../TextInputField";
 import { useAppSelector, useAppDispatch } from "../../../redux/hooks/hooks";
 import {
-  saveFormA,
   selectSavedFormA,
-  updatedFormA,
-  updateFormA
+  updatedFormA
 } from "../../../redux/slices/formASlice";
 import { ValidationSchema } from "./ValidationSchema";
 import { ReferenceDataUtilities } from "../../../utilities/ReferenceDataUtilities";
@@ -29,13 +27,11 @@ import {
   MEDICAL_CURRICULUM
 } from "../../../utilities/Constants";
 import { selectAllReference } from "../../../redux/slices/referenceSlice";
-import { LifeCycleState } from "../../../models/LifeCycleState";
-import store from "../../../redux/store/store";
-import { fetchForms } from "../../../redux/slices/formsSlice";
 import { Redirect } from "react-router-dom";
 import { CombinedReferenceData } from "../../../models/CombinedReferenceData";
 import { CurriculumKeyValue } from "../../../models/CurriculumKeyValue";
 import DataSourceMsg from "../../common/DataSourceMsg";
+import { FormRUtilities } from "../../../utilities/FormRUtilities";
 
 const Create = ({ history }: { history: string[] }) => {
   const dispatch = useAppDispatch();
@@ -46,23 +42,6 @@ const Create = ({ history }: { history: string[] }) => {
   const handleSubmit = async (finalFormA: FormRPartA) => {
     dispatch(updatedFormA(finalFormA));
     history.push("/formr-a/confirm");
-  };
-
-  const saveDraft = async (draftFormA: FormRPartA) => {
-    if (draftFormA.lifecycleState !== LifeCycleState.Unsubmitted) {
-      draftFormA.submissionDate = null;
-      draftFormA.lifecycleState = LifeCycleState.Draft;
-    }
-    // TODO Date type store warning https://github.com/reduxjs/redux-toolkit/issues/456
-    // https://redux-toolkit.js.org/usage/usage-guide#working-with-non-serializable-data
-    draftFormA.lastModifiedDate = new Date();
-    dispatch(updatedFormA(draftFormA));
-    const updatedFormAData = store.getState().formA.formAData;
-    if (draftFormA.id) {
-      await dispatch(updateFormA(updatedFormAData));
-    } else await dispatch(saveFormA(updatedFormAData));
-    dispatch(fetchForms("/formr-a"));
-    history.push("/formr-a");
   };
 
   if (!formRAData.traineeTisId) {
@@ -276,7 +255,9 @@ const Create = ({ history }: { history: string[] }) => {
                 <div className="nhsuk-grid-row">
                   <div className="nhsuk-grid-column-one-third">
                     <Button
-                      onClick={() => saveDraft(values)}
+                      onClick={() => {
+                        FormRUtilities.saveDraftA(values, history);
+                      }}
                       disabled={isSubmitting}
                       data-cy="BtnSaveDraft"
                     >

--- a/src/redux/store/store.ts
+++ b/src/redux/store/store.ts
@@ -2,7 +2,32 @@ import { configureStore, Action } from "@reduxjs/toolkit";
 import { ThunkAction } from "redux-thunk";
 import rootReducer from "../slices";
 
-const store = configureStore({ reducer: rootReducer });
+const store = configureStore({
+  reducer: rootReducer,
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [
+          "formA/fetchFormA/fulfilled",
+          "formA/fetchFormA/pending",
+          "formA/saveFormA/fulfilled",
+          "formA/saveFormA/pending",
+          "formA/updatedFormA",
+          "formA/updateFormA/fulfilled",
+          "formA/updateFormA/pending",
+          "formB/saveFormB/fulfilled",
+          "formB/saveFormB/pending",
+          "formB/updatedFormB",
+          "forms/fetchFeatureFlags/fulfilled",
+          "forms/fetchFeatureFlags/pending",
+          "forms/fetchForms/fulfilled",
+          "forms/fetchForms/pending",
+          "formB/updateForm/fulfilled",
+          "formB/updateForm/pending"
+        ]
+      }
+    })
+});
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/src/utilities/FormRUtilities.ts
+++ b/src/utilities/FormRUtilities.ts
@@ -6,6 +6,15 @@ import Section5 from "../components/forms/formr-part-b/sections/Section5";
 import Section6 from "../components/forms/formr-part-b/sections/Section6";
 import CovidDeclaration from "../components/forms/formr-part-b/sections/CovidDeclaration";
 import { IProgSection } from "../models/IProgressSection";
+import { FormRPartA } from "../models/FormRPartA";
+import { LifeCycleState } from "../models/LifeCycleState";
+import store from "../redux/store/store";
+import {
+  saveFormA,
+  updatedFormA,
+  updateFormA
+} from "../redux/slices/formASlice";
+import { fetchForms } from "../redux/slices/formsSlice";
 
 export class FormRUtilities {
   public static makeFormRBSections(covidFlag: boolean) {
@@ -16,6 +25,31 @@ export class FormRUtilities {
         covidSection,
         ...defaultSections.slice(6)
       ];
+  }
+
+  public static async saveDraftA(
+    draftFormRA: FormRPartA,
+    history: any
+  ): Promise<void> {
+    if (draftFormRA.lifecycleState !== LifeCycleState.Unsubmitted) {
+      store.dispatch(
+        updatedFormA({
+          ...draftFormRA,
+          submissionDate: null,
+          lifecycleState: LifeCycleState.Draft,
+          lastModifiedDate: new Date()
+        })
+      );
+    } else
+      store.dispatch(
+        updatedFormA({ ...draftFormRA, lastModifiedDate: new Date() })
+      );
+    const updatedFormAData = store.getState().formA.formAData;
+    if (draftFormRA.id) {
+      await store.dispatch(updateFormA(updatedFormAData));
+    } else await store.dispatch(saveFormA(updatedFormAData));
+    store.dispatch(fetchForms("/formr-a"));
+    history.push("/formr-a");
   }
 }
 


### PR DESCRIPTION
- Fix Redux console warnings/ errors
Redux toolkit does not consider Date type or anything using new class instance as serializable.
https://github.com/reduxjs/redux-toolkit/issues/456 
As a stop-gap, a list of ignored actions to suppress the console warnings has been added to the redux store as per the docs https://redux-toolkit.js.org/usage/usage-guide#working-with-non-serializable-data.
A more permanent solution might be to store e.g. Dates as numbers or strings rather than Dates in MongoDB.
- Refactor 'save draft' method (form R A).
- Fix stepper css so Section joining line doesn't poke out at the end 

NO TICKET