### PR TITLE
chore: fix preprod deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: trainee-ui
+          service: ${{ github.event.repository.name }}
           cluster: trainee-preprod
           wait-for-service-stability: true
 


### PR DESCRIPTION
The service name for preprod was updated to match the expected naming
standards.

TIS21-2560