### PR TITLE
chore: rename preprod container to meet standards

### DIFF
--- a/.aws/task-definition-pre-prod.json
+++ b/.aws/task-definition-pre-prod.json
@@ -1,7 +1,7 @@
 {
   "containerDefinitions": [
     {
-      "name": "trainee-ui",
+      "name": "tis-trainee-ui",
       "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-ui:1",
       "portMappings": [
         {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
           task-definition: .aws/task-definition-pre-prod.json
-          container-name: trainee-ui
+          container-name: ${{ github.event.repository.name }}
           image: ${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ github.sha }}
 
       - name: Deploy Amazon ECS task definition


### PR DESCRIPTION
Rename the preprod container to match the current naming standards.

TIS21-2560