### PR TITLE
Fix Form R Part B TOOT bug

### DIFF
--- a/cypress/integration/formr-b/formr-b.spec.ts
+++ b/cypress/integration/formr-b/formr-b.spec.ts
@@ -305,6 +305,7 @@ describe("Form R (Part B)", () => {
             "have.text",
             "Health Education England Wessex"
           );
+          cy.get("[data-cy=totalLeave]").should("include.text", "21");
           // Navigate back to the list
           cy.get(".nhsuk-back-link__link").should("exist").click();
           cy.contains("Submitted forms").should("exist");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^2.1.5",

--- a/src/components/forms/formr-part-b/sections/Section2.tsx
+++ b/src/components/forms/formr-part-b/sections/Section2.tsx
@@ -19,6 +19,7 @@ import { useAppSelector } from "../../../../redux/hooks/hooks";
 import { selectSavedFormB } from "../../../../redux/slices/formBSlice";
 import DataSourceMsg from "../../../common/DataSourceMsg";
 import { IFormRPartBSection } from "../../../../models/IFormRPartBSection";
+import { FormRPartB } from "../../../../models/FormRPartB";
 
 const Section2 = ({
   prevSectionLabel,
@@ -33,12 +34,26 @@ const Section2 = ({
     return isNaN(value) ? 0 : Number(value);
   };
 
+  const getTotal = (vals: FormRPartB) => {
+    return (
+      getNumber(vals.sicknessAbsence) +
+      getNumber(vals.parentalLeave) +
+      getNumber(vals.careerBreaks) +
+      getNumber(vals.paidLeave) +
+      getNumber(vals.unauthorisedLeave) +
+      getNumber(vals.otherLeave)
+    );
+  };
+
   return (
     <Formik
       initialValues={formData}
       validationSchema={Section2ValidationSchema}
-      onSubmit={values => {
-        handleSectionSubmit(values);
+      onSubmit={(values, { setValues }) => {
+        const totalLeaveVal: number = getTotal(values);
+        const payload: FormRPartB = { ...values, totalLeave: totalLeaveVal };
+        setValues(payload);
+        handleSectionSubmit(payload);
       }}
     >
       {({ values, errors, handleSubmit }) => (
@@ -139,14 +154,7 @@ const Section2 = ({
               <TextInputField
                 label="Total"
                 name="totalLeave"
-                value={
-                  getNumber(values.sicknessAbsence) +
-                  getNumber(values.parentalLeave) +
-                  getNumber(values.careerBreaks) +
-                  getNumber(values.paidLeave) +
-                  getNumber(values.unauthorisedLeave) +
-                  getNumber(values.otherLeave)
-                }
+                value={getTotal(values)}
                 readOnly
               />
             </Panel>
@@ -163,7 +171,7 @@ const Section2 = ({
           ) : null}
 
           <FormRPartBPagination
-            values={values}
+            values={{ ...values, totalLeave: getTotal(values) }}
             saveDraft={saveDraft}
             prevSectionLabel={prevSectionLabel}
             nextSectionLabel={nextSectionLabel}


### PR DESCRIPTION
**Problem** 
The recent state management upgrade work has led to a bug where the totalLeave form field (Form R Part B - TOOT section) shows the correct value in the UI but is not being saved. This has knock-on effects for Admins UI and Metabase reports where the totalLeave is incorrectly shown as zero.

**Solution** 
Fix the form logic to create a new form values object before save/ submission actions.

TICKET TIS21-2791