### PR TITLE
fix: remove UK postcode validation blocker

### DIFF
--- a/cypress/integration/formr-a/formr-a.spec.ts
+++ b/cypress/integration/formr-a/formr-a.spec.ts
@@ -196,9 +196,9 @@ describe("Form R (Part A)", () => {
             .type("585-6360 Interdum Street");
 
           cy.get("#address2").should("exist").clear().type("Goulburn");
-          cy.get("#address3").should("exist").clear().type("London");
+          cy.get("#address3").should("exist").clear().type("Mauritius");
 
-          cy.get("#postCode").should("exist").clear().type("SW1A1AA");
+          cy.get("#postCode").should("exist").clear().type("80902");
           cy.get("#telephoneNumber")
             .should("exist")
             .clear()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.43.2",
+  "version": "0.43.3",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^2.1.5",

--- a/src/components/forms/formr-part-a/ValidationSchema.ts
+++ b/src/components/forms/formr-part-a/ValidationSchema.ts
@@ -4,7 +4,6 @@ import { StringValidationSchema } from "../StringValidationSchema";
 import {
   CCT_DECLARATION,
   CHECK_PHONE_REGEX,
-  CHECK_POSTCODE_REGEX,
   CHECK_WHOLE_TIME_EQUIVALENT_REGEX
 } from "../../../utilities/Constants";
 
@@ -45,10 +44,7 @@ export const ValidationSchema = yup.object({
   address1: StringValidationSchema("Address Line 1"),
   address2: StringValidationSchema("Address Line 2"),
 
-  postCode: StringValidationSchema("Postcode", 8).matches(
-    CHECK_POSTCODE_REGEX,
-    "Please enter a valid postcode"
-  ),
+  postCode: StringValidationSchema("Postcode", 20),
   telephoneNumber: StringValidationSchema("Contact Telephone").matches(
     CHECK_PHONE_REGEX,
     "Contact Telephone - please provide a valid number with prefix (e.g. 0, +44, or 44), at least 10 digits (including area code), a maximum of 15 digits (to allow for your country code), with no dashes or brackets."

--- a/src/utilities/Constants.ts
+++ b/src/utilities/Constants.ts
@@ -41,9 +41,6 @@ export const IMMIGRATION_STATUS_OTHER_TISIDS = ["12", "13"];
 
 export const CHECK_PHONE_REGEX = /^\+?(?:\d\s?){10,15}$/;
 
-export const CHECK_POSTCODE_REGEX =
-  /[A-Z]{1,2}[0-9]{1,2}[A-Z]?\s?[0-9][A-Z]{2}/i;
-
 export const CHECK_WHOLE_TIME_EQUIVALENT_REGEX =
   /^((0\.[1-9]{1})?|(0\.([0-9]{1}[1-9]{1}|[1-9]{1}[0-9]{1}))|1(\.0{1,2})?)$/;
 


### PR DESCRIPTION
- Remove regex that validates UK postcode
- Limit field to 20 chars, keep 'required' validation too.


TICKET TIS21-2909