### PR TITLE
Feat/sort Type of Work placements (desc)

### DIFF
--- a/cypress/integration/formr-b/formr-b.spec.ts
+++ b/cypress/integration/formr-b/formr-b.spec.ts
@@ -13,6 +13,9 @@ const pastDate = Cypress.dayjs()
 const outOfRangeFutureDate = Cypress.dayjs(futureDate)
   .add(Cypress.dayjs.duration({ years: 20 }))
   .format("YYYY-MM-DD");
+const farFutureDate = Cypress.dayjs()
+  .add(Cypress.dayjs.duration({ years: 5 }))
+  .format("YYYY-MM-DD");
 
 const currRevalDate = Cypress.dayjs().add(3, "month").format("YYYY-MM-DD");
 
@@ -80,7 +83,7 @@ describe("Form R (Part B)", () => {
     cy.get('[data-cy="work[0].startDate"]').clear().type(pastDate);
     cy.get(".nhsuk-error-summary").should("not.exist");
 
-    cy.addWorkPanel(pastDate, currentDate);
+    cy.addWorkPanel(farFutureDate, farFutureDate);
 
     // Navigate back to section 1
     cy.get("[data-cy=LinkToPreviousSection] > .nhsuk-pagination__page").click();
@@ -90,8 +93,8 @@ describe("Form R (Part B)", () => {
 
     // Return to section 2
     cy.get("[data-cy=LinkToNextSection] > .nhsuk-pagination__page").click();
-
     cy.get(".nhsuk-error-summary").should("not.exist");
+    cy.get('[data-cy="work[0].endDate"]').should("have.value", farFutureDate);
     cy.get("[data-cy=LinkToNextSection] > .nhsuk-pagination__page").click();
 
     // -------- Section 3 Declarations relating to Good Medical Practice -----------
@@ -173,7 +176,10 @@ describe("Form R (Part B)", () => {
     cy.get(".nhsuk-warning-callout__label")
       .should("exist")
       .should("include.text", "Confirmation");
-
+    cy.get("[data-cy=endDate1]").should(
+      "contain.text",
+      Cypress.dayjs(farFutureDate).format("DD/MM/YYYY")
+    );
     // check if Covid section exists or not depending on flag
     if (isCovid) {
       cy.get("[data-cy=sectionHeader7]").should("exist");
@@ -261,6 +267,11 @@ describe("Form R (Part B)", () => {
     cy.get("[data-cy=isDeclarationAccepted0]").click();
     cy.get("[data-cy=isConsentAccepted0]").click();
 
+    // check work saved in correct order
+    cy.get("[data-cy=endDate1]").should(
+      "contain.text",
+      Cypress.dayjs(farFutureDate).format("DD/MM/YYYY")
+    );
     // ------------- submit form -----------------------------------------
 
     // intercept formr-partb POST req

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.43.3",
+  "version": "0.44.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^2.1.5",

--- a/src/components/forms/formr-part-b/View.tsx
+++ b/src/components/forms/formr-part-b/View.tsx
@@ -180,16 +180,13 @@ const View = ({ canEdit, history }: IView) => {
                     </SummaryList.Row>
                     <SummaryList.Row>
                       <SummaryList.Key>Start Date</SummaryList.Key>
-                      <SummaryList.Value
-                        data-jest="startDate"
-                        data-cy={`startDate${i + 1}`}
-                      >
+                      <SummaryList.Value data-cy={`startDate${i + 1}`}>
                         {DateUtilities.ToLocalDate(w.startDate || null)}
                       </SummaryList.Value>
                     </SummaryList.Row>
                     <SummaryList.Row>
                       <SummaryList.Key>End Date</SummaryList.Key>
-                      <SummaryList.Value data-jest="endDate">
+                      <SummaryList.Value data-cy={`endDate${i + 1}`}>
                         {DateUtilities.ToLocalDate(w.endDate || null)}
                       </SummaryList.Value>
                     </SummaryList.Row>

--- a/src/components/forms/formr-part-b/sections/Section2.tsx
+++ b/src/components/forms/formr-part-b/sections/Section2.tsx
@@ -19,7 +19,8 @@ import { useAppSelector } from "../../../../redux/hooks/hooks";
 import { selectSavedFormB } from "../../../../redux/slices/formBSlice";
 import DataSourceMsg from "../../../common/DataSourceMsg";
 import { IFormRPartBSection } from "../../../../models/IFormRPartBSection";
-import { FormRPartB, Work } from "../../../../models/FormRPartB";
+import { FormRPartB } from "../../../../models/FormRPartB";
+import { ProfileUtilities } from "../../../../utilities/ProfileUtilities";
 
 const Section2 = ({
   prevSectionLabel,
@@ -30,43 +31,16 @@ const Section2 = ({
 }: IFormRPartBSection) => {
   let formData = useAppSelector(selectSavedFormB);
 
-  const getNumber = (value: number) => {
-    return isNaN(value) ? 0 : Number(value);
-  };
-
-  const getTotal = (vals: FormRPartB) => {
-    return (
-      getNumber(vals.sicknessAbsence) +
-      getNumber(vals.parentalLeave) +
-      getNumber(vals.careerBreaks) +
-      getNumber(vals.paidLeave) +
-      getNumber(vals.unauthorisedLeave) +
-      getNumber(vals.otherLeave)
-    );
-  };
-
-  const sortWorkDesc = (workArr: Work[]) => {
-    const workArrForSorting = [...workArr];
-    return workArrForSorting.sort(
-      (a: Work, b: Work) =>
-        new Date(b.endDate).getTime() - new Date(a.endDate).getTime()
-    );
-  };
-
   return (
     <Formik
       initialValues={formData}
       validationSchema={Section2ValidationSchema}
       onSubmit={values => {
-        const payload: FormRPartB = {
-          ...values,
-          totalLeave: getTotal(values),
-          work: sortWorkDesc(values.work)
-        };
+        const payload: FormRPartB = ProfileUtilities.updateVals(values);
         handleSectionSubmit(payload);
       }}
     >
-      {({ values, errors, handleSubmit, setValues }) => (
+      {({ values, errors, handleSubmit }) => (
         <Form>
           <ScrollTo />
           <Fieldset disableErrorLine={true} name="scopeOfPractice">
@@ -164,7 +138,7 @@ const Section2 = ({
               <TextInputField
                 label="Total"
                 name="totalLeave"
-                value={getTotal(values)}
+                value={ProfileUtilities.getTotal(values)}
                 readOnly
               />
             </Panel>
@@ -181,11 +155,7 @@ const Section2 = ({
           ) : null}
 
           <FormRPartBPagination
-            values={{
-              ...values,
-              totalLeave: getTotal(values),
-              work: sortWorkDesc(values.work)
-            }}
+            values={ProfileUtilities.updateVals(values)}
             saveDraft={saveDraft}
             prevSectionLabel={prevSectionLabel}
             nextSectionLabel={nextSectionLabel}

--- a/src/components/forms/formr-part-b/sections/Section2.tsx
+++ b/src/components/forms/formr-part-b/sections/Section2.tsx
@@ -19,7 +19,7 @@ import { useAppSelector } from "../../../../redux/hooks/hooks";
 import { selectSavedFormB } from "../../../../redux/slices/formBSlice";
 import DataSourceMsg from "../../../common/DataSourceMsg";
 import { IFormRPartBSection } from "../../../../models/IFormRPartBSection";
-import { FormRPartB } from "../../../../models/FormRPartB";
+import { FormRPartB, Work } from "../../../../models/FormRPartB";
 
 const Section2 = ({
   prevSectionLabel,
@@ -45,18 +45,28 @@ const Section2 = ({
     );
   };
 
+  const sortWorkDesc = (workArr: Work[]) => {
+    const workArrForSorting = [...workArr];
+    return workArrForSorting.sort(
+      (a: Work, b: Work) =>
+        new Date(b.endDate).getTime() - new Date(a.endDate).getTime()
+    );
+  };
+
   return (
     <Formik
       initialValues={formData}
       validationSchema={Section2ValidationSchema}
-      onSubmit={(values, { setValues }) => {
-        const totalLeaveVal: number = getTotal(values);
-        const payload: FormRPartB = { ...values, totalLeave: totalLeaveVal };
-        setValues(payload);
+      onSubmit={values => {
+        const payload: FormRPartB = {
+          ...values,
+          totalLeave: getTotal(values),
+          work: sortWorkDesc(values.work)
+        };
         handleSectionSubmit(payload);
       }}
     >
-      {({ values, errors, handleSubmit }) => (
+      {({ values, errors, handleSubmit, setValues }) => (
         <Form>
           <ScrollTo />
           <Fieldset disableErrorLine={true} name="scopeOfPractice">
@@ -171,7 +181,11 @@ const Section2 = ({
           ) : null}
 
           <FormRPartBPagination
-            values={{ ...values, totalLeave: getTotal(values) }}
+            values={{
+              ...values,
+              totalLeave: getTotal(values),
+              work: sortWorkDesc(values.work)
+            }}
             saveDraft={saveDraft}
             prevSectionLabel={prevSectionLabel}
             nextSectionLabel={nextSectionLabel}

--- a/src/mock-data/draft-formr-partb.ts
+++ b/src/mock-data/draft-formr-partb.ts
@@ -1,0 +1,226 @@
+import { FormRPartB } from "../models/FormRPartB";
+import { LifeCycleState } from "../models/LifeCycleState";
+
+export const draftFormRPartB: FormRPartB = {
+  id: "5e972ec9b9b5781b94eb1270",
+  traineeTisId: "123",
+  forename: "Anthony Mara",
+  surname: "Gilliam",
+  gmcNumber: "11111111",
+  email: "email@email.com",
+  localOfficeName: "Health Education England Thames Valley",
+  prevRevalBody: "Health Education England Midlands",
+  prevRevalBodyOther: "",
+  prevRevalDate: "2020-04-22",
+  currRevalDate: "2020-04-22",
+  programmeSpecialty: "ST3",
+  dualSpecialty: "DS",
+  work: [
+    {
+      typeOfWork: "In Post ST1",
+      startDate: "2019-01-12",
+      endDate: "2019-12-13",
+      trainingPost: "Yes",
+      site: "Addenbrookes Hospital",
+      siteLocation: "Hills Road Cambridge Cambridgeshire"
+    },
+    {
+      typeOfWork: "In Post ST2",
+      startDate: "2020-01-13",
+      endDate: "2020-12-21",
+      trainingPost: "Yes",
+      site: "Addenbrookes Hospital",
+      siteLocation: "Hills Road Cambridge Cambridgeshire"
+    },
+    {
+      typeOfWork: "In Post ST3",
+      startDate: "2020-01-22",
+      endDate: "2020-12-24",
+      trainingPost: "Yes",
+      site: "Addenbrookes Hospital",
+      siteLocation: "Hills Road Cambridge Cambridgeshire"
+    }
+  ],
+  sicknessAbsence: 1,
+  parentalLeave: 2,
+  careerBreaks: 3,
+  paidLeave: 4,
+  unauthorisedLeave: 5,
+  otherLeave: 6,
+  totalLeave: 21,
+  isHonest: true,
+  isHealthy: true,
+  isWarned: true,
+  isComplying: true,
+  healthStatement: "I feel great etc.",
+  havePreviousDeclarations: true,
+  previousDeclarations: [
+    {
+      declarationType: "Significant Event",
+      dateOfEntry: "2020-03-07",
+      title: "Previous declaration title",
+      locationOfEntry: "Previous declaration location of entry"
+    }
+  ],
+  previousDeclarationSummary: "",
+  haveCurrentDeclarations: true,
+  currentDeclarations: [
+    {
+      declarationType: "Complaint",
+      dateOfEntry: "2020-06-12",
+      title: "Current declaration title",
+      locationOfEntry: "Current declaration location of entry"
+    }
+  ],
+  currentDeclarationSummary: "",
+  compliments: "",
+  haveCovidDeclarations: null,
+  covidDeclarationDto: null,
+  lifecycleState: LifeCycleState.Submitted,
+  submissionDate: "2020-04-22",
+  lastModifiedDate: "2020-05-15"
+};
+
+export const draftFormRPartBWithNullCareerBreak: FormRPartB = {
+  id: "6e644647434834getee",
+  traineeTisId: "456",
+  forename: "Billy",
+  surname: "Ocean",
+  gmcNumber: "11111111",
+  email: "email2@email.com",
+  localOfficeName: "Health Education England Thames Valley",
+  prevRevalBody: "Health Education England Midlands",
+  prevRevalBodyOther: "",
+  prevRevalDate: "2020-04-22",
+  currRevalDate: "2020-04-22",
+  programmeSpecialty: "ST3",
+  dualSpecialty: "DS",
+  work: [
+    {
+      typeOfWork: "In Post ST1 Dermatology",
+      startDate: "2019-01-12",
+      endDate: "2019-12-21",
+      trainingPost: "Yes",
+      site: "Addenbrookes Hospital",
+      siteLocation: "Hills Road Cambridge Cambridgeshire"
+    },
+    {
+      typeOfWork: "In Post ST1 Dermatology",
+      startDate: "2020-01-01",
+      endDate: "2020-12-31",
+      trainingPost: "Yes",
+      site: "Addenbrookes Hospital",
+      siteLocation: "Hills Road Cambridge Cambridgeshire"
+    }
+  ],
+  sicknessAbsence: 0,
+  parentalLeave: 0,
+  careerBreaks: null,
+  paidLeave: 0,
+  unauthorisedLeave: 10,
+  otherLeave: 0,
+  totalLeave: 10,
+  isHonest: true,
+  isHealthy: true,
+  isWarned: true,
+  isComplying: true,
+  healthStatement: "I feel great etc.",
+  havePreviousDeclarations: true,
+  previousDeclarations: [
+    {
+      declarationType: "Significant Event",
+      dateOfEntry: "2020-03-07",
+      title: "Previous declaration title",
+      locationOfEntry: "Previous declaration location of entry"
+    }
+  ],
+  previousDeclarationSummary: "",
+  haveCurrentDeclarations: true,
+  currentDeclarations: [
+    {
+      declarationType: "Complaint",
+      dateOfEntry: "2020-06-12",
+      title: "Current declaration title",
+      locationOfEntry: "Current declaration location of entry"
+    }
+  ],
+  currentDeclarationSummary: "",
+  compliments: "",
+  haveCovidDeclarations: null,
+  covidDeclarationDto: null,
+  lifecycleState: LifeCycleState.Draft,
+  submissionDate: "2020-04-22",
+  lastModifiedDate: "2020-04-15"
+};
+
+export const draftFormRPartBWithNoLeaveTotal = {
+  id: "5e972ec9b9b5781b94eb1270",
+  traineeTisId: "123",
+  forename: "Anthony Mara",
+  surname: "Gilliam",
+  gmcNumber: "11111111",
+  email: "email@email.com",
+  localOfficeName: "Health Education England Thames Valley",
+  prevRevalBody: "Health Education England Midlands",
+  prevRevalBodyOther: "",
+  prevRevalDate: "2020-04-22",
+  currRevalDate: "2020-04-22",
+  programmeSpecialty: "ST3",
+  dualSpecialty: "DS",
+  work: [
+    {
+      typeOfWork: "In Post ST1 Dermatology",
+      startDate: "2019-01-12",
+      endDate: "2019-12-21",
+      trainingPost: "Yes",
+      site: "Addenbrookes Hospital",
+      siteLocation: "Hills Road Cambridge Cambridgeshire"
+    },
+    {
+      typeOfWork: "In Post ST1 Dermatology",
+      startDate: "2020-01-01",
+      endDate: "2020-12-31",
+      trainingPost: "Yes",
+      site: "Addenbrookes Hospital",
+      siteLocation: "Hills Road Cambridge Cambridgeshire"
+    }
+  ],
+  sicknessAbsence: 1,
+  parentalLeave: 1,
+  careerBreaks: 1,
+  paidLeave: 1,
+  unauthorisedLeave: 1,
+  otherLeave: 1,
+  totalLeave: null,
+  isHonest: true,
+  isHealthy: true,
+  isWarned: true,
+  isComplying: true,
+  healthStatement: "I feel great etc.",
+  havePreviousDeclarations: true,
+  previousDeclarations: [
+    {
+      declarationType: "Significant Event",
+      dateOfEntry: "2020-03-07",
+      title: "Previous declaration title",
+      locationOfEntry: "Previous declaration location of entry"
+    }
+  ],
+  previousDeclarationSummary: "",
+  haveCurrentDeclarations: true,
+  currentDeclarations: [
+    {
+      declarationType: "Complaint",
+      dateOfEntry: "2020-06-12",
+      title: "Current declaration title",
+      locationOfEntry: "Current declaration location of entry"
+    }
+  ],
+  currentDeclarationSummary: "",
+  compliments: "",
+  haveCovidDeclarations: null,
+  covidDeclarationDto: null,
+  lifecycleState: LifeCycleState.Unsubmitted,
+  submissionDate: "2020-04-01",
+  lastModifiedDate: "2020-04-16"
+};

--- a/src/utilities/ProfileUtilities.ts
+++ b/src/utilities/ProfileUtilities.ts
@@ -3,8 +3,9 @@ import { Curriculum, ProgrammeMembership } from "../models/ProgrammeMembership";
 import { MEDICAL_CURRICULUM } from "./Constants";
 
 export class ProfileUtilities {
-  public static sortWorkDesc(formData: FormRPartB) {
-    return formData.work.sort(
+  public static sortWorkDesc(workArr: Work[]) {
+    const workArrForSorting = [...workArr];
+    return workArrForSorting.sort(
       (a: Work, b: Work) =>
         new Date(b.endDate).getTime() - new Date(a.endDate).getTime()
     );
@@ -48,5 +49,28 @@ export class ProfileUtilities {
           )
           .shift()
       : null;
+  }
+
+  private static getNumber(v: number) {
+    return isNaN(v) ? 0 : Number(v);
+  }
+
+  public static getTotal(vals: FormRPartB) {
+    return (
+      this.getNumber(vals.sicknessAbsence) +
+      this.getNumber(vals.parentalLeave) +
+      this.getNumber(vals.careerBreaks) +
+      this.getNumber(vals.paidLeave) +
+      this.getNumber(vals.unauthorisedLeave) +
+      this.getNumber(vals.otherLeave)
+    );
+  }
+
+  public static updateVals(currVals: FormRPartB) {
+    return {
+      ...currVals,
+      totalLeave: this.getTotal(currVals),
+      work: this.sortWorkDesc(currVals.work)
+    };
   }
 }

--- a/src/utilities/__test__/ProfileUtilities.test.ts
+++ b/src/utilities/__test__/ProfileUtilities.test.ts
@@ -1,5 +1,9 @@
 import { ProfileUtilities } from "../ProfileUtilities";
-import { submittedFormRPartBs } from "../../mock-data/submitted-formr-partb";
+import {
+  draftFormRPartB,
+  draftFormRPartBWithNoLeaveTotal,
+  draftFormRPartBWithNullCareerBreak
+} from "../../mock-data/draft-formr-partb";
 import {
   mockProgrammeMemberships,
   mockProgrammeMembershipNoCurricula,
@@ -9,9 +13,29 @@ import {
 
 describe("DesignatedBodiesUtilities", () => {
   it("should sort work in desc order by end date", () => {
-    const sortedWork = ProfileUtilities.sortWorkDesc(submittedFormRPartBs[0]);
-    expect(sortedWork[0].endDate).toBe("2020-12-31");
+    const sortedWork = ProfileUtilities.sortWorkDesc(draftFormRPartB.work);
+    expect(sortedWork[0].endDate).toBe("2020-12-24");
   });
+  it("should return the total leave", () => {
+    const totLeave = draftFormRPartB.totalLeave;
+    const totalLeaveCalc = ProfileUtilities.getTotal(draftFormRPartB);
+    expect(totalLeaveCalc).toEqual(totLeave);
+  });
+  it("should still return the total leave with null value", () => {
+    const totLeave = draftFormRPartBWithNullCareerBreak.totalLeave;
+    const totalLeaveCalc = ProfileUtilities.getTotal(
+      draftFormRPartBWithNullCareerBreak
+    );
+    expect(totalLeaveCalc).toEqual(totLeave);
+  });
+  it("should return the updated form with totalLeave and sorted work", () => {
+    const sortedAndTotalledForm = ProfileUtilities.updateVals(
+      draftFormRPartBWithNoLeaveTotal
+    );
+    expect(sortedAndTotalledForm.totalLeave).toEqual(6);
+    expect(sortedAndTotalledForm.work[0].endDate).toBe("2020-12-31");
+  });
+
   it("should return null if no Programme Membership in array", () => {
     const progMem = ProfileUtilities.getRecentProgramme([]);
     expect(progMem).toBe(null);


### PR DESCRIPTION
**Problem** (via TSS user feedback)
- Work placements loaded (i.e. those synced from TIS) are sorted by end date (desc) when Form R (B) Section 2 loads.
- But any additional work placements entered by the user are just added to the end of the list without being sorted.


**Solution**
- Work placements sort is now triggered on ‘save’ draft and navigation to another section.

TICKET TIS21-2906
