### PR TITLE
feat: Set Work Training Post inital vals to YES for In Post

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^2.1.5",

--- a/src/components/profile/Profile.cy-test.tsx
+++ b/src/components/profile/Profile.cy-test.tsx
@@ -46,8 +46,8 @@ describe("Profile", () => {
     ).should("include.text", "Gilliam");
     cy.contains("Placements").should("exist").click();
     cy.get(
-      ".nhsuk-grid-column-full > .nhsuk-summary-list > :nth-child(6) > .nhsuk-summary-list__value"
-    ).should("include.text", "Dermatology");
+      ":nth-child(2) > .nhsuk-details__text > .nhsuk-grid-row > :nth-child(2) > .nhsuk-summary-list > :nth-child(6) > .nhsuk-summary-list__value"
+    );
     cy.contains("Programmes").should("exist").click();
     cy.get(
       ":nth-child(1) > .nhsuk-summary-list > :nth-child(6) > .nhsuk-summary-list__value > :nth-child(2) > :nth-child(2)"

--- a/src/mock-data/trainee-profile.ts
+++ b/src/mock-data/trainee-profile.ts
@@ -2,6 +2,7 @@ import { PersonalDetails } from "../models/PersonalDetails";
 import { TraineeProfile } from "../models/TraineeProfile";
 import { Status } from "../models/Status";
 import { ProgrammeMembership } from "../models/ProgrammeMembership";
+import { Placement } from "../models/Placement";
 
 export const mockPersonalDetails: PersonalDetails = {
   surname: "Gilliam",
@@ -193,7 +194,7 @@ export const mockProgrammeMembershipDuplicateCurriculaStart = {
   ]
 };
 
-export const mockPlacements = [
+export const mockPlacements: Placement[] = [
   {
     endDate: new Date("2020-12-31"),
     grade: "ST1",
@@ -207,6 +208,20 @@ export const mockPlacements = [
     employingBody: "Employing body",
     trainingBody: "Training body",
     wholeTimeEquivalent: "0.5"
+  },
+  {
+    endDate: new Date("2021-12-31"),
+    grade: "ST2",
+    tisId: "316",
+    placementType: "Long-term sick",
+    site: "Addenbrookes Hospital",
+    siteLocation: "Site location",
+    specialty: "Dermatology",
+    startDate: new Date("2020-01-01"),
+    status: Status.Current,
+    employingBody: "",
+    trainingBody: "Carmarthenshire NHS Trust",
+    wholeTimeEquivalent: "0.75"
   }
 ];
 

--- a/src/models/ProfileToFormRPartBInitialValues.ts
+++ b/src/models/ProfileToFormRPartBInitialValues.ts
@@ -24,7 +24,7 @@ export function ProfileToFormRPartBInitialValues(
     endDate: placement.endDate,
     site: placement.site,
     siteLocation: placement.siteLocation,
-    trainingPost: placement.placementType === "In Post" ? "Yes" : ""
+    trainingPost: ProfileUtilities.getTrainingPostInitVal(placement)
   }));
 
   if (work.length > 1) {

--- a/src/utilities/ProfileUtilities.ts
+++ b/src/utilities/ProfileUtilities.ts
@@ -1,4 +1,5 @@
 import { FormRPartB, Work } from "../models/FormRPartB";
+import { Placement } from "../models/Placement";
 import { Curriculum, ProgrammeMembership } from "../models/ProgrammeMembership";
 import { MEDICAL_CURRICULUM } from "./Constants";
 
@@ -72,5 +73,10 @@ export class ProfileUtilities {
       totalLeave: this.getTotal(currVals),
       work: this.sortWorkDesc(currVals.work)
     };
+  }
+
+  public static getTrainingPostInitVal(pl: Placement) {
+    if (pl.placementType.toLowerCase().includes("in post")) return "Yes";
+    else return "";
   }
 }

--- a/src/utilities/__test__/ProfileUtilities.test.ts
+++ b/src/utilities/__test__/ProfileUtilities.test.ts
@@ -8,10 +8,11 @@ import {
   mockProgrammeMemberships,
   mockProgrammeMembershipNoCurricula,
   mockProgrammeMembershipNoMedicalCurricula,
-  mockProgrammeMembershipDuplicateCurriculaStart
+  mockProgrammeMembershipDuplicateCurriculaStart,
+  mockPlacements
 } from "../../mock-data/trainee-profile";
 
-describe("DesignatedBodiesUtilities", () => {
+describe("ProfileUtilities", () => {
   it("should sort work in desc order by end date", () => {
     const sortedWork = ProfileUtilities.sortWorkDesc(draftFormRPartB.work);
     expect(sortedWork[0].endDate).toBe("2020-12-24");
@@ -34,6 +35,14 @@ describe("DesignatedBodiesUtilities", () => {
     );
     expect(sortedAndTotalledForm.totalLeave).toEqual(6);
     expect(sortedAndTotalledForm.work[0].endDate).toBe("2020-12-31");
+  });
+  it("should return Yes if the placement type includes 'in post'", () => {
+    expect(ProfileUtilities.getTrainingPostInitVal(mockPlacements[0])).toEqual(
+      "Yes"
+    );
+    expect(ProfileUtilities.getTrainingPostInitVal(mockPlacements[1])).toEqual(
+      ""
+    );
   });
 
   it("should return null if no Programme Membership in array", () => {


### PR DESCRIPTION

In response to user feedback:
- Set Work Training Post inital vals to 'Yes' for any type including 'In Post'
- For now, set all others to null so user still has to decide.

TICKET TIS21-1341