### PR TITLE
chore: bump browser-update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.47.4",
+  "version": "0.47.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9961,9 +9961,9 @@
       "dev": true
     },
     "browser-update": {
-      "version": "3.3.30",
-      "resolved": "https://registry.npmjs.org/browser-update/-/browser-update-3.3.30.tgz",
-      "integrity": "sha512-g9ARwuNqvq3mCWbfTZvg9IjF5tkzv6AccyMcXn41sisF1d6M3xi+jQ5wz8A7lfFxApdpvMnLn7t035x5mwD5dw=="
+      "version": "3.3.38",
+      "resolved": "https://registry.npmjs.org/browser-update/-/browser-update-3.3.38.tgz",
+      "integrity": "sha512-2mLnlL25WLBP6pISo8dMoK7J8hKoLbgQtCQ+/g67T/SHvy+NpcvNPxqlpbwLF/mceIWTK34s24MUHmLcUrsKig=="
     },
     "browserify": {
       "version": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.47.4",
+  "version": "0.47.5",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^2.1.5",
@@ -29,7 +29,7 @@
     "aws-amplify": "^4.3.10",
     "axios": "^0.21.2",
     "babel-plugin-istanbul": "^6.0.0",
-    "browser-update": "^3.3.25",
+    "browser-update": "^3.3.38",
     "cross-env": "^7.0.3",
     "cypress": "^8.7.0",
     "cypress-otp": "^1.0.3",


### PR DESCRIPTION
Some GitHub issues report earlier versions not showing out-of-date browser banner for Safari 14. (e.g. https://github.com/browser-update/browser-update/issues/548) 

NO TICKET