### PR TITLE
fix: Add mapbox-gl to deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.48.0",
+  "version": "0.49.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -272,6 +272,11 @@
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
           "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+        },
+        "mapbox-gl": {
+          "version": "npm:empty-npm-package@1.0.0",
+          "resolved": "https://registry.npmjs.org/empty-npm-package/-/empty-npm-package-1.0.0.tgz",
+          "integrity": "sha512-q4Mq/+XO7UNDdMiPpR/LIBIW1Zl4V0Z6UT9aKGqIAnBCtCb3lvZJM1KbDbdzdC8fKflwflModfjR29Nt0EpcwA=="
         }
       }
     },
@@ -18607,9 +18612,45 @@
       }
     },
     "mapbox-gl": {
-      "version": "npm:empty-npm-package@1.0.0",
-      "resolved": "https://registry.npmjs.org/empty-npm-package/-/empty-npm-package-1.0.0.tgz",
-      "integrity": "sha512-q4Mq/+XO7UNDdMiPpR/LIBIW1Zl4V0Z6UT9aKGqIAnBCtCb3lvZJM1KbDbdzdC8fKflwflModfjR29Nt0EpcwA=="
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.9.1.tgz",
+      "integrity": "sha512-PWEyI0FUeWaCbDnKmzHBi6CIB264SG6O894PJL1q4Cz/ZiHNyAROonCD48bxVWSQnXXAEDPyhJS5MiJ2K5DTjw==",
+      "requires": {
+        "@mapbox/geojson-rewind": "^0.5.1",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^2.0.1",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^2.0.5",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.3",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.4.3",
+        "grid-index": "^1.1.0",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.2",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.1.4",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.3"
+      },
+      "dependencies": {
+        "@mapbox/mapbox-gl-supported": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz",
+          "integrity": "sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ=="
+        },
+        "@mapbox/tiny-sdf": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.5.tgz",
+          "integrity": "sha512-OhXt2lS//WpLdkqrzo/KwB7SRD8AiNTFFzuo9n14IBupzIMa67yGItcK7I2W9D8Ghpa4T04Sw9FWsKCJG50Bxw=="
+        }
+      }
     },
     "maplibre-gl": {
       "version": "1.15.3",
@@ -19562,7 +19603,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "camelcase": {
@@ -27329,7 +27371,8 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": ""
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
             },
             "strip-ansi": {
               "version": "5.2.0",
@@ -27551,7 +27594,8 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": ""
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
             },
             "strip-ansi": {
               "version": "5.2.0",
@@ -27608,7 +27652,8 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": ""
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
             },
             "strip-ansi": {
               "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^2.20.0",
@@ -40,6 +40,7 @@
     "formik": "^2.2.6",
     "html-webpack-plugin": "^4.5.2",
     "istanbul-lib-coverage": "^3.0.1",
+    "mapbox-gl": "^2.9.1",
     "nanoid": "^3.2.0",
     "nhsuk-frontend": "^3.1.0",
     "nhsuk-react-components": "^1.2.8",


### PR DESCRIPTION
There is a known aws-amplify issue which looks to have caused the latest build to fail (https://github.com/aws-amplify/amplify-ui/issues/1736 for more info).
The fix will be in the next release: @aws-amplify/ui-react 3.0 .
Current workaround is to add **mapbox-gl** dep directly to package.json and cross your toes.

TIS21-3193