### PR TITLE
Remove phone_number attribute when swapping MFA type from SMS to TOTP

### DIFF
--- a/cypress/integration/mfa/mfa.spec.ts
+++ b/cypress/integration/mfa/mfa.spec.ts
@@ -1,0 +1,44 @@
+/// <reference types="cypress" />
+/// <reference path="../../support/index.d.ts" />
+
+describe("MFA set-up", () => {
+  before(() => {
+    cy.wait(30000);
+    cy.visit("./profile");
+    cy.signIn();
+  });
+  it("should render the Choose MFA page", () => {
+    cy.get('[data-cy="MFA set-up"]').should("exist").click();
+    cy.get("[data-cy=mfaAlreadyWarning]").should("exist");
+    cy.get("[data-cy=mfaAlreadyText]")
+      .should("exist")
+      .should(
+        "include.text",
+        "You have already set up your Authenticator App for MFA "
+      );
+    cy.get("[data-cy=mfaSummary]").click();
+    cy.get("[data-cy=mfaText] > :nth-child(3) > b").should(
+      "include.text",
+      "or SMS"
+    );
+    cy.get("[data-cy=mfaChoice1]").click();
+    cy.get("[data-cy=BtnSubmitMfaChoice]").click();
+    cy.get("[data-cy=backLink]")
+      .should("exist")
+      .should("contain.text", "Start over")
+      .click();
+    cy.get("[data-cy=mfaChoice0]").should("exist").click();
+    cy.get("[data-cy=BtnSubmitMfaChoice]").click();
+    cy.get("[data-cy=appInstalledAlready0]").should("exist").click();
+    cy.get("[data-cy=threeMinWarning]").should("exist");
+    cy.get("form > .nhsuk-button")
+      .should(
+        "contain.text",
+        "Add 'NHS TIS Self-Service' to your Authenticator App"
+      )
+      .click();
+    cy.get("[data-cy=Profile]").click();
+    cy.get('[data-cy="MFA set-up"]').click();
+    cy.get(".nhsuk-fieldset__heading").should("include.text", "MFA");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.49.1",
+  "version": "0.49.2",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^2.20.0",

--- a/src/components/authentication/setMfa/ChooseMfa.tsx
+++ b/src/components/authentication/setMfa/ChooseMfa.tsx
@@ -39,8 +39,8 @@ const ChooseMfa = ({ mfa }: IChooseMfa) => {
           <>
             <ScrollTo />
             {mfa !== "NOMFA" && (
-              <WarningCallout label="Important">
-                <p>
+              <WarningCallout label="Important" data-cy="mfaAlreadyWarning">
+                <p data-cy="mfaAlreadyText">
                   You have already set up
                   <b>
                     {" "}

--- a/src/components/authentication/setMfa/ChooseMfa.tsx
+++ b/src/components/authentication/setMfa/ChooseMfa.tsx
@@ -8,7 +8,7 @@ import * as Yup from "yup";
 import { useEffect } from "react";
 import ScrollTo from "../../forms/ScrollTo";
 import history from "../../navigation/history";
-
+import { MFAStatus } from "../../../models/MFAStatus";
 interface IChooseMfa {
   mfa: string;
 }
@@ -44,7 +44,7 @@ const ChooseMfa = ({ mfa }: IChooseMfa) => {
                   You have already set up
                   <b>
                     {" "}
-                    {mfa === "SOFTWARE_TOKEN_MFA"
+                    {mfa === MFAStatus.TOTP
                       ? "your Authenticator App for MFA"
                       : "SMS for MFA"}{" "}
                   </b>

--- a/src/components/authentication/setMfa/MFA.scss
+++ b/src/components/authentication/setMfa/MFA.scss
@@ -1,0 +1,29 @@
+.panelBack {
+  background-color: #f0f4f5;
+}
+
+.qrAuth {
+  height: 300px;
+  width: 200px;
+  margin-bottom: 30px;
+}
+
+.qrTss {
+  padding: 20px;
+}
+
+.detailsAuthHelp {
+  margin-bottom: 40px;
+}
+
+.altDownloadApple {
+  height: 90px;
+  width: 175px;
+  margin-left: 12px;
+  margin-right: 12px;
+}
+
+.altDownloadAndroid {
+  height: 89px;
+  width: 200px;
+}

--- a/src/components/authentication/setMfa/sms/ConfirmSms.tsx
+++ b/src/components/authentication/setMfa/sms/ConfirmSms.tsx
@@ -7,6 +7,7 @@ import { CognitoUser } from "@aws-amplify/auth";
 import {
   decrementSmsSection,
   resetError,
+  resetUser,
   setPreferredMfa,
   verifyUserAttributeSubmit
 } from "../../../../redux/slices/userSlice";
@@ -21,14 +22,12 @@ const ConfirmSms = ({ user }: IConfirmSms) => {
   const dispatch = useAppDispatch();
 
   const verifyCodeSub = async (code: string) => {
-    dispatch(resetError);
     const attrib: string = "phone_number";
     await dispatch(verifyUserAttributeSubmit({ attrib, code }));
     return store.getState().user.status;
   };
 
   const updateMfa = async () => {
-    dispatch(resetError);
     const pref: MFAType = "SMS";
     await dispatch(setPreferredMfa({ user, pref }));
     return store.getState().user.status;
@@ -43,6 +42,7 @@ const ConfirmSms = ({ user }: IConfirmSms) => {
     if (res === "succeeded") {
       const res = await updateMfa();
       if (res === "succeeded") {
+        dispatch(resetUser());
         history.push("/profile");
       } else {
         stepBack();

--- a/src/components/authentication/setMfa/sms/ConfirmSms.tsx
+++ b/src/components/authentication/setMfa/sms/ConfirmSms.tsx
@@ -41,8 +41,8 @@ const ConfirmSms = ({ user }: IConfirmSms) => {
       dispatch(decrementSmsSection());
     };
     if (res === "succeeded") {
-      const res = await updateMfa();
-      if (res === "succeeded") {
+      const resU = await updateMfa();
+      if (resU === "succeeded") {
         dispatch(resetUser());
         history.push("/profile");
         dispatch(

--- a/src/components/authentication/setMfa/sms/ConfirmSms.tsx
+++ b/src/components/authentication/setMfa/sms/ConfirmSms.tsx
@@ -14,6 +14,7 @@ import {
 import store from "../../../../redux/store/store";
 import history from "../../../navigation/history";
 import { MFAType } from "../../../../models/MFAStatus";
+import { addNotification } from "../../../../redux/slices/notificationsSlice";
 interface IConfirmSms {
   user: CognitoUser;
 }
@@ -44,6 +45,12 @@ const ConfirmSms = ({ user }: IConfirmSms) => {
       if (res === "succeeded") {
         dispatch(resetUser());
         history.push("/profile");
+        dispatch(
+          addNotification({
+            type: "Success",
+            text: "- SMS authentication is now set up. You will be asked for a new 6-digit (sent to your phone) each time you log in"
+          })
+        );
       } else {
         stepBack();
       }

--- a/src/components/authentication/setMfa/sms/ConfirmSms.tsx
+++ b/src/components/authentication/setMfa/sms/ConfirmSms.tsx
@@ -69,10 +69,7 @@ const ConfirmSms = ({ user }: IConfirmSms) => {
     >
       {({ isValid, isSubmitting }) => (
         <Form>
-          <Panel
-            label="Enter the 6-digit code sent to your phone"
-            style={{ backgroundColor: "aliceblue" }}
-          >
+          <Panel label="Enter the 6-digit code sent to your phone">
             <TextInputField
               footer="It may take a minute to arrive."
               name="smsCode"

--- a/src/components/authentication/setMfa/sms/ConfirmSms.tsx
+++ b/src/components/authentication/setMfa/sms/ConfirmSms.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../../../redux/slices/userSlice";
 import store from "../../../../redux/store/store";
 import history from "../../../navigation/history";
+import { MFAType } from "../../../../models/MFAStatus";
 interface IConfirmSms {
   user: CognitoUser;
 }
@@ -27,9 +28,10 @@ const ConfirmSms = ({ user }: IConfirmSms) => {
   };
 
   const updateMfa = async () => {
+    const pref: MFAType = "SMS";
     const upMfaObj = {
       user,
-      pref: "SMS"
+      pref
     };
     await dispatch(setPreferredMfa(upMfaObj));
   };

--- a/src/components/authentication/setMfa/sms/VerifySms.tsx
+++ b/src/components/authentication/setMfa/sms/VerifySms.tsx
@@ -33,8 +33,8 @@ const VerifySms = ({ user }: IVerifySms) => {
   const handleSmsVerify = async (mobilePhoneNumber: string) => {
     const res = await updatePhoneAttrib(mobilePhoneNumber);
     if (res === "succeeded") {
-      const res = await verifPhone();
-      if (res === "succeeded") {
+      const resV = await verifPhone();
+      if (resV === "succeeded") {
         dispatch(resetError());
         dispatch(incrementSmsSection());
       }

--- a/src/components/authentication/setMfa/sms/VerifySms.tsx
+++ b/src/components/authentication/setMfa/sms/VerifySms.tsx
@@ -51,10 +51,7 @@ const VerifySms = ({ user }: IVerifySms) => {
     >
       {({ isValid, isSubmitting }) => (
         <Form>
-          <Panel
-            label="I want to receive codes sent by SMS to this mobile"
-            style={{ backgroundColor: "aliceblue" }}
-          >
+          <Panel label="I want to receive codes sent by SMS to this mobile">
             <MobilePhoneInputField name="mobilePhoneNumber" />
           </Panel>
 

--- a/src/components/authentication/setMfa/sms/VerifySms.tsx
+++ b/src/components/authentication/setMfa/sms/VerifySms.tsx
@@ -6,6 +6,7 @@ import { Button, Panel } from "nhsuk-react-components";
 import { useAppDispatch } from "../../../../redux/hooks/hooks";
 import {
   incrementSmsSection,
+  resetError,
   updateUserAttributes,
   verifyPhone
 } from "../../../../redux/slices/userSlice";
@@ -18,25 +19,23 @@ interface IVerifySms {
 const VerifySms = ({ user }: IVerifySms) => {
   const dispatch = useAppDispatch();
 
-  const updatePhoneAttrib = async (vals: { mobilePhoneNumber: string }) => {
-    const updatePhoneAttribObj = {
-      user,
-      attrib: { phone_number: vals.mobilePhoneNumber }
-    };
-    await dispatch(updateUserAttributes(updatePhoneAttribObj));
+  const updatePhoneAttrib = async (mobNo: string) => {
+    const attrib = { phone_number: mobNo };
+    await dispatch(updateUserAttributes({ user, attrib }));
+    return store.getState().user.status;
   };
 
   const verifPhone = async () => {
     await dispatch(verifyPhone());
+    return store.getState().user.status;
   };
 
-  const handleSmsVerify = async (formVals: { mobilePhoneNumber: string }) => {
-    await updatePhoneAttrib(formVals);
-    const statusAfterphoneUpdate = store.getState().user.status;
-    if (statusAfterphoneUpdate === "succeeded") {
-      await verifPhone();
-      const statusAfterVerifyphone = store.getState().user.status;
-      if (statusAfterVerifyphone === "succeeded") {
+  const handleSmsVerify = async (mobilePhoneNumber: string) => {
+    const res = await updatePhoneAttrib(mobilePhoneNumber);
+    if (res === "succeeded") {
+      const res = await verifPhone();
+      if (res === "succeeded") {
+        dispatch(resetError());
         dispatch(incrementSmsSection());
       }
     }
@@ -46,7 +45,7 @@ const VerifySms = ({ user }: IVerifySms) => {
     <Formik
       initialValues={{ mobilePhoneNumber: "" }}
       onSubmit={values => {
-        handleSmsVerify(values);
+        handleSmsVerify(values.mobilePhoneNumber);
       }}
       validationSchema={MobilePhoneValidationSchema}
     >

--- a/src/components/authentication/setMfa/totp/TotpInstructions.tsx
+++ b/src/components/authentication/setMfa/totp/TotpInstructions.tsx
@@ -8,6 +8,7 @@ import {
   Row
 } from "nhsuk-react-components";
 import MultiChoiceInputField from "../../../forms/MultiChoiceInputField";
+import "../MFA.scss";
 
 const TotpInstructions = () => {
   return (
@@ -29,8 +30,8 @@ const TotpInstructions = () => {
           </Details.Text>
         </Details>
         <Panel
+          className="panelBack"
           label="Scan the QR Code with your phone"
-          style={{ backgroundColor: "aliceblue" }}
           data-cy="scanQrPanel"
         >
           <Fieldset.Legend size="m" data-cy="scanQrHeader">
@@ -41,32 +42,24 @@ const TotpInstructions = () => {
             <Row>
               <Col width="one-half">
                 <img
+                  className="qrAuth"
                   data-cy="qrApple"
                   alt="Get it from the App store"
                   src="https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RWHRpz?ver=9319&q=90&m=2&h=2147483647&w=2147483647&b=%23FFFFFFFF&aim=true"
-                  style={{
-                    height: 300,
-                    width: 200,
-                    marginBottom: 30
-                  }}
                 ></img>
               </Col>
               <Col width="one-half">
                 <img
+                  className="qrAuth"
                   data-cy="qrAndroid"
                   alt="Get it from the Google Play store"
                   src="https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RWHRpj?ver=90bf&q=90&m=2&h=2147483647&w=2147483647&b=%23FFFFFFFF&aim=true"
-                  style={{
-                    height: 300,
-                    width: 200,
-                    marginBottom: 30
-                  }}
                 ></img>
               </Col>
             </Row>
           </Container>
         </Panel>
-        <Details style={{ marginBottom: 40 }}>
+        <Details className="detailsAuthHelp">
           <Details.Summary data-cy="moreHelpSummary">
             Need more help?
           </Details.Summary>
@@ -98,14 +91,9 @@ const TotpInstructions = () => {
                     rel="noopener noreferrer"
                   >
                     <img
+                      className="altDownloadApple"
                       src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1432944000&h=39686e6a537b2c44ff7ce60f6287e68f"
                       alt="Download on the App Store"
-                      style={{
-                        height: 90,
-                        width: 175,
-                        marginLeft: 12,
-                        marginRight: 12
-                      }}
                     />
                   </a>
                 </Col>
@@ -117,12 +105,9 @@ const TotpInstructions = () => {
                     href="https://play.google.com/store/apps/details?id=com.azure.authenticator&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
                   >
                     <img
+                      className="altDownloadAndroid"
                       alt="Get it on Google Play"
                       src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
-                      style={{
-                        height: 89,
-                        width: 200
-                      }}
                     />
                   </a>
                 </Col>

--- a/src/components/authentication/setMfa/totp/VerifyTotp.tsx
+++ b/src/components/authentication/setMfa/totp/VerifyTotp.tsx
@@ -76,10 +76,10 @@ const VerifyTotp = ({ user }: IVerifyTotp) => {
     };
     const res = await verifyTotpInput(totp);
     if (res === "succeeded") {
-      const res = await updateMfa();
-      if (res === "succeeded") {
-        const res = await removePhoneNo();
-        if (res === "succeeded") {
+      const resU = await updateMfa();
+      if (resU === "succeeded") {
+        const resR = await removePhoneNo();
+        if (resR === "succeeded") {
           dispatch(resetUser());
           history.push("/profile");
           dispatch(

--- a/src/components/authentication/setMfa/totp/VerifyTotp.tsx
+++ b/src/components/authentication/setMfa/totp/VerifyTotp.tsx
@@ -27,7 +27,7 @@ import store from "../../../../redux/store/store";
 import history from "../../../navigation/history";
 import { MFAType } from "../../../../models/MFAStatus";
 import { addNotification } from "../../../../redux/slices/notificationsSlice";
-
+import "../MFA.scss";
 interface IVerifyTotp {
   user: CognitoUser | any;
 }
@@ -121,15 +121,12 @@ const VerifyTotp = ({ user }: IVerifyTotp) => {
             </ActionLink>
           </Details.Text>
         </Details>
-        <Panel
-          label="using your phone"
-          style={{ backgroundColor: "aliceblue" }}
-        >
+        <Panel className="panelBack" label="using your phone">
           <Fieldset.Legend size="m">
             Open your Authenticator App, click 'add a new account' button then
             scan the QR Code below.
           </Fieldset.Legend>
-          <div style={{ padding: "20px" }}>
+          <div className="qrTss">
             <QRCodeSVG
               data-cy="tssQrCode"
               size={192}

--- a/src/components/authentication/setMfa/totp/VerifyTotp.tsx
+++ b/src/components/authentication/setMfa/totp/VerifyTotp.tsx
@@ -26,6 +26,7 @@ import TextInputField from "../../../forms/TextInputField";
 import store from "../../../../redux/store/store";
 import history from "../../../navigation/history";
 import { MFAType } from "../../../../models/MFAStatus";
+import { addNotification } from "../../../../redux/slices/notificationsSlice";
 
 interface IVerifyTotp {
   user: CognitoUser | any;
@@ -63,7 +64,6 @@ const VerifyTotp = ({ user }: IVerifyTotp) => {
   };
 
   const removePhoneNo = async () => {
-    dispatch(resetError());
     const attrib = { phone_number: "" };
     await dispatch(updateUserAttributes({ user, attrib }));
     return store.getState().user.status;
@@ -76,12 +76,18 @@ const VerifyTotp = ({ user }: IVerifyTotp) => {
     };
     const res = await verifyTotpInput(totp);
     if (res === "succeeded") {
-      const res = await removePhoneNo();
+      const res = await updateMfa();
       if (res === "succeeded") {
-        const res = await updateMfa();
+        const res = await removePhoneNo();
         if (res === "succeeded") {
           dispatch(resetUser());
           history.push("/profile");
+          dispatch(
+            addNotification({
+              type: "Success",
+              text: "- Your Authenticator App is now set up. You will be asked for a new 6-digit code each time you log in"
+            })
+          );
         } else getBack();
       } else getBack();
     }

--- a/src/components/authentication/setMfa/totp/VerifyTotp.tsx
+++ b/src/components/authentication/setMfa/totp/VerifyTotp.tsx
@@ -23,6 +23,7 @@ import * as Yup from "yup";
 import TextInputField from "../../../forms/TextInputField";
 import store from "../../../../redux/store/store";
 import history from "../../../navigation/history";
+import { MFAType } from "../../../../models/MFAStatus";
 
 interface IVerifyTotp {
   user: CognitoUser | any;
@@ -57,9 +58,10 @@ const VerifyTotp = ({ user }: IVerifyTotp) => {
   };
 
   const updateMfa = async () => {
+    const pref: MFAType = "TOTP";
     const upMfaObj = {
       user,
-      pref: "TOTP"
+      pref
     };
     await dispatch(setPreferredMfa(upMfaObj));
   };

--- a/src/components/forms/MobilePhoneInputField.scss
+++ b/src/components/forms/MobilePhoneInputField.scss
@@ -1,4 +1,5 @@
 .PhoneInputInput {
   padding: 8px;
   font-size: 1em;
+  max-width: 41ex;
 }

--- a/src/components/forms/MobilePhoneInputField.tsx
+++ b/src/components/forms/MobilePhoneInputField.tsx
@@ -9,9 +9,7 @@ interface IMobilePhoneInputField {
   hidelabel?: boolean;
   id?: string;
   placeholder?: string;
-
   footer?: any;
-
   value?: any;
   disabled?: boolean;
 }

--- a/src/models/MFAStatus.ts
+++ b/src/models/MFAStatus.ts
@@ -3,3 +3,10 @@ export enum MFAStatus {
   SMS = "SMS_MFA",
   TOTP = "SOFTWARE_TOKEN_MFA"
 }
+
+export type MFAType =
+  | "TOTP"
+  | "SMS"
+  | "NOMFA"
+  | "SMS_MFA"
+  | "SOFTWARE_TOKEN_MFA";

--- a/src/redux/slices/notificationsSlice.ts
+++ b/src/redux/slices/notificationsSlice.ts
@@ -27,7 +27,7 @@ const thunkArrRejected = [
   { thunk: loadSavedFormB, text: "load your saved Form R (Part B)" },
   { thunk: saveFormB, text: "save your Form R (Part B)" },
   { thunk: updateFormB, text: "save your updated Form R (Part B)" },
-  { thunk: updateUserAttributes, text: "update your MFA information" },
+  { thunk: updateUserAttributes, text: "update all your user information" },
   {
     thunk: verifyPhone,
     text: "send you an SMS code to sign in. Please try again"
@@ -67,7 +67,7 @@ const thunkArrFulfilled = [
   },
   {
     thunk: setPreferredMfa,
-    text: "MFA choice is set. You will be prompted for a new 6-digit code each time you log in"
+    text: "MFA type has been updated"
   }
 ];
 

--- a/src/redux/slices/notificationsSlice.ts
+++ b/src/redux/slices/notificationsSlice.ts
@@ -64,10 +64,6 @@ const thunkArrFulfilled = [
   {
     thunk: verifyPhone,
     text: "phone has been verified. An SMS code from HEE should arrive soon"
-  },
-  {
-    thunk: setPreferredMfa,
-    text: "MFA type has been updated"
   }
 ];
 

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -1,6 +1,7 @@
 import { CognitoUser } from "@aws-amplify/auth";
 import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { Auth } from "aws-amplify";
+import { MFAType } from "../../models/MFAStatus";
 
 interface IUser {
   status: string;
@@ -57,7 +58,7 @@ export const verifyUserAttributeSubmit = createAsyncThunk(
 
 export const setPreferredMfa = createAsyncThunk(
   "user/setPreferredMfa",
-  async (userPrefMfaData: { user: CognitoUser | any; pref: any }) => {
+  async (userPrefMfaData: { user: CognitoUser | any; pref: MFAType }) => {
     const { user, pref } = userPrefMfaData;
     return Auth.setPreferredMFA(user, pref);
   }


### PR DESCRIPTION
- Remove phone_number attribute when swapping MFA type from SMS to TOTP.
- Order the actions so the phone_number removal is the last action in TOTP set-up process just in case process is aborted.
- Refactor some mfa comps

TODO 
- (see https://github.com/Health-Education-England/tis-trainee-ui/pull/680 )
- refactor redux slices to make DRY
- look at ways to increase test coverage for sign-up/MFA 
 
TICKET TIS21-3193