### PR TITLE
feat: Add gmc and/or tisId to support emails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^2.20.0",

--- a/src/components/support/Support.cy-test.tsx
+++ b/src/components/support/Support.cy-test.tsx
@@ -5,6 +5,7 @@ import { useAppDispatch } from "../../redux/hooks/hooks";
 import store from "../../redux/store/store";
 import {
   mockTraineeProfile,
+  mockTraineeProfileNoGMC,
   mockTraineeProfileNoMatch
 } from "../../mock-data/trainee-profile";
 import {
@@ -39,7 +40,7 @@ describe("Support", () => {
     cy.get("[data-cy=techSupportLink]").should(
       "have.attr",
       "href",
-      "mailto:tis.support@hee.nhs.uk?subject=TSS tech support query"
+      "mailto:tis.support@hee.nhs.uk?subject=TSS tech support query (GMC no. 11111111, TIS ID 123)"
     );
     cy.get("[data-cy=techSupportLink] > .nhsuk-action-link__text").should(
       "include.text",
@@ -51,7 +52,7 @@ describe("Support", () => {
     cy.get("[data-cy=loLink]").should(
       "have.attr",
       "href",
-      "mailto:Formr.tv@hee.nhs.uk?subject=Form R support query"
+      "mailto:Formr.tv@hee.nhs.uk?subject=Form R support query (GMC no. 11111111, TIS ID 123)"
     );
     cy.get(".nhsuk-details__text > :nth-child(1)").should("be.visible");
     cy.get("[data-cy=successMsg] > :nth-child(1)").should(
@@ -96,6 +97,30 @@ describe("Support", () => {
     cy.get(".nhsuk-action-link__text").should(
       "include.text",
       "TIS.yh@hee.nhs.uk"
+    );
+  });
+  it("should only show tisId if no GMC number", () => {
+    const MockedSupportNoGmc = () => {
+      const dispatch = useAppDispatch();
+      dispatch(updatedTraineeProfileData(mockTraineeProfileNoGMC));
+      return <Support />;
+    };
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <MockedSupportNoGmc />
+        </Router>
+      </Provider>
+    );
+    cy.get("[data-cy=loLink]").should(
+      "have.attr",
+      "href",
+      "mailto:Formr.tv@hee.nhs.uk?subject=Form R support query (TIS ID 789)"
+    );
+    cy.get("[data-cy=techSupportLink]").should(
+      "have.attr",
+      "href",
+      "mailto:tis.support@hee.nhs.uk?subject=TSS tech support query (TIS ID 789)"
     );
   });
 });

--- a/src/components/support/Support.tsx
+++ b/src/components/support/Support.tsx
@@ -10,6 +10,11 @@ import { useEffect, useState } from "react";
 const Support = () => {
   const traineeProfileData = useAppSelector(selectTraineeProfile);
   const personOwner = traineeProfileData.personalDetails?.personOwner;
+  const gmcNo = traineeProfileData.personalDetails?.gmcNumber;
+  const tisId = traineeProfileData.traineeTisId;
+  const emailIds = gmcNo
+    ? `GMC no. ${gmcNo}, TIS ID ${tisId}`
+    : `TIS ID ${tisId}`;
   const [mappedContact, setIsMappedContact] = useState("");
 
   useEffect(() => {
@@ -57,12 +62,12 @@ const Support = () => {
         data-cy="loSupportLabel"
       >
         <SupportMsg personOwner={personOwner} mappedContact={mappedContact} />
-        <SupportList mappedContact={mappedContact} />
+        <SupportList mappedContact={mappedContact} emailIds={emailIds} />
       </Panel>
       <Panel label="Technical issues" data-cy="techSupportLabel">
         <ActionLink
           data-cy="techSupportLink"
-          href={`mailto:tis.support@hee.nhs.uk?subject=TSS tech support query`}
+          href={`mailto:tis.support@hee.nhs.uk?subject=TSS tech support query (${emailIds})`}
         >
           Please click here to email TIS Support
         </ActionLink>

--- a/src/components/support/SupportList.tsx
+++ b/src/components/support/SupportList.tsx
@@ -4,7 +4,7 @@ import { localOfficeContacts } from "../../models/LocalOfficeContacts";
 
 interface ISupportList {
   mappedContact: string | null | undefined;
-  emailIds: String;
+  emailIds: string;
 }
 
 const SupportList = ({ mappedContact, emailIds }: ISupportList) => {

--- a/src/components/support/SupportList.tsx
+++ b/src/components/support/SupportList.tsx
@@ -4,9 +4,10 @@ import { localOfficeContacts } from "../../models/LocalOfficeContacts";
 
 interface ISupportList {
   mappedContact: string | null | undefined;
+  emailIds: String;
 }
 
-const SupportList = ({ mappedContact }: ISupportList) => {
+const SupportList = ({ mappedContact, emailIds }: ISupportList) => {
   const [linkContact, updateLinkContact] = useState(mappedContact);
 
   useEffect(() => {
@@ -37,7 +38,7 @@ const SupportList = ({ mappedContact }: ISupportList) => {
               return (
                 <ActionLink
                   data-cy="loLink"
-                  href={`mailto:${linkContact}?subject=Form R support query`}
+                  href={`mailto:${linkContact}?subject=Form R support query (${emailIds})`}
                 >
                   {linkContact}
                 </ActionLink>

--- a/src/mock-data/trainee-profile.ts
+++ b/src/mock-data/trainee-profile.ts
@@ -238,3 +238,10 @@ export const mockTraineeProfileNoMatch: TraineeProfile = {
   programmeMemberships: mockProgrammeMemberships,
   placements: mockPlacements
 };
+
+export const mockTraineeProfileNoGMC: TraineeProfile = {
+  traineeTisId: "789",
+  personalDetails: { ...mockPersonalDetails, gmcNumber: "" },
+  programmeMemberships: mockProgrammeMemberships,
+  placements: mockPlacements
+};


### PR DESCRIPTION
Following feedback at last TSS meeting where support staff are finding it difficult to locate users' details (which could lead to cases of mistaken ID/ possible data breaches):
- Add GMC (when given) and tisId to subject of support emails

TICKET TIS21-3246

