### PR TITLE
fix: remove 30 character limit on surname

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.53.3",
+  "version": "0.53.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.53.3",
+  "version": "0.53.4",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^2.20.0",

--- a/src/components/forms/formr-part-a/ValidationSchema.ts
+++ b/src/components/forms/formr-part-a/ValidationSchema.ts
@@ -12,7 +12,7 @@ const dateValidationSchema = (fieldName: string) =>
 
 export const ValidationSchema = yup.object({
   forename: StringValidationSchema("Forename"),
-  surname: StringValidationSchema("GMC-Registered Surname", 30),
+  surname: StringValidationSchema("GMC-Registered Surname"),
   gmcNumber: StringValidationSchema("GMC number", 20),
   localOfficeName: StringValidationSchema("Deanery / HEE Local Office"),
   dateOfBirth: dateValidationSchema("Your date of birth")

--- a/src/components/forms/formr-part-b/ValidationSchema.ts
+++ b/src/components/forms/formr-part-b/ValidationSchema.ts
@@ -36,7 +36,7 @@ const panelSchemaValidation = yup.array(
 
 export const Section1ValidationSchema = yup.object({
   forename: StringValidationSchema("Forename"),
-  surname: StringValidationSchema("GMC-Registered Surname", 30),
+  surname: StringValidationSchema("GMC-Registered Surname"),
   gmcNumber: StringValidationSchema("GMC number", 20),
   email: yup
     .string()


### PR DESCRIPTION
The surname field is too restrictive at 30 characters, pre-populated
data from TIS can trigger the field validation as TIS allows up to 255
characters.
Remove the 30 character limit.

TIS21-3299