### PR TITLE
##### DRAFT ###### run a matrix of tests using electron, chrome and firefox

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,34 +7,45 @@ on:
   workflow_dispatch:
 
 jobs:
+  continue-on-error: ${{ matrix.experimental }}
+  testing_matrix:
+    strategy:
+      matrix:
+        browser: [chrome, firefox]
+        experimental: true
+        include:
+          - browser: electron
+            experimental: false
+
+
   dockerize:
     name: Dockerize
     runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-2
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Build, tag, and push image to Amazon ECR
-        id: build-image
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ github.event.repository.name }}
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
-          docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: ${{ github.event.repository.name }}
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+        docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
 
   deploy-pre-prod:
     needs: [dockerize]
@@ -77,7 +88,7 @@ jobs:
     needs: [deploy-pre-prod]
     name: Run Cypress E2E tests
     runs-on: ubuntu-latest
-    container: 
+    container:
       image: cypress/browsers:node18.6.0-chrome105-ff104
       options: --user 1001
 
@@ -98,7 +109,7 @@ jobs:
           CYPRESS_coverage: false
           NODE_OPTIONS: --max_old_space_size=4096
         with:
-          browser: chrome
+          browser: ${{ matrix.browser }}
 
       - name: Merge test results into one
         if: always()


### PR DESCRIPTION
Not sure if this is really needed, (or if it'll work ...) but it may be good to see how it goes running the e2e tests on different browsers, this PR will set cypress to use electron, chrome and firefox, but if chrome or firefox crash and electron complete successfully then it will just continue to the next step of the deploy pipeline, only if electron fails its tests then we fail that job.

🤞🏻 