### PR TITLE
test: do not immediately fail tests on 404

### DIFF
--- a/cypress/integration/authenticator/authenticator.spec.ts
+++ b/cypress/integration/authenticator/authenticator.spec.ts
@@ -3,7 +3,7 @@
 
 describe("Authenticator", () => {
   before(() => {
-    cy.visit("./");
+    cy.visit("/");
   });
 
   it("Header should show logo and heading", () => {

--- a/cypress/integration/footer/footer.spec.ts
+++ b/cypress/integration/footer/footer.spec.ts
@@ -6,7 +6,7 @@
 describe("Footer", () => {
   before(() => {
     cy.wait(30000);
-    cy.visit("./");
+    cy.visit("/");
     cy.signIn();
   });
 

--- a/cypress/integration/formr-a/formr-a.spec.ts
+++ b/cypress/integration/formr-a/formr-a.spec.ts
@@ -14,12 +14,12 @@ const startDate = Cypress.dayjs()
 describe("Form R (Part A)", () => {
   before(() => {
     cy.wait(30000);
-    cy.visit("./profile");
+    cy.visit("/");
     cy.signIn();
   });
   it("Should complete a new Form R Part A.", () => {
     cy.contains("Form R (Part A)").click();
-    cy.visit("/formr-a");
+    cy.visit("/formr-a", {failOnStatusCode: false});
     cy.get("#btnOpenForm")
       .should("exist")
       .focus()

--- a/cypress/integration/formr-b/formr-b.spec.ts
+++ b/cypress/integration/formr-b/formr-b.spec.ts
@@ -23,7 +23,7 @@ const prevRevalDate = Cypress.dayjs().subtract(5, "years").format("YYYY-MM-DD");
 
 describe("Form R (Part B)", () => {
   before(() => {
-    cy.visit("./");
+    cy.visit("/");
     cy.viewport("iphone-6");
     cy.signIn();
   });
@@ -31,7 +31,7 @@ describe("Form R (Part B)", () => {
     isCovid = true;
     cy.get("[data-cy=BtnMenu]").should("exist").click();
     cy.contains("Form R (Part B)").click();
-    cy.visit("/formr-b");
+    cy.visit("/formr-b", {failOnStatusCode: false});
     cy.get("[data-cy=btnLoadNewForm]").click();
     cy.get(".MuiDialog-container").should("exist");
     cy.get(".MuiDialogContentText-root").should(

--- a/cypress/integration/mfa/mfa.spec.ts
+++ b/cypress/integration/mfa/mfa.spec.ts
@@ -4,7 +4,7 @@
 describe("MFA set-up", () => {
   before(() => {
     cy.wait(30000);
-    cy.visit("./profile");
+    cy.visit("/");
     cy.signIn();
   });
   it("should render the Choose MFA page", () => {

--- a/cypress/integration/navbar/navbar.spec.ts
+++ b/cypress/integration/navbar/navbar.spec.ts
@@ -7,7 +7,7 @@ describe("Desktop/ tablet header", () => {
   const sizes = [mobileView, desktopView];
 
   before(() => {
-    cy.visit("./profile");
+    cy.visit("/");
     cy.signIn();
   });
 

--- a/cypress/integration/profile/profile.spec.ts
+++ b/cypress/integration/profile/profile.spec.ts
@@ -4,7 +4,7 @@
 describe("Profile", () => {
   before(() => {
     cy.wait(30000);
-    cy.visit("./profile");
+    cy.visit("/profile", {failOnStatusCode: false});
     cy.signIn();
   });
 

--- a/cypress/integration/support/support.spec.ts
+++ b/cypress/integration/support/support.spec.ts
@@ -1,7 +1,7 @@
 describe("Support", () => {
   before(() => {
     cy.wait(30000);
-    cy.visit("./");
+    cy.visit("/");
     cy.signIn();
   });
 


### PR DESCRIPTION
The app is returning `404` errors when using routes to navigate directly to a view e.g. `<base-url>/profile`, this is an infrastructure limitation and the response body is still the full working application. Update the Cypress tests to no longer fail based on the status code when navigating directly to a specific view. Use the base url wherever appropriate to reduce the number of places we need to ignore the status code.

TIS21-3726