### PR TITLE
chore: exclude experimental browser tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,8 @@ jobs:
       matrix:
         browser: [electron, firefox]
         experimental: [true]
+        exclude:
+          - experimental: true
         include:
           - browser: chrome
             experimental: false


### PR DESCRIPTION
The workflow fails when running parallel tests for unknown reasons. Exclude the firefox and electron tests until they can be looked at again.

TIS21-3726
TIS21-3727