### PR TITLE
chore: invalidate cloudfront cache on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ jobs:
   deploy-preprod:
     name: Deploy to Preprod
     runs-on: ubuntu-latest
+    environment: preprod
 
     steps:
       - name: Checkout
@@ -33,6 +34,9 @@ jobs:
 
       - name: Deploy app build to S3 bucket
         run: aws s3 sync ./build/ s3://${{ secrets.AWS_S3_BUCKET_PREPROD }} --delete
+
+      - name: Invalidate CDN Cache
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID}} --paths /static/*
 
   cypress-e2e:
     continue-on-error: ${{ matrix.experimental }}
@@ -181,3 +185,6 @@ jobs:
 
       - name: Deploy app build to S3 bucket
         run: aws s3 sync ./build/ s3://${{ secrets.AWS_S3_BUCKET_PROD }} --delete
+
+      - name: Invalidate CDN Cache
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID}} --paths /static/*


### PR DESCRIPTION
The static JS and CSS content is cached within Cloudfront, when deploying a new version of the site that cache should be invalidated. Technically this is not required for normal running of the application, as the CSS an JS files are versioned with a content hash. While Cloudfront does not need to re-cache a file with the same name, invalidating the cache does mean that old un-used version are cleaned up more quickly.

TIS21-3765
TIS21-3781