### PR TITLE
Feat: sentry alert for failed API calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.55.3",
+  "version": "0.55.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.55.3",
+      "version": "0.55.7",
       "dependencies": {
         "@aws-amplify/ui-react": "^2.20.0",
         "@cypress/code-coverage": "^3.9.12",
@@ -35,7 +35,7 @@
         "@types/react-router-dom": "^5.1.5",
         "@types/yup": "0.29.13",
         "aws-amplify": "^4.3.25",
-        "axios": "^0.21.2",
+        "axios": "^0.21.4",
         "babel-plugin-istanbul": "^6.0.0",
         "browser-update": "^3.3.38",
         "cross-env": "^7.0.3",
@@ -155,14 +155,6 @@
       "dependencies": {
         "@aws-amplify/core": "4.5.7",
         "axios": "0.21.4"
-      }
-    },
-    "node_modules/@aws-amplify/api-rest/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@aws-amplify/auth": {
@@ -298,14 +290,6 @@
         "@aws-sdk/util-format-url": "3.6.1",
         "axios": "0.21.4",
         "events": "^3.1.0"
-      }
-    },
-    "node_modules/@aws-amplify/storage/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@aws-amplify/ui": {
@@ -13962,9 +13946,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-      "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
@@ -40171,16 +40155,6 @@
       "requires": {
         "@aws-amplify/core": "4.5.7",
         "axios": "0.21.4"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "requires": {
-            "follow-redirects": "^1.14.0"
-          }
-        }
       }
     },
     "@aws-amplify/auth": {
@@ -40310,16 +40284,6 @@
         "@aws-sdk/util-format-url": "3.6.1",
         "axios": "0.21.4",
         "events": "^3.1.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "requires": {
-            "follow-redirects": "^1.14.0"
-          }
-        }
       }
     },
     "@aws-amplify/ui": {
@@ -51023,9 +50987,9 @@
       "integrity": "sha512-evY7DN8qSIbsW2H/TWQ1bX3sXN1d4MNb5Vb4n7BzPuCwRHdkZ1H2eNLuSh73EoQqkGKUtju2G2HCcjCfhvZIAA=="
     },
     "axios": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-      "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
         "follow-redirects": "^1.14.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/react-router-dom": "^5.1.5",
     "@types/yup": "0.29.13",
     "aws-amplify": "^4.3.25",
-    "axios": "^0.21.2",
+    "axios": "^0.21.4",
     "babel-plugin-istanbul": "^6.0.0",
     "browser-update": "^3.3.38",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.55.6",
+  "version": "0.55.7",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^2.20.0",

--- a/src/redux/slices/traineeProfileSlice.ts
+++ b/src/redux/slices/traineeProfileSlice.ts
@@ -27,8 +27,6 @@ export const fetchTraineeProfileData = createAsyncThunk(
     const traineeProfileService = new TraineeProfileService();
     const response: AxiosResponse<TraineeProfile> =
       await traineeProfileService.getTraineeProfile();
-    console.log("response:");
-    console.log(response);
     return response.data;
   }
 );

--- a/src/redux/slices/traineeProfileSlice.ts
+++ b/src/redux/slices/traineeProfileSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
 import { AxiosResponse } from "axios";
+import * as Sentry from "@sentry/browser";
 import { TraineeProfile } from "../../models/TraineeProfile";
 import { TraineeProfileService } from "../../services/TraineeProfileService";
 import { initialPersonalDetails } from "../../models/PersonalDetails";
@@ -57,6 +58,10 @@ const traineeProfileSlice = createSlice({
       .addCase(fetchTraineeProfileData.rejected, (state, action) => {
         state.status = "failed";
         state.error = action.error.message;
+        Sentry.captureException(action.error, {
+          tags: { profile: "Profile request rejected" },
+          level: Sentry.Severity.Warning
+        });
       });
   }
 });

--- a/src/redux/slices/traineeProfileSlice.ts
+++ b/src/redux/slices/traineeProfileSlice.ts
@@ -1,6 +1,5 @@
 import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
 import { AxiosResponse } from "axios";
-import * as Sentry from "@sentry/browser";
 import { TraineeProfile } from "../../models/TraineeProfile";
 import { TraineeProfileService } from "../../services/TraineeProfileService";
 import { initialPersonalDetails } from "../../models/PersonalDetails";
@@ -28,6 +27,8 @@ export const fetchTraineeProfileData = createAsyncThunk(
     const traineeProfileService = new TraineeProfileService();
     const response: AxiosResponse<TraineeProfile> =
       await traineeProfileService.getTraineeProfile();
+    console.log("response:");
+    console.log(response);
     return response.data;
   }
 );
@@ -58,10 +59,6 @@ const traineeProfileSlice = createSlice({
       .addCase(fetchTraineeProfileData.rejected, (state, action) => {
         state.status = "failed";
         state.error = action.error.message;
-        Sentry.captureException(action.error, {
-          tags: { profile: "Profile request rejected" },
-          level: Sentry.Severity.Warning
-        });
       });
   }
 });

--- a/src/services/__test__/apiService.test.ts
+++ b/src/services/__test__/apiService.test.ts
@@ -1,0 +1,26 @@
+import { onFulfilled, onRejected } from "../apiService";
+import { errorResponse } from "../../mock-data/service-api-err-res";
+import * as Sentry from "@sentry/browser";
+
+describe("ApiService", () => {
+
+  it("Error should not be captured by Sentry on fulfilled", () => {
+    const sentrySpy = jest.spyOn(Sentry, "captureException");
+
+    onFulfilled({}).then(res => {
+        expect(res).toEqual({});
+    });
+
+    expect(sentrySpy).not.toHaveBeenCalled();
+  });
+
+  it("Error should be captured by Sentry on rejection", () => {
+    const sentrySpy = jest.spyOn(Sentry, "captureException");
+
+    onRejected(errorResponse).catch(error => {
+        expect(error).toEqual(errorResponse);
+    });
+
+    expect(sentrySpy).toHaveBeenCalledWith(errorResponse);
+  });
+});

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, AxiosResponse } from "axios";
+import * as Sentry from "@sentry/browser";
 import { Auth } from "aws-amplify";
 
 export class ApiService {
@@ -16,9 +17,22 @@ export class ApiService {
 
       return config;
     });
+
+    this.axiosInstance.interceptors.response.use(
+      async function (response) {
+        // Any status code that lie within the range of 2xx
+        return response;
+      },
+      async function (error) {
+        // Any status codes that falls outside the range of 2xx
+        Sentry.captureException(error);
+        return Promise.reject(error);
+      }
+    );
   }
 
   get<T = any>(endpoint: string): Promise<AxiosResponse<T>> {
+    console.log(this.axiosInstance.interceptors);
     return this.axiosInstance.get(endpoint);
   }
 

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -32,7 +32,6 @@ export class ApiService {
   }
 
   get<T = any>(endpoint: string): Promise<AxiosResponse<T>> {
-    console.log(this.axiosInstance.interceptors);
     return this.axiosInstance.get(endpoint);
   }
 

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -2,6 +2,17 @@ import axios, { AxiosInstance, AxiosResponse } from "axios";
 import * as Sentry from "@sentry/browser";
 import { Auth } from "aws-amplify";
 
+export const onFulfilled = async function (response: any) {
+  // Any status code that lie within the range of 2xx.
+  return response;
+}
+
+export const onRejected = async function (error: any) {
+  // Any status codes that falls outside the range of 2xx.
+  Sentry.captureException(error);
+  return Promise.reject(error);
+}
+
 export class ApiService {
   axiosInstance: AxiosInstance;
 
@@ -18,17 +29,7 @@ export class ApiService {
       return config;
     });
 
-    this.axiosInstance.interceptors.response.use(
-      async function (response) {
-        // Any status code that lie within the range of 2xx
-        return response;
-      },
-      async function (error) {
-        // Any status codes that falls outside the range of 2xx
-        Sentry.captureException(error);
-        return Promise.reject(error);
-      }
-    );
+    this.axiosInstance.interceptors.response.use(onFulfilled, onRejected);
   }
 
   get<T = any>(endpoint: string): Promise<AxiosResponse<T>> {


### PR DESCRIPTION
TODO: tests

Example sentry alert triggered by 401 on GET trainee/profile: https://sentry.io/organizations/health-education-england-9v/issues/3781050571/?environment=development&project=1882746&query=&referrer=issue-stream&sort=date&statsPeriod=1h

TIS21-3746