### PR TITLE
style: add missing semi-colon for prettier

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Amazon ECS
+name: Deploy to Amazon S3
 
 on:
   push:

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -5,13 +5,13 @@ import { Auth } from "aws-amplify";
 export const onFulfilled = async function (response: any) {
   // Any status code that lie within the range of 2xx.
   return response;
-}
+};
 
 export const onRejected = async function (error: any) {
   // Any status codes that falls outside the range of 2xx.
   Sentry.captureException(error);
   return Promise.reject(error);
-}
+};
 
 export class ApiService {
   axiosInstance: AxiosInstance;


### PR DESCRIPTION
Prettier is failing the build due to some missing semi-colons, add them where appropriate.
Rename the deploy working from ECS to S3 to reflect the new build process.

TIS21-3744