### PR TITLE
fix: breaking cypress e2e tests

### DIFF
--- a/cypress/integration/formr-a/formr-a.spec.ts
+++ b/cypress/integration/formr-a/formr-a.spec.ts
@@ -19,7 +19,7 @@ describe("Form R (Part A)", () => {
   });
   it("Should complete a new Form R Part A.", () => {
     cy.contains("Form R (Part A)").click();
-    cy.visit("/formr-a", {failOnStatusCode: false});
+    cy.visit("/formr-a", { failOnStatusCode: false });
     cy.get("#btnOpenForm")
       .should("exist")
       .focus()
@@ -27,13 +27,15 @@ describe("Form R (Part A)", () => {
         // ---------- if New form btn ------------------------------------------------------------------
         if (loadFormAButton.attr("data-cy") === "btnLoadNewForm") {
           cy.get("[data-cy=btnLoadNewForm]").click();
-          cy.get(".MuiDialog-container").should("exist");
-          cy.get(".MuiDialogContentText-root").should(
-            "include.text",
-            "You recently submitted a form"
-          );
-          cy.get(".MuiDialogActions-root > :nth-child(2)").click();
-
+          cy.get("body").then($body => {
+            if ($body.find(".MuiDialog-container").length) {
+              cy.get(".MuiDialogContentText-root").should(
+                "include.text",
+                "You recently submitted a form"
+              );
+              cy.get(".MuiDialogActions-root > :nth-child(2)").click();
+            }
+          });
           cy.log("##################### NEW FORM ##################");
           cy.get(".nhsuk-warning-callout > p").should("exist");
 

--- a/cypress/integration/formr-b/formr-b.spec.ts
+++ b/cypress/integration/formr-b/formr-b.spec.ts
@@ -31,14 +31,17 @@ describe("Form R (Part B)", () => {
     isCovid = true;
     cy.get("[data-cy=BtnMenu]").should("exist").click();
     cy.contains("Form R (Part B)").click();
-    cy.visit("/formr-b", {failOnStatusCode: false});
+    cy.visit("/formr-b", { failOnStatusCode: false });
     cy.get("[data-cy=btnLoadNewForm]").click();
-    cy.get(".MuiDialog-container").should("exist");
-    cy.get(".MuiDialogContentText-root").should(
-      "include.text",
-      "You recently submitted a form"
-    );
-    cy.get(".MuiDialogActions-root > :nth-child(2)").click();
+    cy.get("body").then($body => {
+      if ($body.find(".MuiDialog-container").length) {
+        cy.get(".MuiDialogContentText-root").should(
+          "include.text",
+          "You recently submitted a form"
+        );
+        cy.get(".MuiDialogActions-root > :nth-child(2)").click();
+      }
+    });
     cy.get(".nhsuk-warning-callout > p").should("exist");
 
     // ---- check if form state resets if navigate away from create page ------------


### PR DESCRIPTION
Quick and dirty/ !DRY fix (will add the conditional as a cypress cmd when Next JS migration is done). 
Conditional solves the problem where the test will break if no recently-submitted forms (following the great purge).

NO TICKET