### PR TITLE
fix: only show templated fields on profile panels

### DIFF
--- a/src/components/profile/Profile.cy-test.tsx
+++ b/src/components/profile/Profile.cy-test.tsx
@@ -15,7 +15,9 @@ import {
   mockPersonalDetails,
   mockProgrammeMemberships,
   mockPlacements,
-  mockProgrammeMembershipNoCurricula
+  mockPlacementNonTemplatedField,
+  mockProgrammeMembershipNoCurricula,
+  mockProgrammeMembershipNonTemplatedField
 } from "../../mock-data/trainee-profile";
 import history from "../navigation/history";
 import React from "react";
@@ -149,5 +151,53 @@ describe("Profile", () => {
     cy.get("[data-cy=curricula5Val]")
       .should("exist")
       .should("contain.text", "N/A");
+  });
+  it("should not show non-templated placement properties", () => {
+    const MockedProfileNonTemplatedField = () => {
+      const dispatch = useAppDispatch();
+      dispatch(
+        updatedTraineeProfileData({
+          traineeTisId: "12345",
+          personalDetails: mockPersonalDetails,
+          programmeMemberships: [],
+          placements: [mockPlacementNonTemplatedField]
+        })
+      );
+      dispatch(updatedTraineeProfileStatus("succeeded"));
+      return <Profile />;
+    };
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <MockedProfileNonTemplatedField />
+        </Router>
+      </Provider>
+    );
+    cy.get("[data-cy=placementsExpander]").should("exist").click();
+    cy.get("[data-cy=nonTemplatedField10Val]").should("not.exist");
+  });
+  it("should not show non-templated programme membership properties", () => {
+    const MockedProfileNonTemplatedField = () => {
+      const dispatch = useAppDispatch();
+      dispatch(
+        updatedTraineeProfileData({
+          traineeTisId: "12345",
+          personalDetails: mockPersonalDetails,
+          programmeMemberships: [mockProgrammeMembershipNonTemplatedField],
+          placements: []
+        })
+      );
+      dispatch(updatedTraineeProfileStatus("succeeded"));
+      return <Profile />;
+    };
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <MockedProfileNonTemplatedField />
+        </Router>
+      </Provider>
+    );
+    cy.get("[data-cy=programmeMembershipsExpander]").should("exist").click();
+    cy.get("[data-cy=nonTemplatedField6Val]").should("not.exist");
   });
 });

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -75,11 +75,15 @@ function filterAndOrderProfilePanelData<T>(
   pObj: T extends ProfileType ? any : any
 ) {
   if (pName === TraineeProfileName.Placements) {
-    const reorderedPl = Object.assign(placementPanelTemplate, { ...pObj });
+    const reorderedPl = populateTemplateProperties(placementPanelTemplate, {
+      ...pObj
+    });
     const { tisId, status, ...filteredPlacementPanel } = reorderedPl;
     return filteredPlacementPanel;
   } else {
-    const reorderedPr = Object.assign(programmePanelTemplate, { ...pObj });
+    const reorderedPr = populateTemplateProperties(programmePanelTemplate, {
+      ...pObj
+    });
     const {
       tisId,
       programmeTisId,
@@ -90,4 +94,12 @@ function filterAndOrderProfilePanelData<T>(
     } = reorderedPr;
     return filteredProgrammePanel;
   }
+}
+
+function populateTemplateProperties(template: any, values: any) {
+  const populatedTemplate: any = {};
+  Object.keys(template).forEach(
+    key => (populatedTemplate[key] = (key in values ? values : template)[key])
+  );
+  return populatedTemplate;
 }

--- a/src/mock-data/trainee-profile.ts
+++ b/src/mock-data/trainee-profile.ts
@@ -111,6 +111,20 @@ export const mockProgrammeMemberships: ProgrammeMembership[] = [
   }
 ];
 
+export const mockProgrammeMembershipNonTemplatedField = {
+  startDate: new Date("2020-01-01"),
+  endDate: new Date("2022-01-01"),
+  programmeCompletionDate: new Date("2019-12-31"),
+  programmeTisId: "1",
+  programmeName: "Cardiology",
+  programmeNumber: "EOE8945",
+  managingDeanery: "Health Education England East of England",
+  programmeMembershipType: "SUBSTANTIVE",
+  status: Status.Current,
+  curricula: [],
+  nonTemplatedField: "nonTemplatedField"
+};
+
 export const mockProgrammeMembershipNoCurricula = {
   startDate: new Date("2020-01-01"),
   endDate: new Date("2022-01-01"),
@@ -224,6 +238,22 @@ export const mockPlacements: Placement[] = [
     wholeTimeEquivalent: "0.75"
   }
 ];
+
+export const mockPlacementNonTemplatedField = {
+  endDate: new Date("2020-12-31"),
+  grade: "ST1",
+  tisId: "315",
+  placementType: "In Post",
+  site: "Addenbrookes Hospital",
+  siteLocation: "Site location",
+  specialty: "Dermatology",
+  startDate: new Date("2019-01-01"),
+  status: Status.Current,
+  employingBody: "Employing body",
+  trainingBody: "Training body",
+  wholeTimeEquivalent: "0.5",
+  nonTemplatedField: "nonTemplatedField"
+};
 
 export const mockTraineeProfile: TraineeProfile = {
   traineeTisId: "123",


### PR DESCRIPTION
The profile panel creator uses `Object.assign(a, b)` to populate the placement and programme membership templates with data. However, that also brings all remaining properties from object `b` resulting in unexpected field values appearing.

Update Profile.tsx to populate only properties that exist in the template object.

TIS21-3681
TIS21-3692