### PR TITLE
fix: e2e tests again

### DIFF
--- a/cypress/integration/formr-a/formr-a.spec.ts
+++ b/cypress/integration/formr-a/formr-a.spec.ts
@@ -108,6 +108,11 @@ describe("Form R (Part A)", () => {
           cy.get("[data-cy=cctSpecialty1]").should("not.exist");
           cy.get("[data-cy=cctSpecialty2]").should("not.exist");
           cy.get("[data-cy=declarationType0]").click();
+          cy.get("[data-cy=programmeSpecialty]").should("exist").click();
+          cy.get("[data-cy=programmeSpecialty] + ul").should("exist");
+          cy.get("[data-cy=programmeSpecialty] + ul li").eq(1).click();
+          cy.get("[data-cy=programmeSpecialty]").should("not.have.value", "");
+
           cy.get("[data-cy=cctSpecialty1]").should("exist");
           cy.get("[data-cy=cctSpecialty2]").should("exist");
 

--- a/cypress/integration/formr-b/formr-b.spec.ts
+++ b/cypress/integration/formr-b/formr-b.spec.ts
@@ -52,7 +52,11 @@ describe("Form R (Part B)", () => {
     cy.get("[data-cy=BtnMenu]").click();
     cy.get(":nth-child(3) > .nhsuk-header__navigation-link").click();
     cy.get("[data-cy=btnLoadNewForm]").click();
-    cy.get(".MuiDialogActions-root > :nth-child(2)").click();
+    cy.get("body").then($body => {
+      if ($body.find(".MuiDialog-container").length) {
+        cy.get(".MuiDialogActions-root > :nth-child(2)").click();
+      }
+    });
     cy.get("[data-cy=email]").should("have.value", "");
 
     //   // -------- Section 1 - Doctor's details -----------


### PR DESCRIPTION
Add another conditional in Form-r b test (missed in the last fix) to check for the MUI pop-up msg again after navigating away from the form page. In Form-r a, populate the programmeSpecialty field (looks like the preprod data has changed so no pre-pop programmeSpecialty) so there's no form error before submission.

NO TICKET (but epic potential) 