### PR TITLE
build: always backup artifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,6 +132,7 @@ jobs:
     needs: [cypress-e2e]
     name: Backup build artifacts
     runs-on: ubuntu-latest
+    if: always()
 
     steps:
       - name: Download build artifacts


### PR DESCRIPTION
Artefacts are only backed up if the E2E tests pass, this should always be done.

TIS21-SHED