### PR TITLE
Refactor/dsp comp2

### DIFF
--- a/components/dsp/CredentialInvalid.tsx
+++ b/components/dsp/CredentialInvalid.tsx
@@ -1,6 +1,42 @@
-const CredentialInvalid = () => {
-  // TODO check if and when to remove redundant dsp local storage data (and reset any redux store data)
-  return <div>Invalid credential</div>;
+const CredentialInvalid: React.FC = () => {
+  const queryParams = new URLSearchParams(location.search);
+  const stateParam = queryParams?.get("state");
+  const reasonParam = queryParams?.get("reason");
+  const errText =
+    "If problem persists then please contact Support (Technical issues).";
+  let content;
+
+  if (stateParam && reasonParam) {
+    localStorage.removeItem("verification");
+    localStorage.removeItem(stateParam);
+    content = (
+      <>
+        <p>{`Your ${reasonParam.replaceAll("_", " ")}.`}</p>
+        <p>{errText}</p>
+      </>
+    );
+  } else {
+    localStorage.removeItem("verification");
+    content = (
+      <>
+        <p>{`Invalid credential.`} </p>
+        <p>{errText}</p>
+      </>
+    );
+  }
+
+  return (
+    <div
+      className="nhsuk-error-summary"
+      aria-labelledby="error-summary-title"
+      role="alert"
+    >
+      <h2 className="nhsuk-error-summary__title" id="error-summary-title">
+        Something went wrong
+      </h2>
+      <div className="nhsuk-error-summary__body">{content}</div>
+    </div>
+  );
 };
 
 export default CredentialInvalid;

--- a/components/dsp/CredentialInvalid.tsx
+++ b/components/dsp/CredentialInvalid.tsx
@@ -1,4 +1,5 @@
 const CredentialInvalid = () => {
+  // TODO check if and when to remove redundant dsp local storage data (and reset any redux store data)
   return <div>CredentialInvalid</div>;
 };
 

--- a/components/dsp/CredentialInvalid.tsx
+++ b/components/dsp/CredentialInvalid.tsx
@@ -1,0 +1,5 @@
+const CredentialInvalid = () => {
+  return <div>CredentialInvalid</div>;
+};
+
+export default CredentialInvalid;

--- a/components/dsp/CredentialInvalid.tsx
+++ b/components/dsp/CredentialInvalid.tsx
@@ -1,6 +1,6 @@
 const CredentialInvalid = () => {
   // TODO check if and when to remove redundant dsp local storage data (and reset any redux store data)
-  return <div>CredentialInvalid</div>;
+  return <div>Invalid credential</div>;
 };
 
 export default CredentialInvalid;

--- a/components/dsp/CredentialIssued.tsx
+++ b/components/dsp/CredentialIssued.tsx
@@ -9,7 +9,7 @@ import {
 import store from "../../redux/store/store";
 import DSPPanel from "./DSPPanel";
 import history from "../navigation/history";
-import { Redirect } from "react-router-dom";
+import { DspUtilities } from "../../utilities/DspUtilities";
 
 const CredentialIssued: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -18,45 +18,62 @@ const CredentialIssued: React.FC = () => {
   const errorDescParam = queryParams?.get("error_description");
 
   if (stateParam && !errorDescParam) {
-    const savedState = localStorage.getItem(stateParam) as string;
-    const currSessionState = JSON.parse(savedState);
-    dispatch(updatedDspPanelObj(currSessionState.panelData));
-    dispatch(updatedDspPanelObjName(currSessionState.panelName));
-    const storedPanelData = store.getState().dsp.dspPanelObj;
-    const storedPanelName = store.getState().dsp.dspPanelObjName;
-    return (
-      <WarningCallout>
-        <WarningCallout.Label visuallyHiddenText={false}>
-          Success
-        </WarningCallout.Label>
-        <p>The following credential has been added to your DSP wallet.</p>
-        <DSPPanel profName={storedPanelName} profData={storedPanelData} />
-        <Button
-          onClick={() => {
-            localStorage.removeItem("verification");
-            localStorage.removeItem(stateParam);
-            history.push(`/${storedPanelName}`);
-            store.dispatch(resetDspSlice());
-          }}
-          data-cy="dspVerifyIdentity"
-        >
-          {`Back to ${storedPanelName} page`}
-        </Button>
-      </WarningCallout>
-    );
+    const savedState = localStorage.getItem(stateParam);
+    if (savedState) {
+      const currSessionState = JSON.parse(savedState);
+      dispatch(updatedDspPanelObj(currSessionState.panelData));
+      dispatch(updatedDspPanelObjName(currSessionState.panelName));
+      const storedPanelData = store.getState().dsp.dspPanelObj;
+      const storedPanelName = store.getState().dsp.dspPanelObjName;
+      return (
+        <WarningCallout>
+          <WarningCallout.Label visuallyHiddenText={false}>
+            Success
+          </WarningCallout.Label>
+          <p>The following credential has been added to your DSP wallet.</p>
+          <DSPPanel profName={storedPanelName} profData={storedPanelData} />
+          <Button
+            onClick={() => {
+              localStorage.removeItem("verification");
+              localStorage.removeItem(stateParam);
+              history.push(`/${storedPanelName}`);
+              store.dispatch(resetDspSlice());
+            }}
+            data-cy="dspVerifyIdentity"
+          >
+            OK
+          </Button>
+        </WarningCallout>
+      );
+    }
+    return DspUtilities.redirectToCredInvalid();
   }
 
+  // Condition for when user cancels adding the cred to the wallet
   if (stateParam && errorDescParam) {
-    // Condition for when user cancels adding the cred to the wallet
-    // i.e. ...error_description=User%20cancelled%20the%20issuance%20request
     localStorage.removeItem("verification");
     localStorage.removeItem(stateParam);
     store.dispatch(resetDspSlice());
-    // placeholder error msg until agree best approach
-    return <p>{`${errorDescParam.replaceAll("%20", " ")}`}</p>;
+    return (
+      <div
+        className="nhsuk-error-summary"
+        aria-labelledby="error-summary-title"
+        role="alert"
+      >
+        <h2 className="nhsuk-error-summary__title" id="error-summary-title">
+          Something went wrong
+        </h2>
+        <div className="nhsuk-error-summary__body">
+          {" "}
+          <p>{`Credential has not been added to your wallet. Reason: ${errorDescParam.replaceAll(
+            "%20",
+            " "
+          )}`}</p>
+        </div>
+      </div>
+    );
   }
-
-  return <Redirect to="/credential/invalid" />;
+  return DspUtilities.redirectToCredInvalid();
 };
 
 export default CredentialIssued;

--- a/components/dsp/CredentialIssued.tsx
+++ b/components/dsp/CredentialIssued.tsx
@@ -1,0 +1,5 @@
+const CredentialIssued = () => {
+  return <div>CredentialIssued</div>;
+};
+
+export default CredentialIssued;

--- a/components/dsp/CredentialIssued.tsx
+++ b/components/dsp/CredentialIssued.tsx
@@ -1,5 +1,62 @@
-const CredentialIssued = () => {
-  return <div>CredentialIssued</div>;
+import { Button, WarningCallout } from "nhsuk-react-components";
+import React from "react";
+import { useAppDispatch } from "../../redux/hooks/hooks";
+import {
+  resetDspSlice,
+  updatedDspPanelObj,
+  updatedDspPanelObjName
+} from "../../redux/slices/dspSlice";
+import store from "../../redux/store/store";
+import DSPPanel from "./DSPPanel";
+import history from "../navigation/history";
+import { Redirect } from "react-router-dom";
+
+const CredentialIssued: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const queryParams = new URLSearchParams(location.search);
+  const stateParam = queryParams?.get("state");
+  const errorDescParam = queryParams?.get("error_description");
+
+  if (stateParam && !errorDescParam) {
+    const savedState = localStorage.getItem(stateParam) as string;
+    const currSessionState = JSON.parse(savedState);
+    dispatch(updatedDspPanelObj(currSessionState.panelData));
+    dispatch(updatedDspPanelObjName(currSessionState.panelName));
+    const storedPanelData = store.getState().dsp.dspPanelObj;
+    const storedPanelName = store.getState().dsp.dspPanelObjName;
+    return (
+      <WarningCallout>
+        <WarningCallout.Label visuallyHiddenText={false}>
+          Success
+        </WarningCallout.Label>
+        <p>The following credential has been added to your DSP wallet.</p>
+        <DSPPanel profName={storedPanelName} profData={storedPanelData} />
+        <Button
+          onClick={() => {
+            localStorage.removeItem("verification");
+            localStorage.removeItem(stateParam);
+            history.push(`/${storedPanelName}`);
+            store.dispatch(resetDspSlice());
+          }}
+          data-cy="dspVerifyIdentity"
+        >
+          {`Back to ${storedPanelName} page`}
+        </Button>
+      </WarningCallout>
+    );
+  }
+
+  if (stateParam && errorDescParam) {
+    // Condition for when user cancels adding the cred to the wallet
+    // i.e. ...error_description=User%20cancelled%20the%20issuance%20request
+    localStorage.removeItem("verification");
+    localStorage.removeItem(stateParam);
+    store.dispatch(resetDspSlice());
+    // placeholder error msg until agree best approach
+    return <p>{`${errorDescParam.replaceAll("%20", " ")}`}</p>;
+  }
+
+  return <Redirect to="/credential/invalid" />;
 };
 
 export default CredentialIssued;

--- a/components/dsp/CredentialStart.tsx
+++ b/components/dsp/CredentialStart.tsx
@@ -58,8 +58,7 @@ const CredentialStart: React.FC = () => {
   }
   localStorage.removeItem("verification");
   return <Redirect to="/home" />;
-  // Note: No state param in URI when aborting verify ID in Gateway, so no key to access and remove DSP local storage data.
-  // (One hacky fix could be to store the dsp local storage key under it's own named key?)
+  // TODO No state param in URI when aborting verify ID in Gateway, so no key to access and remove DSP local storage data in the usual way.
 };
 
 export default CredentialStart;

--- a/components/dsp/CredentialStart.tsx
+++ b/components/dsp/CredentialStart.tsx
@@ -21,8 +21,8 @@ const CredentialStart: React.FC = () => {
           Important
         </WarningCallout.Label>
         <p>
-          Before you can issue this credential to you DSP wallet you must verify
-          your identity.
+          Before you can issue this credential to your DSP wallet you must
+          verify your identity.
         </p>
         <DSPPanel profName={storedPanelName} profData={storedPanelData} />
         <Button
@@ -57,8 +57,8 @@ const CredentialStart: React.FC = () => {
     );
   }
   localStorage.removeItem("verification");
-  return <Redirect to="/home" />;
-  // TODO No state param in URI when aborting verify ID in Gateway, so no key to access and remove DSP local storage data in the usual way.
+  return <Redirect to="/credential/invalid" />;
+  // TODO No state or reason param in URI when aborting verify ID in Gateway, so no key to access and remove DSP local storage data in the usual way and provide appropriate msg.
 };
 
 export default CredentialStart;

--- a/components/dsp/CredentialStart.tsx
+++ b/components/dsp/CredentialStart.tsx
@@ -1,5 +1,79 @@
-const CredentialStart = () => {
-  return <div>CredentialStart</div>;
+import { Button, WarningCallout } from "nhsuk-react-components";
+import { Redirect } from "react-router-dom";
+import {
+  issueDspCredential,
+  verifyDspIdentity
+} from "../../redux/slices/dspSlice";
+import store from "../../redux/store/store";
+import DSPPanel from "./DSPPanel";
+
+const CredentialStart: React.FC = () => {
+  const issueUri = store.getState().dsp.gatewayUri;
+  const dspErrCode = store.getState().dsp.errorCode;
+  const issuingState = store.getState().dsp.isIssuing;
+  const storedPanelData = store.getState().dsp.dspPanelObj;
+  const storedPanelName = store.getState().dsp.dspPanelObjName;
+
+  if (issuingState && dspErrCode === "401") {
+    return (
+      <WarningCallout>
+        <WarningCallout.Label visuallyHiddenText={false}>
+          Important
+        </WarningCallout.Label>
+        <p>
+          Before you can issue this credential to you DSP wallet you must verify
+          your identity.
+        </p>
+        <DSPPanel profName={storedPanelName} profData={storedPanelData} />
+        <Button
+          onClick={() => {
+            handleVerifyClick();
+          }}
+          data-cy="dspVerifyIdentity"
+        >
+          Click to verify your identity
+        </Button>
+      </WarningCallout>
+    );
+  }
+
+  if (issuingState && issueUri) {
+    return (
+      <WarningCallout>
+        <WarningCallout.Label visuallyHiddenText={false}>
+          Important
+        </WarningCallout.Label>
+        <p>You are about to issue this credential to your DSP wallet.</p>
+        <DSPPanel profName={storedPanelName} profData={storedPanelData} />
+        <Button
+          onClick={() => {
+            window.location.href = issueUri;
+          }}
+          data-cy="dspIssueCred"
+        >
+          Click to add credential to your wallet
+        </Button>
+      </WarningCallout>
+    );
+  }
+  localStorage.removeItem("verification");
+  return <Redirect to="/home" />;
+  // Note: No state param in URI when aborting verify ID in Gateway, so no key to access and remove DSP local storage data.
+  // (One hacky fix could be to store the dsp local storage key under it's own named key?)
 };
 
 export default CredentialStart;
+
+async function handleVerifyClick() {
+  localStorage.setItem("verification", "yes");
+  await store.dispatch(verifyDspIdentity());
+  const verifyUri = store.getState().dsp.gatewayUri;
+  if (verifyUri) {
+    const issueName = store.getState().dsp.dspPanelObjName.slice(0, -1);
+    await store.dispatch(issueDspCredential(issueName));
+    const issueUri = store.getState().dsp.gatewayUri;
+    if (issueUri) {
+      window.location.href = issueUri;
+    }
+  } else return <Redirect to="/credential/invalid" />;
+}

--- a/components/dsp/CredentialStart.tsx
+++ b/components/dsp/CredentialStart.tsx
@@ -1,0 +1,5 @@
+const CredentialStart = () => {
+  return <div>CredentialStart</div>;
+};
+
+export default CredentialStart;

--- a/components/dsp/CredentialVerified.tsx
+++ b/components/dsp/CredentialVerified.tsx
@@ -1,4 +1,4 @@
-import { Redirect, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import { useAppDispatch } from "../../redux/hooks/hooks";
 import {
   issueDspCredential,
@@ -9,6 +9,7 @@ import {
 import store from "../../redux/store/store";
 import { Button, WarningCallout } from "nhsuk-react-components";
 import DSPPanel from "./DSPPanel";
+import { DspUtilities } from "../../utilities/DspUtilities";
 
 const CredentialVerified: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -18,41 +19,42 @@ const CredentialVerified: React.FC = () => {
   const verificationStatus = localStorage.getItem("verification");
 
   if (stateParam && verificationStatus === "yes") {
-    const savedState = localStorage.getItem(stateParam) as string;
-    const currSessionState = JSON.parse(savedState);
-    dispatch(updatedDspStateId(stateParam));
-    dispatch(updatedDspPanelObj(currSessionState.panelData));
-    dispatch(updatedDspPanelObjName(currSessionState.panelName));
-    const storedPanelData = store.getState().dsp.dspPanelObj;
-    const storedPanelName = store.getState().dsp.dspPanelObjName;
-    return (
-      <WarningCallout>
-        <WarningCallout.Label visuallyHiddenText={false}>
-          Success
-        </WarningCallout.Label>
-        <p>
-          Your ID has been verified and you can now add this credential to your
-          DSP wallet.
-        </p>
-        <DSPPanel profName={storedPanelName} profData={storedPanelData} />
-        <Button
-          onClick={async () => {
-            localStorage.removeItem("verification");
-            await dispatch(issueDspCredential(storedPanelName.slice(0, -1)));
+    const savedState = localStorage.getItem(stateParam);
+    if (savedState) {
+      const currSessionState = JSON.parse(savedState);
+      dispatch(updatedDspStateId(stateParam));
+      dispatch(updatedDspPanelObj(currSessionState.panelData));
+      dispatch(updatedDspPanelObjName(currSessionState.panelName));
+      const storedPanelData = store.getState().dsp.dspPanelObj;
+      const storedPanelName = store.getState().dsp.dspPanelObjName;
+      return (
+        <WarningCallout>
+          <WarningCallout.Label visuallyHiddenText={false}>
+            Success
+          </WarningCallout.Label>
+          <p>
+            Your ID has been verified and you can now add this credential to
+            your DSP wallet.
+          </p>
+          <DSPPanel profName={storedPanelName} profData={storedPanelData} />
+          <Button
+            onClick={async () => {
+              localStorage.removeItem("verification");
+              await dispatch(issueDspCredential(storedPanelName.slice(0, -1)));
 
-            const issueUri = store.getState().dsp.gatewayUri;
-            if (issueUri) window.location.href = issueUri;
-          }}
-          data-cy="dspIssueCred"
-        >
-          Click to add credential to your wallet
-        </Button>
-      </WarningCallout>
-    );
+              const issueUri = store.getState().dsp.gatewayUri;
+              if (issueUri) window.location.href = issueUri;
+            }}
+            data-cy="dspIssueCred"
+          >
+            Click to add credential to your wallet
+          </Button>
+        </WarningCallout>
+      );
+    }
+    return DspUtilities.redirectToCredInvalid();
   }
-  // TODO ensure any dsp local storage data is removed
-  localStorage.removeItem("verification");
-  return <Redirect to="/credential/invalid" />;
+  return DspUtilities.redirectToCredInvalid();
 };
 
 export default CredentialVerified;

--- a/components/dsp/CredentialVerified.tsx
+++ b/components/dsp/CredentialVerified.tsx
@@ -1,5 +1,58 @@
-const CredentialVerified = () => {
-  return <div>CredentialVerified</div>;
+import { Redirect, useLocation } from "react-router-dom";
+import { useAppDispatch } from "../../redux/hooks/hooks";
+import {
+  issueDspCredential,
+  updatedDspPanelObj,
+  updatedDspPanelObjName,
+  updatedDspStateId
+} from "../../redux/slices/dspSlice";
+import store from "../../redux/store/store";
+import { Button, WarningCallout } from "nhsuk-react-components";
+import DSPPanel from "./DSPPanel";
+
+const CredentialVerified: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const stateParam = queryParams?.get("state");
+  const verificationStatus = localStorage.getItem("verification");
+
+  if (stateParam && verificationStatus === "yes") {
+    const savedState = localStorage.getItem(stateParam) as string;
+    const currSessionState = JSON.parse(savedState);
+    dispatch(updatedDspStateId(stateParam));
+    dispatch(updatedDspPanelObj(currSessionState.panelData));
+    dispatch(updatedDspPanelObjName(currSessionState.panelName));
+    const storedPanelData = store.getState().dsp.dspPanelObj;
+    const storedPanelName = store.getState().dsp.dspPanelObjName;
+    return (
+      <WarningCallout>
+        <WarningCallout.Label visuallyHiddenText={false}>
+          Success
+        </WarningCallout.Label>
+        <p>
+          Your ID has been verified and you can now add this credential to your
+          DSP wallet.
+        </p>
+        <DSPPanel profName={storedPanelName} profData={storedPanelData} />
+        <Button
+          onClick={async () => {
+            localStorage.removeItem("verification");
+            await dispatch(issueDspCredential(storedPanelName.slice(0, -1)));
+
+            const issueUri = store.getState().dsp.gatewayUri;
+            if (issueUri) window.location.href = issueUri;
+          }}
+          data-cy="dspIssueCred"
+        >
+          Click to add credential to your wallet
+        </Button>
+      </WarningCallout>
+    );
+  }
+  // TODO ensure any dsp local storage data is removed
+  localStorage.removeItem("verification");
+  return <Redirect to="/credential/invalid" />;
 };
 
 export default CredentialVerified;

--- a/components/dsp/CredentialVerified.tsx
+++ b/components/dsp/CredentialVerified.tsx
@@ -1,0 +1,5 @@
+const CredentialVerified = () => {
+  return <div>CredentialVerified</div>;
+};
+
+export default CredentialVerified;

--- a/components/dsp/Dsp.tsx
+++ b/components/dsp/Dsp.tsx
@@ -1,72 +1,15 @@
-import { Redirect, useLocation } from "react-router-dom";
-import store from "../../redux/store/store";
-import useLocalStorage from "../../utilities/hooks/useLocalStorage";
-import Loading from "../common/Loading";
-import {
-  issueDspCredential,
-  resetDspSlice,
-  updatedDspPanelObj,
-  updatedDspPanelObjName,
-  verifyDspIdentity
-} from "../../redux/slices/dspSlice";
-import { useAppDispatch } from "../../redux/hooks/hooks";
-import history from "../navigation/history";
-import DSPPanel from "./DSPPanel";
+import { Redirect, Route, Switch } from "react-router-dom";
 import PageTitle from "../common/PageTitle";
 import ScrollTo from "../forms/ScrollTo";
-import {
-  Button,
-  ErrorMessage,
-  Fieldset,
-  WarningCallout
-} from "nhsuk-react-components";
+import { Fieldset } from "nhsuk-react-components";
 import style from "../Common.module.scss";
+import CredentialStart from "./CredentialStart";
+import CredentialVerified from "./CredentialVerified";
+import CredentialIssued from "./CredentialIssued";
+import CredentialInvalid from "./CredentialInvalid";
+import PageNotFound from "../common/PageNotFound";
 
 export default function Dsp() {
-  const dspError = store.getState().dsp.error;
-  const dspStatus = store.getState().dsp.status;
-  const dspErrCode = store.getState().dsp.errorCode;
-  const location = useLocation();
-  const queryParams = new URLSearchParams(location.search);
-  const stateParam = queryParams?.get("state");
-  const issuingStatus = store.getState().dsp.isIssuing;
-  const issueUri = store.getState().dsp.gatewayUri;
-  const verificationStatus = localStorage.getItem("verification");
-
-  let content;
-
-  if (verificationStatus) {
-    return <PostVerificationIssuePrompt stateParam={stateParam} />;
-  }
-
-  if (issueUri) {
-    return <IssuePrompt issueUri={issueUri} />;
-  }
-
-  if (issuingStatus === false && !stateParam) {
-    return <Redirect to="/home" />;
-  }
-
-  if (stateParam) {
-    return <IssueSuccessPrompt stateParam={stateParam} />;
-  }
-
-  if (dspStatus === "loading") {
-    content = <Loading />;
-  }
-
-  if (dspErrCode === "401") {
-    content = <VerifyIdPrompt />;
-  }
-
-  if (dspStatus === "failed" && dspErrCode !== "401") {
-    return (
-      <WarningCallout>
-        <ErrorMessage>{dspError}</ErrorMessage>
-      </WarningCallout>
-    );
-  }
-
   return (
     <>
       <PageTitle title="Dsp" />
@@ -80,152 +23,18 @@ export default function Dsp() {
           Digital Staff Passport
         </Fieldset.Legend>
       </Fieldset>
-      {content}
+      <Switch>
+        <Route
+          exact
+          path="/credential/verified"
+          component={CredentialVerified}
+        />
+        <Route exact path="/credential/issued" component={CredentialIssued} />
+        <Route exact path="/credential/invalid" component={CredentialInvalid} />
+        <Route exact path="/credential" component={CredentialStart} />
+        <Redirect exact path="/" to="/credential" />
+        <Route path="/credential/*" component={PageNotFound} />
+      </Switch>
     </>
-  );
-}
-
-type IssuePromptProps = {
-  issueUri: string;
-};
-
-function IssuePrompt({ issueUri }: IssuePromptProps) {
-  const storedPanelData = store.getState().dsp.dspPanelObj;
-  const storedPanelName = store.getState().dsp.dspPanelObjName;
-  return (
-    <WarningCallout>
-      <WarningCallout.Label visuallyHiddenText={false}>
-        Important
-      </WarningCallout.Label>
-      <p>You are about to issue this credential to your DSP wallet.</p>
-      <DSPPanel profName={storedPanelName} profData={storedPanelData} />
-      <Button
-        onClick={() => {
-          window.location.href = issueUri;
-        }}
-        data-cy="dspIssueCred"
-      >
-        Click to add credential to your wallet
-      </Button>
-    </WarningCallout>
-  );
-}
-
-type PostVerificationIssuePromptProps = {
-  stateParam: string | null;
-};
-
-function PostVerificationIssuePrompt({
-  stateParam
-}: PostVerificationIssuePromptProps) {
-  const dispatch = useAppDispatch();
-  const [currSessionState, _setCurrSessionState] = useLocalStorage(
-    stateParam ? stateParam : "",
-    ""
-  );
-  if (currSessionState) {
-    dispatch(updatedDspPanelObj(currSessionState.panelData));
-    dispatch(updatedDspPanelObjName(currSessionState.panelName));
-  }
-  const storedPanelData = store.getState().dsp.dspPanelObj;
-  const storedPanelName = store.getState().dsp.dspPanelObjName;
-  return (
-    <WarningCallout>
-      <WarningCallout.Label visuallyHiddenText={false}>
-        Important
-      </WarningCallout.Label>
-      <p>
-        Your ID has been verified and you can now add this credential to your
-        DSP wallet.
-      </p>
-      <DSPPanel profName={storedPanelName} profData={storedPanelData} />
-      <Button
-        onClick={async () => {
-          localStorage.removeItem("verification");
-          await dispatch(issueDspCredential(storedPanelName.slice(0, -1)));
-          const issueUri = store.getState().dsp.gatewayUri;
-          if (issueUri) window.location.href = issueUri;
-        }}
-        data-cy="dspIssueCred"
-      >
-        Click to add credential to your wallet
-      </Button>
-    </WarningCallout>
-  );
-}
-
-function VerifyIdPrompt() {
-  const storedPanelData = store.getState().dsp.dspPanelObj;
-  const storedPanelName = store.getState().dsp.dspPanelObjName;
-  return (
-    <WarningCallout>
-      <WarningCallout.Label visuallyHiddenText={false}>
-        Important
-      </WarningCallout.Label>
-      <p>
-        Before you can issue this credential to you DSP wallet you must verify
-        your identity.
-      </p>
-      <DSPPanel profName={storedPanelName} profData={storedPanelData} />
-      <Button
-        onClick={() => {
-          handleVerifyClick();
-        }}
-        data-cy="dspVerifyIdentity"
-      >
-        Click to verify your identity
-      </Button>
-    </WarningCallout>
-  );
-}
-
-async function handleVerifyClick() {
-  localStorage.setItem("verification", "yes");
-  await store.dispatch(verifyDspIdentity());
-  const verifyUri = store.getState().dsp.gatewayUri;
-  // todo go to issue prompt screen before issuing gateway
-  if (verifyUri) {
-    const issueName = store.getState().dsp.dspPanelObjName.slice(0, -1);
-    await store.dispatch(issueDspCredential(issueName));
-    const issueUri = store.getState().dsp.gatewayUri;
-    if (issueUri) {
-      window.location.href = issueUri;
-    }
-  } else console.log("Identity verification failed.");
-}
-
-type IssueSuccessPromptProps = {
-  stateParam: string;
-};
-
-function IssueSuccessPrompt({ stateParam }: IssueSuccessPromptProps) {
-  const dispatch = useAppDispatch();
-  const [currSessionState, _setCurrSessionState] = useLocalStorage(
-    stateParam,
-    ""
-  );
-  dispatch(updatedDspPanelObj(currSessionState.panelData));
-  dispatch(updatedDspPanelObjName(currSessionState.panelName));
-  const storedPanelData = store.getState().dsp.dspPanelObj;
-  const storedPanelName = store.getState().dsp.dspPanelObjName;
-  return (
-    <WarningCallout>
-      <WarningCallout.Label visuallyHiddenText={false}>
-        Success
-      </WarningCallout.Label>
-      <p>The following credential has been added to your DSP wallet.</p>
-      <DSPPanel profName={storedPanelName} profData={storedPanelData} />
-      <Button
-        onClick={() => {
-          localStorage.removeItem(stateParam);
-          store.dispatch(resetDspSlice());
-          localStorage.removeItem(stateParam);
-          history.push(`/${storedPanelName}`);
-        }}
-        data-cy="dspVerifyIdentity"
-      >
-        {`Back to ${storedPanelName} page`}
-      </Button>
-    </WarningCallout>
   );
 }

--- a/components/dsp/DspIssueBtn.tsx
+++ b/components/dsp/DspIssueBtn.tsx
@@ -13,7 +13,7 @@ import {
 import { ProfileType, TraineeProfileName } from "../../models/TraineeProfile";
 import { useAppDispatch } from "../../redux/hooks/hooks";
 import { nanoid } from "nanoid";
-
+import { addNotification } from "../../redux/slices/notificationsSlice";
 interface IDspIssueBtn {
   panelName: string;
   panelId: string;
@@ -43,8 +43,12 @@ export const DspIssueBtn: React.FC<IDspIssueBtn> = ({
     if (issueUri !== null || dspErrorCode === "401") {
       history.push("/credential");
     } else {
-      // TODO proper error notification
-      console.log("DspIssueBtn click error: ", dspErrorText);
+      dispatch(
+        addNotification({
+          type: "Error",
+          text: ` - Something went wrong (Error: ${dspErrorText}). If problem persists please contact Support`
+        })
+      );
       localStorage.removeItem(stateId);
       dispatch(resetDspSlice());
     }

--- a/components/dsp/DspIssueBtn.tsx
+++ b/components/dsp/DspIssueBtn.tsx
@@ -6,10 +6,12 @@ import {
   issueDspCredential,
   updatedDspIsIssuing,
   updatedDspPanelObj,
-  updatedDspPanelObjName
+  updatedDspPanelObjName,
+  updatedDspStateId
 } from "../../redux/slices/dspSlice";
 import { ProfileType, TraineeProfileName } from "../../models/TraineeProfile";
 import { useAppDispatch } from "../../redux/hooks/hooks";
+import { nanoid } from "nanoid";
 
 interface IDspIssueBtn {
   panelName: string;
@@ -27,6 +29,9 @@ export const DspIssueBtn: React.FC<IDspIssueBtn> = ({
     panelName === TraineeProfileName.Programmes ? "programmes" : "placements";
 
   const handleClick = async () => {
+    // create and store the stateid here so we can use the same one throughout the issue -> verify -> issue journey.
+    const stateId = nanoid();
+    dispatch(updatedDspStateId(stateId));
     dispatch(updatedDspIsIssuing(true));
     dispatch(updatedDspPanelObjName(panelNameShort));
     chooseProfileArr(panelName, panelId);

--- a/components/dsp/DspIssueBtn.tsx
+++ b/components/dsp/DspIssueBtn.tsx
@@ -4,6 +4,7 @@ import styles from "./Dsp.module.scss";
 import history from "../navigation/history";
 import {
   issueDspCredential,
+  resetDspSlice,
   updatedDspIsIssuing,
   updatedDspPanelObj,
   updatedDspPanelObjName,
@@ -29,7 +30,6 @@ export const DspIssueBtn: React.FC<IDspIssueBtn> = ({
     panelName === TraineeProfileName.Programmes ? "programmes" : "placements";
 
   const handleClick = async () => {
-    // create and store the stateid here so we can use the same one throughout the issue -> verify -> issue journey.
     const stateId = nanoid();
     dispatch(updatedDspStateId(stateId));
     dispatch(updatedDspIsIssuing(true));
@@ -37,7 +37,17 @@ export const DspIssueBtn: React.FC<IDspIssueBtn> = ({
     chooseProfileArr(panelName, panelId);
     const issueName = panelNameShort.slice(0, -1);
     await dispatch(issueDspCredential(issueName));
-    history.push("/credential");
+    const dspErrorCode = store.getState().dsp.errorCode;
+    const dspErrorText = store.getState().dsp.error;
+    const issueUri = store.getState().dsp.gatewayUri;
+    if (issueUri !== null || dspErrorCode === "401") {
+      history.push("/credential");
+    } else {
+      // TODO proper error notification
+      console.log("DspIssueBtn click error: ", dspErrorText);
+      localStorage.removeItem(stateId);
+      dispatch(resetDspSlice());
+    }
   };
 
   const cyTag = `dspBtn${panelName}${panelId}`;

--- a/cypress/component/dsp/DspIssueBtn.cy.tsx
+++ b/cypress/component/dsp/DspIssueBtn.cy.tsx
@@ -4,15 +4,19 @@ import { mount } from "cypress/react18";
 import { Router } from "react-router-dom";
 import history from "../../../components/navigation/history";
 import { DspIssueBtn } from "../../../components/dsp/DspIssueBtn";
+import { Provider } from "react-redux";
+import store from "../../../redux/store/store";
 
 describe("DSP issue button", () => {
   it("should enable digital staff passport button if date is not past", () => {
     mount(
-      <Router history={history}>
-        <DspIssueBtn panelName="placement" panelId="" isPastDate={false} />
-      </Router>
+      <Provider store={store}>
+        <Router history={history}>
+          <DspIssueBtn panelName="placement" panelId="" isPastDate={false} />
+        </Router>
+      </Provider>
     );
-    cy.get("[data-cy=dspBtnplacement1]")
+    cy.get("[data-cy=dspBtnplacement]")
       .should("not.be.disabled")
       .should(
         "include.text",
@@ -22,11 +26,13 @@ describe("DSP issue button", () => {
 
   it("should disable digital staff passport button if date is past", () => {
     mount(
-      <Router history={history}>
-        <DspIssueBtn panelName="placement" panelId="" isPastDate={true} />
-      </Router>
+      <Provider store={store}>
+        <Router history={history}>
+          <DspIssueBtn panelName="placement" panelId="" isPastDate={true} />
+        </Router>
+      </Provider>
     );
-    cy.get("[data-cy=dspBtnplacement2]")
+    cy.get("[data-cy=dspBtnplacement]")
       .should("be.disabled")
       .should(
         "include.text",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^4.2.1",

--- a/utilities/DspUtilities.tsx
+++ b/utilities/DspUtilities.tsx
@@ -1,0 +1,8 @@
+import { Redirect } from "react-router-dom";
+
+export class DspUtilities {
+  public static redirectToCredInvalid() {
+    localStorage.removeItem("verification");
+    return <Redirect to="/credential/invalid" />;
+  }
+}


### PR DESCRIPTION
Quick refactor to map the dsp/credential comps to agreed paths and make the dsp journey a little more informative if you happen to venture from the very narrow happy path.

TODO: 
1. Have a chat about the state id storage workflow
2. Configure React-testing-library on top of existing Jest config to help test the DSP comps using window props then write some more tests.

TICKET TIS21-4311
