### PR TITLE
Add more DSP Credential CT's

### DIFF
--- a/components/common/Loading.tsx
+++ b/components/common/Loading.tsx
@@ -1,16 +1,12 @@
 import React from "react";
 import ReactLoading from "react-loading";
 
-class Loading extends React.PureComponent {
-  render() {
-    return (
-      <ReactLoading
-        data-cy="loading"
-        type={"bars"}
-        color={"black"}
-      ></ReactLoading>
-    );
-  }
+export default function Loading() {
+  return (
+    <ReactLoading
+      data-cy="loading"
+      type={"bars"}
+      color={"black"}
+    ></ReactLoading>
+  );
 }
-
-export default Loading;

--- a/components/dsp/CredentialIssue.tsx
+++ b/components/dsp/CredentialIssue.tsx
@@ -1,7 +1,7 @@
 import { nanoid } from "nanoid";
 import { Button, WarningCallout } from "nhsuk-react-components";
 import { useState } from "react";
-import { Redirect, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import {
   issueDspCredential,
   updatedDspPanelObj,
@@ -28,10 +28,15 @@ const CredentialIssue: React.FC = () => {
   if (issueUri) {
     content = (
       <WarningCallout>
-        <WarningCallout.Label visuallyHiddenText={false}>
+        <WarningCallout.Label
+          visuallyHiddenText={false}
+          data-cy="dspIssueWarningLabel"
+        >
           Important
         </WarningCallout.Label>
-        <p>You are about to issue this credential to your DSP wallet.</p>
+        <p data-cy="dspIssueWarningText">
+          You are about to issue this credential to your DSP wallet.
+        </p>
         <DSPPanel profName={storedPanelName} profData={storedPanelData} />
         <Button
           disabled={isIssuing ? true : false}
@@ -39,7 +44,7 @@ const CredentialIssue: React.FC = () => {
             setIsIssuing(true);
             window.location.href = issueUri;
           }}
-          data-cy="dspIssueCred"
+          data-cy="dspIssueCredBtn"
         >
           Click to add credential to your wallet
         </Button>

--- a/components/dsp/CredentialIssue.tsx
+++ b/components/dsp/CredentialIssue.tsx
@@ -62,10 +62,13 @@ const CredentialIssue: React.FC = () => {
       const storedPanelName = store.getState().dsp.dspPanelObjName;
       content = (
         <WarningCallout>
-          <WarningCallout.Label visuallyHiddenText={false}>
+          <WarningCallout.Label
+            visuallyHiddenText={false}
+            data-cy="dspVerifiedWarningLabel"
+          >
             Success
           </WarningCallout.Label>
-          <p>
+          <p data-cy="dspVerifiedWarningText">
             Your ID has been verified and you can now add this credential to
             your DSP wallet.
           </p>
@@ -81,7 +84,7 @@ const CredentialIssue: React.FC = () => {
               const issueUri = store.getState().dsp.gatewayUri;
               if (issueUri) window.location.href = issueUri;
             }}
-            data-cy="dspIssueCred"
+            data-cy="dspIssueCredBtn"
           >
             Click to add credential to your wallet
           </Button>

--- a/components/dsp/CredentialIssued.tsx
+++ b/components/dsp/CredentialIssued.tsx
@@ -9,10 +9,11 @@ import {
 import store from "../../redux/store/store";
 import DSPPanel from "./DSPPanel";
 import history from "../navigation/history";
-import { Redirect } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 const CredentialIssued: React.FC = () => {
   const dispatch = useAppDispatch();
+  const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
   const stateParam = queryParams?.get("state");
   const errorDescParam = queryParams?.get("error_description");
@@ -28,10 +29,15 @@ const CredentialIssued: React.FC = () => {
       const storedPanelName = store.getState().dsp.dspPanelObjName;
       content = (
         <WarningCallout>
-          <WarningCallout.Label visuallyHiddenText={false}>
+          <WarningCallout.Label
+            visuallyHiddenText={false}
+            data-cy="dspIssuedSuccessWarningLabel"
+          >
             Success
           </WarningCallout.Label>
-          <p>The following credential has been added to your DSP wallet.</p>
+          <p data-cy="dspIssuedSuccessWarningText">
+            The following credential has been added to your DSP wallet.
+          </p>
           <DSPPanel profName={storedPanelName} profData={storedPanelData} />
           <Button
             onClick={() => {
@@ -39,7 +45,7 @@ const CredentialIssued: React.FC = () => {
               history.push(`/${storedPanelName}`);
               store.dispatch(resetDspSlice());
             }}
-            data-cy="dspVerifyIdentity"
+            data-cy="dspIssuedSuccessBtn"
           >
             OK
           </Button>
@@ -58,12 +64,16 @@ const CredentialIssued: React.FC = () => {
         aria-labelledby="error-summary-title"
         role="alert"
       >
-        <h2 className="nhsuk-error-summary__title" id="error-summary-title">
+        <h2
+          className="nhsuk-error-summary__title"
+          data-cy="dspIssuedErrorSummaryTitle"
+          id="error-summary-title"
+        >
           Something went wrong
         </h2>
         <div className="nhsuk-error-summary__body">
           {" "}
-          <p>{`Credential has not been added to your wallet. Reason: ${errorDescParam.replaceAll(
+          <p data-cy="dspIssuedErrorSummaryText">{`Credential has not been added to your wallet. Reason: ${errorDescParam.replaceAll(
             "%20",
             " "
           )}`}</p>

--- a/components/dsp/CredentialVerify.tsx
+++ b/components/dsp/CredentialVerify.tsx
@@ -19,10 +19,13 @@ const CredentialVerify: React.FC = () => {
   if (storedPanelName && storedPanelData) {
     content = (
       <WarningCallout>
-        <WarningCallout.Label visuallyHiddenText={false}>
+        <WarningCallout.Label
+          visuallyHiddenText={false}
+          data-cy="dspVerifyWarningLabel"
+        >
           Important
         </WarningCallout.Label>
-        <p>
+        <p data-cy="dspVerifyWarningText">
           Before you can issue this credential to your DSP wallet you must
           verify your identity.
         </p>
@@ -32,7 +35,7 @@ const CredentialVerify: React.FC = () => {
             setIsIssuing(true);
             handleVerifyClick();
           }}
-          data-cy="dspVerifyIdentity"
+          data-cy="dspVerifyIdentityBtn"
         >
           Click to verify your identity
         </Button>

--- a/components/dsp/DSPPanel.tsx
+++ b/components/dsp/DSPPanel.tsx
@@ -26,17 +26,17 @@ export default function DSPPanel({ profName, profData }: DSPPanelProps) {
 
   return filteredProf ? (
     <Card className={style.panelDiv}>
-      <Card.Heading>{`${panelHeader} credential`}</Card.Heading>
+      <Card.Heading data-cy="dspPanelHeading">{`${panelHeader} credential`}</Card.Heading>
       <SummaryList>
         {Object.keys(filteredProf).map((panelProp, index) => {
           const propKey =
             panelHeader === "Programme" ? prKeys[index] : plKeys[index];
           return (
             <SummaryList.Row key={index}>
-              <SummaryList.Key data-cy={`${panelProp}${index}Key`}>
+              <SummaryList.Key data-cy={`${panelProp}Key`}>
                 {PANEL_KEYS[panelProp]}
               </SummaryList.Key>
-              <SummaryList.Value data-cy={`${panelProp}${index}Val`}>
+              <SummaryList.Value data-cy={`${panelProp}Val`}>
                 {displayListVal(profData[propKey], propKey)}
               </SummaryList.Value>
             </SummaryList.Row>

--- a/components/dsp/DspIssueBtn.tsx
+++ b/components/dsp/DspIssueBtn.tsx
@@ -77,7 +77,7 @@ export const DspIssueBtn: React.FC<IDspIssueBtn> = ({
   return (
     <div className={styles.btnDiv}>
       <Button
-        disabled={isIssuing ? true : false}
+        disabled={isIssuing || isPastDate ? true : false}
         className={styles.btn}
         secondary
         onClick={(e: { preventDefault: () => void }) => {

--- a/cypress/component/dsp/CredentialIssue.cy.tsx
+++ b/cypress/component/dsp/CredentialIssue.cy.tsx
@@ -1,0 +1,89 @@
+import { Provider } from "react-redux";
+import { Router } from "react-router-dom";
+import history from "../../../components/navigation/history";
+import CredentialIssue from "../../../components/dsp/CredentialIssue";
+import store from "../../../redux/store/store";
+import {
+  updatedDspGatewayUri,
+  updatedDspPanelObj,
+  updatedDspPanelObjName
+} from "../../../redux/slices/dspSlice";
+
+const panelData = {
+  tisId: "321",
+  programmeTisId: "2",
+  programmeName: "General Practice",
+  programmeNumber: "EOE8950",
+  startDate: "2020-01-01",
+  endDate: "2028-01-01",
+  managingDeanery: "West of England",
+  curricula: []
+};
+
+describe("CredentialIssue", () => {
+  it("should mount the Issue prompt comp when gatewayUri but no dsp state in localStorage", () => {
+    const MockedCredentialIssueJustUri = () => {
+      store.dispatch(updatedDspPanelObjName("programmes"));
+      store.dispatch(updatedDspPanelObj(panelData));
+      store.dispatch(updatedDspGatewayUri("/"));
+      return <CredentialIssue />;
+    };
+    cy.mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <MockedCredentialIssueJustUri />
+        </Router>
+      </Provider>
+    );
+    cy.get('[data-cy="dspIssueWarningLabel"]')
+      .should("exist")
+      .should("have.text", "Important");
+    cy.get('[data-cy="dspIssueWarningText"]')
+      .should("exist")
+      .should(
+        "have.text",
+        "You are about to issue this credential to your DSP wallet."
+      );
+    cy.get('[data-cy="dspPanelHeading"]')
+      .should("exist")
+      .should("have.text", "Programme credential");
+    cy.get('[data-cy="programmeNameVal"]')
+      .should("exist")
+      .should("have.text", "General Practice");
+    cy.get('[data-cy="startDateVal"]')
+      .should("exist")
+      .should("have.text", "01/01/2020");
+    cy.get('[data-cy="endDateVal"]').should("have.text", "01/01/2028");
+    cy.get('[data-cy="dspIssueCredBtn"]').should("exist");
+    // would like to test for loading state etc. onClick but can't work out a way to do it at the moment. Might try RTL.
+  });
+});
+
+// // TODO Can't set the correct URL for this test. Might try RTL.
+// describe("Credential - verify Id before issuing credential", () => {
+//   it("should show the verify Id prompt when a state param but no gateway uri", () => {
+//     const MockedCredentialIssueJustStateParam = () => {
+//       store.dispatch(updatedDspPanelObjName("programmes"));
+//       store.dispatch(updatedDspPanelObj(panelData));
+//       localStorage.setItem(
+//         "eMdRu7Ir8kRNOrs8QxKSP",
+//         JSON.stringify({
+//           panelData: store.getState().dsp.dspPanelObj,
+//           panelName: store.getState().dsp.dspPanelObjName
+//         })
+//       );
+//       return (
+//         <Provider store={store}>
+//           <Router history={history}>
+//             <CredentialIssue />
+//           </Router>
+//         </Provider>
+//       );
+//     };
+//     cy.mount(<MockedCredentialIssueJustStateParam />, {
+//       routerProps: {
+//         initialEntries: ["/credential/issue?state=eMdRu7Ir8kRNOrs8QxKSP"]
+//       }
+//     });
+//   });
+// });

--- a/cypress/component/dsp/CredentialIssued.cy.tsx
+++ b/cypress/component/dsp/CredentialIssued.cy.tsx
@@ -1,0 +1,86 @@
+import { Provider } from "react-redux";
+import CredentialIssued from "../../../components/dsp/CredentialIssued";
+import {
+  updatedDspGatewayUri,
+  updatedDspPanelObj,
+  updatedDspPanelObjName
+} from "../../../redux/slices/dspSlice";
+import store from "../../../redux/store/store";
+
+const panelData = {
+  tisId: "321",
+  programmeTisId: "2",
+  programmeName: "General Practice",
+  programmeNumber: "EOE8950",
+  startDate: "2020-01-01",
+  endDate: "2028-01-01",
+  managingDeanery: "West of England",
+  curricula: []
+};
+
+describe("CredentialIssued success", () => {
+  it("should mount the Issued success msg when state is in the URI and there is no error msg query param ", () => {
+    const MockedCredentialIssuedWithStateParam = () => {
+      store.dispatch(updatedDspPanelObjName("programmes"));
+      store.dispatch(updatedDspPanelObj(panelData));
+      localStorage.setItem(
+        "eMdRu7Ir8kRNOrs8QxKSP",
+        JSON.stringify({
+          panelData: store.getState().dsp.dspPanelObj,
+          panelName: store.getState().dsp.dspPanelObjName
+        })
+      );
+      return (
+        <Provider store={store}>
+          <CredentialIssued />
+        </Provider>
+      );
+    };
+    cy.mountRouterComponent(
+      <MockedCredentialIssuedWithStateParam />,
+      "?state=eMdRu7Ir8kRNOrs8QxKSP"
+    );
+    cy.get('[data-cy="dspIssuedSuccessWarningLabel"]')
+      .should("exist")
+      .should("have.text", "Success");
+    cy.get('[data-cy="dspIssuedSuccessWarningText"]')
+      .should("exist")
+      .should(
+        "have.text",
+        "The following credential has been added to your DSP wallet."
+      );
+    cy.get('[data-cy="programmeNameVal"]')
+      .should("exist")
+      .should("have.text", "General Practice");
+    cy.get('[data-cy="startDateVal"]')
+      .should("exist")
+      .should("have.text", "01/01/2020");
+    cy.get('[data-cy="endDateVal"]').should("have.text", "01/01/2028");
+    cy.get('[data-cy="dspIssuedSuccessBtn"]').should("exist");
+  });
+});
+
+describe("CredentialIssued user cancels", () => {
+  it("should show the 'user cancelled issuance' msg when error_description param is user_cancelled.", () => {
+    const CredIssued = () => {
+      return (
+        <Provider store={store}>
+          <CredentialIssued />
+        </Provider>
+      );
+    };
+    cy.mountRouterComponent(
+      <CredIssued />,
+      "?state=eMdRu7Ir8kRNOrs8QxKSP&error_description=user%20cancelled"
+    );
+    cy.get('[data-cy="dspIssuedErrorSummaryTitle"]')
+      .should("exist")
+      .should("have.text", "Something went wrong");
+    cy.get('[data-cy="dspIssuedErrorSummaryText"]')
+      .should("exist")
+      .should(
+        "have.text",
+        "Credential has not been added to your wallet. Reason: user cancelled"
+      );
+  });
+});

--- a/cypress/component/dsp/CredentialVerify.cy.tsx
+++ b/cypress/component/dsp/CredentialVerify.cy.tsx
@@ -1,0 +1,58 @@
+import { Provider } from "react-redux";
+import { Router } from "react-router-dom";
+import history from "../../../components/navigation/history";
+import CredentialVerify from "../../../components/dsp/CredentialVerify";
+import store from "../../../redux/store/store";
+import {
+  updatedDspPanelObj,
+  updatedDspPanelObjName
+} from "../../../redux/slices/dspSlice";
+import { mount } from "cypress/react18";
+
+const panelData = {
+  tisId: "321",
+  programmeTisId: "2",
+  programmeName: "General Practice",
+  programmeNumber: "EOE8950",
+  startDate: "2020-01-01",
+  endDate: "2028-01-01",
+  managingDeanery: "West of England",
+  curricula: []
+};
+
+describe("CredentialVerify", () => {
+  it("should mount the Verify prompt when store panel data available ", () => {
+    const MockedCredentialIssueWithPanelData = () => {
+      store.dispatch(updatedDspPanelObjName("programmes"));
+      store.dispatch(updatedDspPanelObj(panelData));
+      return (
+        <Provider store={store}>
+          <Router history={history}>
+            <CredentialVerify />
+          </Router>
+        </Provider>
+      );
+    };
+    mount(<MockedCredentialIssueWithPanelData />);
+    cy.get('[data-cy="dspVerifyWarningLabel"]')
+      .should("exist")
+      .should("have.text", "Important");
+    cy.get('[data-cy="dspVerifyWarningText"]')
+      .should("exist")
+      .should(
+        "have.text",
+        "Before you can issue this credential to your DSP wallet you must verify your identity."
+      );
+    cy.get('[data-cy="dspPanelHeading"]')
+      .should("exist")
+      .should("have.text", "Programme credential");
+    cy.get('[data-cy="programmeNameVal"]')
+      .should("exist")
+      .should("have.text", "General Practice");
+    cy.get('[data-cy="startDateVal"]')
+      .should("exist")
+      .should("have.text", "01/01/2020");
+    cy.get('[data-cy="endDateVal"]').should("have.text", "01/01/2028");
+    cy.get('[data-cy="dspVerifyIdentityBtn"]').should("exist");
+  });
+});

--- a/cypress/support/commands.tsx
+++ b/cypress/support/commands.tsx
@@ -1,8 +1,21 @@
 /// <reference types="cypress" />
 
+import { mount } from "cypress/react18";
+import { MemoryRouter } from "react-router-dom";
 import day from "dayjs";
 import { DateUtilities } from "../../utilities/DateUtilities";
 import { BooleanUtilities } from "../../utilities/BooleanUtilities";
+
+Cypress.Commands.add("mount", (component, options = {}) => {
+  const {
+    routerProps = {
+      initialEntries: ["/"]
+    },
+    ...mountOptions
+  } = options;
+  const wrapped = <MemoryRouter {...routerProps}>{component}</MemoryRouter>;
+  return mount(wrapped, mountOptions);
+});
 
 Cypress.Commands.add("checkForSuccessNotif", (successMsg: string) => {
   cy.get(".notification").should(

--- a/cypress/support/commands.tsx
+++ b/cypress/support/commands.tsx
@@ -1,20 +1,31 @@
 /// <reference types="cypress" />
 
-import { mount } from "cypress/react18";
 import { MemoryRouter } from "react-router-dom";
 import day from "dayjs";
 import { DateUtilities } from "../../utilities/DateUtilities";
 import { BooleanUtilities } from "../../utilities/BooleanUtilities";
 
-Cypress.Commands.add("mount", (component, options = {}) => {
-  const {
-    routerProps = {
-      initialEntries: ["/"]
-    },
-    ...mountOptions
-  } = options;
-  const wrapped = <MemoryRouter {...routerProps}>{component}</MemoryRouter>;
-  return mount(wrapped, mountOptions);
+const RenderSearchParams = () => {
+  const searchParams = new URLSearchParams(window.location.search);
+  const paramsObj = Object.fromEntries(searchParams.entries());
+  return (
+    <div id="search-params">
+      {Object.keys(paramsObj).map(key => (
+        <span id={`${key}:${paramsObj[key]}`} />
+      ))}
+    </div>
+  );
+};
+
+Cypress.Commands.add("mountRouterComponent", (component, route) => {
+  const wrapped = (
+    <MemoryRouter initialEntries={[route]}>
+      <RenderSearchParams />
+      {component}
+    </MemoryRouter>
+  );
+
+  return cy.mount(wrapped);
 });
 
 Cypress.Commands.add("checkForSuccessNotif", (successMsg: string) => {

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 import dayjs from "dayjs";
+import { MountOptions, MountReturn } from "cypress/react18";
+import { MemoryRouterProps } from "react-router-dom";
 
 declare global {
   namespace Cypress {
@@ -8,6 +10,10 @@ declare global {
        * Custom command to select DOM element by data-cy attribute.
        * @example cy.dataCy('greeting')
        */
+      mount(
+        component: React.ReactNode,
+        options?: MountOptions & { routerProps?: MemoryRouterProps }
+      ): Cypress.Chainable<MountReturn>;
       checkFormRAValues(
         dateAttained: string,
         completionDate: string,

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -10,9 +10,9 @@ declare global {
        * Custom command to select DOM element by data-cy attribute.
        * @example cy.dataCy('greeting')
        */
-      mount(
+      mountRouterComponent(
         component: React.ReactNode,
-        options?: MountOptions & { routerProps?: MemoryRouterProps }
+        route: string
       ): Cypress.Chainable<MountReturn>;
       checkFormRAValues(
         dateAttained: string,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^4.2.1",

--- a/redux/slices/dspSlice.ts
+++ b/redux/slices/dspSlice.ts
@@ -86,6 +86,9 @@ const dspSlice = createSlice({
     updatedDspPanelObjName(state, action: PayloadAction<string>) {
       return { ...state, dspPanelObjName: action.payload };
     },
+    updatedDspGatewayUri(state, action: PayloadAction<string>) {
+      return { ...state, gatewayUri: action.payload };
+    },
     resetDspSlice() {
       return initialState;
     }
@@ -127,5 +130,6 @@ export const {
   updatedDspStateId,
   updatedDspPanelObj,
   updatedDspPanelObjName,
+  updatedDspGatewayUri,
   resetDspSlice
 } = dspSlice.actions;


### PR DESCRIPTION
Add more Cypress CT's to cover the main happy paths (i.e. the various screens on the issue -> verify -> issue journey) .

TODO: There are more conditions to test and also the onClick events but this can probably wait until we finalise the unhappy paths, feature flags etc.

(ps. There's a bit of refactoring to do to make the test files a bit DRY'er which can wait for the next PR 😩 )

NO TICKET