### PR TITLE
Fix/cypress config

### DIFF
--- a/components/authentication/signup/header/AuthHeader.tsx
+++ b/components/authentication/signup/header/AuthHeader.tsx
@@ -10,7 +10,7 @@ const AuthHeader = (): JSX.Element => {
       </Flex>
       <Flex className={styles.authTitle}>
         <View>
-          <h1 data-cy="authTitle">TIS Self-Service (Alpha)</h1>
+          <h1 data-cy="authTitle">TIS Self-Service</h1>
         </View>
       </Flex>
       <Flex>

--- a/cypress/component/dsp/CredentialIssued.cy.tsx
+++ b/cypress/component/dsp/CredentialIssued.cy.tsx
@@ -1,7 +1,6 @@
 import { Provider } from "react-redux";
 import CredentialIssued from "../../../components/dsp/CredentialIssued";
 import {
-  updatedDspGatewayUri,
   updatedDspPanelObj,
   updatedDspPanelObjName
 } from "../../../redux/slices/dspSlice";

--- a/cypress/support/RenderSearchParams.tsx
+++ b/cypress/support/RenderSearchParams.tsx
@@ -1,0 +1,27 @@
+import { mount } from "cypress/react18";
+import { MemoryRouter } from "react-router-dom";
+
+export default function RenderSearchParams() {
+  const searchParams = new URLSearchParams(window.location.search);
+  const paramsObj = Object.fromEntries(searchParams.entries());
+  return (
+    <div id="search-params">
+      {Object.keys(paramsObj).map(key => (
+        <span id={`${key}:${paramsObj[key]}`} />
+      ))}
+    </div>
+  );
+}
+
+// Npte: had to put this command here rather than commands.ts because of webpack compilaton error on e2e test run (this cmd is only required for CT'ing).
+
+Cypress.Commands.add("mountRouterComponent", (component, route) => {
+  const wrapped = (
+    <MemoryRouter initialEntries={[route]}>
+      <RenderSearchParams />
+      {component}
+    </MemoryRouter>
+  );
+
+  return mount(wrapped);
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,32 +1,8 @@
 /// <reference types="cypress" />
 
-import { MemoryRouter } from "react-router-dom";
 import day from "dayjs";
 import { DateUtilities } from "../../utilities/DateUtilities";
 import { BooleanUtilities } from "../../utilities/BooleanUtilities";
-
-const RenderSearchParams = () => {
-  const searchParams = new URLSearchParams(window.location.search);
-  const paramsObj = Object.fromEntries(searchParams.entries());
-  return (
-    <div id="search-params">
-      {Object.keys(paramsObj).map(key => (
-        <span id={`${key}:${paramsObj[key]}`} />
-      ))}
-    </div>
-  );
-};
-
-Cypress.Commands.add("mountRouterComponent", (component, route) => {
-  const wrapped = (
-    <MemoryRouter initialEntries={[route]}>
-      <RenderSearchParams />
-      {component}
-    </MemoryRouter>
-  );
-
-  return cy.mount(wrapped);
-});
 
 Cypress.Commands.add("checkForSuccessNotif", (successMsg: string) => {
   cy.get(".notification").should(

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -26,15 +26,3 @@ import "../../styles/globals.scss";
 // your custom command.
 // Alternatively, can be defined in cypress/support/component.d.ts
 // with a <reference path="./component" /> at the top of your spec.
-declare global {
-  namespace Cypress {
-    interface Chainable {
-      mount: typeof mount;
-    }
-  }
-}
-
-Cypress.Commands.add("mount", mount);
-
-// Example use:
-// cy.mount(<MyComponent />)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.61.0",
+      "version": "0.61.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^4.2.1",
         "@cypress/code-coverage": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^4.2.1",


### PR DESCRIPTION
- Move the RenderSearchParams logic/ command (only used for CT but being compiled during e2e tests ) out of the commands file to prevent the e2e Webpack compilation error.
 (Not much officially re configuring e2e and CT with separate commands files (which includes some JSX); tried a few alternative file structures etc. but this was the one that made things work while keeping TS happy.)
- Remove temp Alpha heading before the merge to main.

NO TICKET
