### PR TITLE
test: more DSP conditions 

### DIFF
--- a/components/common/Loading.tsx
+++ b/components/common/Loading.tsx
@@ -7,6 +7,7 @@ export default function Loading() {
       data-cy="loading"
       type={"bars"}
       color={"black"}
+      aria-label="loading-bars"
     ></ReactLoading>
   );
 }

--- a/components/dsp/CredentialIssue.tsx
+++ b/components/dsp/CredentialIssue.tsx
@@ -1,15 +1,14 @@
-import { nanoid } from "nanoid";
 import { Button, WarningCallout } from "nhsuk-react-components";
 import { useState } from "react";
 import { useLocation } from "react-router-dom";
 import {
-  issueDspCredential,
   updatedDspPanelObj,
   updatedDspPanelObjName
 } from "../../redux/slices/dspSlice";
 import store from "../../redux/store/store";
 import Loading from "../common/Loading";
 import DSPPanel from "./DSPPanel";
+import { handleIssueCredential } from "../../utilities/DspUtilities";
 
 const CredentialIssue: React.FC = () => {
   const [isIssuing, setIsIssuing] = useState(false);
@@ -77,12 +76,11 @@ const CredentialIssue: React.FC = () => {
             disabled={isIssuing ? true : false}
             onClick={async () => {
               setIsIssuing(true);
-              localStorage.removeItem(stateParam);
-              const stateId = nanoid();
-              const issueName = storedPanelName.slice(0, -1);
-              await store.dispatch(issueDspCredential({ issueName, stateId }));
-              const issueUri = store.getState().dsp.gatewayUri;
-              if (issueUri) window.location.href = issueUri;
+              const newIssueUri = await handleIssueCredential(
+                stateParam,
+                storedPanelName
+              );
+              if (newIssueUri) window.location.href = newIssueUri;
             }}
             data-cy="dspIssueCredBtn"
           >

--- a/components/dsp/__test__/CredentialIssue.test.tsx
+++ b/components/dsp/__test__/CredentialIssue.test.tsx
@@ -1,0 +1,74 @@
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import CredentialIssue from "../CredentialIssue";
+import { handleIssueCredential } from "../../../utilities/DspUtilities";
+import { MemoryRouter, Route } from "react-router-dom";
+import { Provider } from "react-redux";
+import store from "../../../redux/store/store";
+import {
+  updatedDspPanelObjName,
+  updatedDspPanelObj,
+  updatedDspGatewayUri
+} from "../../../redux/slices/dspSlice";
+import React from "react";
+
+jest.mock("../../../utilities/DspUtilities", () => ({
+  handleIssueCredential: jest.fn()
+}));
+
+describe("CredentialIssue component", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      value: { href: "" },
+      writable: true
+    });
+  });
+  it("calls handleIssueCredential on button click", async () => {
+    const panelName = "programmes";
+    const stateParam = "eMdRu7Ir8kRNOrs8QxKSP";
+    const panelData = {
+      tisId: "321",
+      programmeTisId: "2",
+      programmeName: "General Practice",
+      programmeNumber: "EOE8950",
+      startDate: "2020-01-01",
+      endDate: "2028-01-01",
+      managingDeanery: "West of England",
+      curricula: []
+    };
+    store.dispatch(updatedDspPanelObjName(panelName));
+    store.dispatch(updatedDspPanelObj(panelData));
+    store.dispatch(updatedDspGatewayUri(""));
+    localStorage.setItem(
+      stateParam,
+      JSON.stringify({
+        panelData: store.getState().dsp.dspPanelObj,
+        panelName: store.getState().dsp.dspPanelObjName
+      })
+    );
+    (handleIssueCredential as jest.Mock).mockResolvedValueOnce(
+      "https://www.evertonfc.com"
+    );
+
+    const { getByRole } = render(
+      <MemoryRouter initialEntries={[`/?state=${stateParam}`]}>
+        <Route path="/">
+          <Provider store={store}>
+            <CredentialIssue />
+          </Provider>
+        </Route>
+      </MemoryRouter>
+    );
+
+    const button = getByRole("button", {
+      name: /Click to add credential to your wallet/i
+    });
+
+    fireEvent.click(button);
+
+    expect(handleIssueCredential).toHaveBeenCalledWith(stateParam, panelName);
+
+    await waitFor(() => {
+      expect(window.location.href).toBe("https://www.evertonfc.com");
+    });
+  });
+});

--- a/components/dsp/__test__/CredentialIssueLoading.test.tsx
+++ b/components/dsp/__test__/CredentialIssueLoading.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import store from "../../../redux/store/store";
+import CredentialIssue from "../CredentialIssue";
+
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useState: jest.fn()
+}));
+
+describe("CredentialIssue loading state", () => {
+  it("renders Loading component when isIssuing is true", () => {
+    (React.useState as jest.Mock).mockReturnValue([true, jest.fn()]);
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Route path="/">
+          <Provider store={store}>
+            <CredentialIssue />
+          </Provider>
+        </Route>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByLabelText("loading-bars")).toBeInTheDocument();
+  });
+});

--- a/cypress/component/dsp/CredentialIssue.cy.tsx
+++ b/cypress/component/dsp/CredentialIssue.cy.tsx
@@ -105,4 +105,3 @@ describe("CredentialIssue", () => {
     cy.get('[data-cy="dspIssueCredBtn"]').should("exist");
   });
 });
-// TODO: Would like to test for loading state onClick but can't work out a way to do it at the moment. Might try RTL.

--- a/utilities/DspUtilities.ts
+++ b/utilities/DspUtilities.ts
@@ -1,0 +1,19 @@
+import { nanoid } from "nanoid";
+import { issueDspCredential } from "../redux/slices/dspSlice";
+import store from "../redux/store/store";
+
+async function dispatchIssueDspCredential(issueName: string, stateId: string) {
+  await store.dispatch(issueDspCredential({ issueName, stateId }));
+}
+
+export async function handleIssueCredential(
+  stateP: string,
+  storedPName: string
+) {
+  localStorage.removeItem(stateP);
+  const stateId = nanoid();
+  const issueName = storedPName.slice(0, -1);
+  await dispatchIssueDspCredential(issueName, stateId);
+  const newIssueUri = store.getState().dsp.gatewayUri;
+  return newIssueUri;
+}


### PR DESCRIPTION
Before mothballing DSP, test a couple more CredentialIssue conditions using RTL/Jest. Still a bit of a WIP which depends on future 'unhappy path' decisions (e.g. error-handling implementation).  
Put Loading test in a separate file because can't currently find a good way of stopping the jest.mock for React.useState conflicting with the other RTL test. 
There's also some component refactoring to make it easier to test other functions in follow-up work.

NO TICKET