### PR TITLE
chore: update analysed folders

### DIFF
--- a/.github/workflows/pr-analysis.yml
+++ b/.github/workflows/pr-analysis.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           do_analysis=false
           for changed_file in ${{ steps.changed-files.outputs.all }}; do
-            if [[ $changed_file =~ ^(src|cypress)\/.+$ ]]; then
+            if [[ $changed_file =~ ^(components|cypress|mock-data|models|pages|redux|services|utilities)\/.+$ ]]; then
               do_analysis=true
               break
             fi


### PR DESCRIPTION
The folder structure was changed and no longer has everything under a `src` folder. Update the regex to include source folders.

This is a quick fix, a better approach may need to be considered now we don't have the common `src` parent folder.

TIS21-SHED