### PR TITLE
Feat/display when coj can be signed

### DIFF
--- a/components/common/PanelsCreator.tsx
+++ b/components/common/PanelsCreator.tsx
@@ -11,7 +11,7 @@ import { DateUtilities } from "../../utilities/DateUtilities";
 import { StringUtilities } from "../../utilities/StringUtilities";
 import style from "../Common.module.scss";
 import { DspIssueBtn } from "../dsp/DspIssueBtn";
-import { ConditionsOfJoiningField } from "../programmes/ConditionsOfJoining";
+import { ConditionsOfJoining } from "../programmes/ConditionsOfJoining";
 import { Curricula } from "../programmes/Curricula";
 
 type PanelsCreatorProps = {
@@ -51,7 +51,7 @@ export function PanelsCreator({
                             curricula={filteredPanel[panelProp] as Curriculum[]}
                           />
                         ) : panelProp === "conditionsOfJoining" ? (
-                          <ConditionsOfJoiningField
+                          <ConditionsOfJoining
                             conditionsOfJoining={filteredPanel[panelProp]}
                             startDate={filteredPanel["startDate"]}
                           />

--- a/components/programmes/ConditionsOfJoining.tsx
+++ b/components/programmes/ConditionsOfJoining.tsx
@@ -1,3 +1,4 @@
+import { Button } from "nhsuk-react-components";
 import { ConditionsOfJoining } from "../../models/ProgrammeMembership";
 import { getStatusText, getVersionText } from "../../utilities/CojUtilities";
 import { DateUtilities } from "../../utilities/DateUtilities";
@@ -11,6 +12,8 @@ export function ConditionsOfJoiningField({
   conditionsOfJoining,
   startDate
 }: ConditionsOfJoiningProps) {
+  const statusText = getStatusText(startDate);
+
   return (
     <>
       {conditionsOfJoining.signedAt ? (
@@ -34,8 +37,27 @@ export function ConditionsOfJoiningField({
           </div>
         </dl>
       ) : (
-        <div>{getStatusText(startDate)}</div>
+        <div>{statusText}</div>
       )}
+      {statusText === "Not signed" ? (
+        <>
+          <Button onClick={() => {}} data-cy="goToCojBtn">
+            Sign Condition of Joining Form
+          </Button>
+        </>
+      ) : statusText.includes("Signed on") ? (
+        <>
+          {
+            <a
+              href="FutureLinkToCoJform"
+              onClick={() => {}}
+              data-cy="goToCojBtn"
+            >
+              View Signed Form
+            </a>
+          }
+        </>
+      ) : null}
     </>
   );
 }

--- a/components/programmes/ConditionsOfJoining.tsx
+++ b/components/programmes/ConditionsOfJoining.tsx
@@ -40,14 +40,14 @@ export function ConditionsOfJoining({
             className="nhsuk-summary-list__actions"
             style={{ borderBottom: 0 }}
           >
-            <a
-              href="#"
+            <button
+              className="nhsuk-button nhsuk-button--secondary"
               onClick={() =>
                 alert("We're still working on this feature, check back later.")
               }
             >
               Sign
-            </a>
+            </button>
           </dd>
         ) : null}
       </div>

--- a/components/programmes/ConditionsOfJoining.tsx
+++ b/components/programmes/ConditionsOfJoining.tsx
@@ -1,6 +1,6 @@
 import { Button } from "nhsuk-react-components";
 import { ConditionsOfJoining } from "../../models/ProgrammeMembership";
-import { getStatusText, getVersionText } from "../../utilities/CojUtilities";
+import { CojUtilities } from "../../utilities/CojUtilities";
 import { DateUtilities } from "../../utilities/DateUtilities";
 
 type ConditionsOfJoiningProps = {
@@ -12,7 +12,7 @@ export function ConditionsOfJoiningField({
   conditionsOfJoining,
   startDate
 }: ConditionsOfJoiningProps) {
-  const statusText = getStatusText(startDate);
+  const statusText = CojUtilities.getStatusText(startDate);
 
   return (
     <>
@@ -32,7 +32,7 @@ export function ConditionsOfJoiningField({
               className="nhsuk-summary-list__value"
               style={{ borderBottom: 0 }}
             >
-              {getVersionText(conditionsOfJoining.version)}
+              {CojUtilities.getVersionText(conditionsOfJoining.version)}
             </dd>
           </div>
         </dl>

--- a/components/programmes/ConditionsOfJoining.tsx
+++ b/components/programmes/ConditionsOfJoining.tsx
@@ -34,8 +34,7 @@ export function ConditionsOfJoining({
         <dd className="nhsuk-summary-list__value" style={{ borderBottom: 0 }}>
           {CojUtilities.getStatusText(startDate)}
         </dd>
-        {startDate &&
-        CojUtilities.canBeSigned(new Date(startDate as string)) ? (
+        {startDate && CojUtilities.canBeSigned(new Date(startDate)) ? (
           <dd
             className="nhsuk-summary-list__actions"
             style={{ borderBottom: 0 }}

--- a/components/programmes/ConditionsOfJoining.tsx
+++ b/components/programmes/ConditionsOfJoining.tsx
@@ -1,63 +1,56 @@
-import { Button } from "nhsuk-react-components";
-import { ConditionsOfJoining } from "../../models/ProgrammeMembership";
+import { ConditionsOfJoining as ConditionsOfJoiningModel } from "../../models/ProgrammeMembership";
 import { CojUtilities } from "../../utilities/CojUtilities";
 import { DateUtilities } from "../../utilities/DateUtilities";
 
 type ConditionsOfJoiningProps = {
-  conditionsOfJoining: ConditionsOfJoining;
+  conditionsOfJoining: ConditionsOfJoiningModel;
   startDate: string | null;
 };
 
-export function ConditionsOfJoiningField({
+export function ConditionsOfJoining({
   conditionsOfJoining,
   startDate
 }: ConditionsOfJoiningProps) {
-  const statusText = CojUtilities.getStatusText(startDate);
-
-  return (
-    <>
-      {conditionsOfJoining.signedAt ? (
-        <dl className="nhsuk-summary-list">
-          <div className="nhsuk-summary-list__row">
-            <dt className="nhsuk-summary-list__key">Signed</dt>
-            <dd className="nhsuk-summary-list__value">
-              {DateUtilities.ToLocalDate(conditionsOfJoining.signedAt)}
-            </dd>
-          </div>
-          <div className="nhsuk-summary-list__row">
-            <dt className="nhsuk-summary-list__key" style={{ borderBottom: 0 }}>
-              Version
-            </dt>
-            <dd
-              className="nhsuk-summary-list__value"
-              style={{ borderBottom: 0 }}
-            >
-              {CojUtilities.getVersionText(conditionsOfJoining.version)}
-            </dd>
-          </div>
-        </dl>
-      ) : (
-        <div>{statusText}</div>
-      )}
-      {statusText === "Not signed" ? (
-        <>
-          <Button onClick={() => {}} data-cy="goToCojBtn">
-            Sign Condition of Joining Form
-          </Button>
-        </>
-      ) : statusText.includes("Signed on") ? (
-        <>
-          {
+  return conditionsOfJoining.signedAt ? (
+    <dl className="nhsuk-summary-list">
+      <div className="nhsuk-summary-list__row">
+        <dt className="nhsuk-summary-list__key">Signed</dt>
+        <dd className="nhsuk-summary-list__value">
+          {DateUtilities.ToLocalDate(conditionsOfJoining.signedAt)}
+        </dd>
+      </div>
+      <div className="nhsuk-summary-list__row">
+        <dt className="nhsuk-summary-list__key" style={{ borderBottom: 0 }}>
+          Version
+        </dt>
+        <dd className="nhsuk-summary-list__value" style={{ borderBottom: 0 }}>
+          {CojUtilities.getVersionText(conditionsOfJoining.version)}
+        </dd>
+      </div>
+    </dl>
+  ) : (
+    <dl className="nhsuk-summary-list">
+      <div className="nhsuk-summary-list__row">
+        <dd className="nhsuk-summary-list__value" style={{ borderBottom: 0 }}>
+          {CojUtilities.getStatusText(startDate)}
+        </dd>
+        {startDate &&
+        CojUtilities.canBeSigned(new Date(startDate as string)) ? (
+          <dd
+            className="nhsuk-summary-list__actions"
+            style={{ borderBottom: 0 }}
+          >
             <a
-              href="FutureLinkToCoJform"
-              onClick={() => {}}
-              data-cy="goToCojBtn"
+              href="#"
+              onClick={() =>
+                alert("We're still working on this feature, check back later.")
+              }
             >
-              View Signed Form
+              Sign
             </a>
-          }
-        </>
-      ) : null}
-    </>
+          </dd>
+        ) : null}
+      </div>
+    </dl>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^4.2.1",

--- a/services/TraineeProfileService.ts
+++ b/services/TraineeProfileService.ts
@@ -1,6 +1,7 @@
 import { AxiosResponse } from "axios";
 import ApiService from "./apiService";
 import { TraineeProfile } from "../models/TraineeProfile";
+import { ProgrammeMembership } from "../models/ProgrammeMembership";
 
 export class TraineeProfileService extends ApiService {
   constructor() {
@@ -9,5 +10,11 @@ export class TraineeProfileService extends ApiService {
 
   async getTraineeProfile(): Promise<AxiosResponse<TraineeProfile>> {
     return this.get<TraineeProfile>("/profile");
+  }
+
+  async signCoj(
+    programmeMembershipId : string
+  ): Promise<AxiosResponse<ProgrammeMembership>> {
+    return this.post<ProgrammeMembership>(`/programme-membership/${programmeMembershipId}/sign-coj`, null);
   }
 }

--- a/utilities/CojUtilities.ts
+++ b/utilities/CojUtilities.ts
@@ -1,16 +1,36 @@
 import { COJ_EPOCH, GOLD_GUIDE_VERSION_REGEX } from "./Constants";
 
+export const SIGNABLE_OFFSET = 13 * 7 * 24 * 60 * 60 * 1000; // 13 weeks.
+
 export function getStatusText(startDate: string | null) {
   if (!startDate) {
     return "Unknown status";
   }
 
-  return new Date(startDate) < COJ_EPOCH
-    ? "Submitted directly to Local Office"
-    : "Not signed";
+  if (new Date(startDate) < COJ_EPOCH) {
+    return "Submitted directly to Local Office";
+  } else {
+    if (canBeSigned(new Date(startDate))) {
+      return "Not signed";
+    } else {
+      return `Not signed, available from ${getSignableFromDate(
+        new Date(startDate)
+      ).toLocaleDateString()}`;
+    }
+  }
 }
 
 export function getVersionText(version: string) {
   const matcher = GOLD_GUIDE_VERSION_REGEX.exec(version);
   return matcher && matcher[1] ? "Gold Guide " + matcher[1] : "Unknown";
+}
+
+function canBeSigned(startDate: Date): boolean {
+  const now = new Date();
+  const signableFrom = getSignableFromDate(startDate);
+  return now >= signableFrom;
+}
+
+function getSignableFromDate(startDate: Date): Date {
+  return new Date(startDate.getTime() - SIGNABLE_OFFSET);
 }

--- a/utilities/CojUtilities.ts
+++ b/utilities/CojUtilities.ts
@@ -27,10 +27,10 @@ export class CojUtilities {
     return matcher && matcher[1] ? `Gold Guide ${matcher[1]}` : "Unknown";
   }
 
-  private static canBeSigned(startDate: Date): boolean {
+  public static canBeSigned(startDate: Date): boolean {
     const now = new Date();
     const signableFrom = CojUtilities.getSignableFromDate(startDate);
-    return now >= signableFrom;
+    return now >= signableFrom && startDate >= COJ_EPOCH;
   }
 
   private static getSignableFromDate(startDate: Date): Date {

--- a/utilities/CojUtilities.ts
+++ b/utilities/CojUtilities.ts
@@ -1,36 +1,39 @@
+import day from "dayjs";
 import { COJ_EPOCH, GOLD_GUIDE_VERSION_REGEX } from "./Constants";
+import { DateUtilities } from "./DateUtilities";
 
-export const SIGNABLE_OFFSET = 13 * 7 * 24 * 60 * 60 * 1000; // 13 weeks.
-
-export function getStatusText(startDate: string | null) {
-  if (!startDate) {
-    return "Unknown status";
-  }
-
-  if (new Date(startDate) < COJ_EPOCH) {
-    return "Submitted directly to Local Office";
-  } else {
-    if (canBeSigned(new Date(startDate))) {
-      return "Not signed";
-    } else {
-      return `Not signed, available from ${getSignableFromDate(
-        new Date(startDate)
-      ).toLocaleDateString()}`;
+export class CojUtilities {
+  public static getStatusText(startDate: string | null) {
+    if (!startDate) {
+      return "Unknown status";
     }
+
+    if (new Date(startDate) < COJ_EPOCH) {
+      return "Submitted directly to Local Office";
+    }
+
+    if (CojUtilities.canBeSigned(new Date(startDate))) {
+      return "Not signed";
+    }
+
+    const signableDate = DateUtilities.ToLocalDate(
+      CojUtilities.getSignableFromDate(new Date(startDate))
+    );
+    return `Not signed, available from ${signableDate}`;
   }
-}
 
-export function getVersionText(version: string) {
-  const matcher = GOLD_GUIDE_VERSION_REGEX.exec(version);
-  return matcher && matcher[1] ? "Gold Guide " + matcher[1] : "Unknown";
-}
+  public static getVersionText(version: string) {
+    const matcher = GOLD_GUIDE_VERSION_REGEX.exec(version);
+    return matcher && matcher[1] ? `Gold Guide ${matcher[1]}` : "Unknown";
+  }
 
-function canBeSigned(startDate: Date): boolean {
-  const now = new Date();
-  const signableFrom = getSignableFromDate(startDate);
-  return now >= signableFrom;
-}
+  private static canBeSigned(startDate: Date): boolean {
+    const now = new Date();
+    const signableFrom = CojUtilities.getSignableFromDate(startDate);
+    return now >= signableFrom;
+  }
 
-function getSignableFromDate(startDate: Date): Date {
-  return new Date(startDate.getTime() - SIGNABLE_OFFSET);
+  private static getSignableFromDate(startDate: Date): Date {
+    return day(startDate.getTime()).subtract(13, "week").toDate();
+  }
 }

--- a/utilities/DateUtilities.ts
+++ b/utilities/DateUtilities.ts
@@ -134,6 +134,7 @@ export class DateUtilities {
     return arr.sort((a, b) => DateUtilities.gSorter(a, b, prop, desc));
   }
 }
+
 export const isWithinRange = (
   date: DateType = null,
   range: number = 1,

--- a/utilities/DateUtilities.ts
+++ b/utilities/DateUtilities.ts
@@ -134,7 +134,6 @@ export class DateUtilities {
     return arr.sort((a, b) => DateUtilities.gSorter(a, b, prop, desc));
   }
 }
-
 export const isWithinRange = (
   date: DateType = null,
   range: number = 1,

--- a/utilities/__test__/CojUtilities.test.ts
+++ b/utilities/__test__/CojUtilities.test.ts
@@ -76,7 +76,7 @@ describe("CojUtilities", () => {
         startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
       );
 
-      jest.setSystemTime(new Date(signableDate));
+      jest.setSystemTime(signableDate);
 
       expect(CojUtilities.getStatusText(startDate.toISOString())).toEqual(
         "Not signed"
@@ -119,7 +119,7 @@ describe("CojUtilities", () => {
         startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
       );
 
-      jest.setSystemTime(new Date(signableDate.getTime()));
+      jest.setSystemTime(signableDate);
 
       expect(CojUtilities.canBeSigned(startDate)).toEqual(false);
     });
@@ -163,7 +163,7 @@ describe("CojUtilities", () => {
         startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
       );
 
-      jest.setSystemTime(new Date(signableDate.getTime()));
+      jest.setSystemTime(signableDate);
 
       expect(CojUtilities.canBeSigned(startDate)).toEqual(true);
     });
@@ -196,7 +196,7 @@ describe("CojUtilities", () => {
         startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
       );
 
-      jest.setSystemTime(new Date(signableDate.getTime()));
+      jest.setSystemTime(signableDate);
 
       expect(CojUtilities.canBeSigned(startDate)).toEqual(true);
     });

--- a/utilities/__test__/CojUtilities.test.ts
+++ b/utilities/__test__/CojUtilities.test.ts
@@ -1,36 +1,38 @@
-import {
-  SIGNABLE_OFFSET,
-  getStatusText,
-  getVersionText
-} from "../CojUtilities";
+import { CojUtilities } from "../CojUtilities";
 
 describe("CojUtilities", () => {
   describe("getStatusText", () => {
+    const SIGNING_WINDOW_OFFSET_IN_MS = 13 * 7 * 24 * 60 * 60 * 1000; // 13 weeks
+
     it("should return unknown when start date is null", () => {
-      expect(getStatusText(null)).toEqual("Unknown status");
+      expect(CojUtilities.getStatusText(null)).toEqual("Unknown status");
     });
 
     it("should return submitted to LO when start date before coj epoch", () => {
       const minDate = new Date(-8640000000000000).toISOString();
-      expect(getStatusText(minDate)).toEqual(
+      expect(CojUtilities.getStatusText(minDate)).toEqual(
         "Submitted directly to Local Office"
       );
     });
 
     it("should return Not signed, available from 02/05/2023 when start date equal to coj epoch and earlier than 13 weeks", () => {
       const maxDate = new Date("2023-10-31");
-      const expectedDate = new Date(maxDate.getTime() - SIGNABLE_OFFSET);
+      const expectedDate = new Date(
+        maxDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
+      );
 
-      expect(getStatusText(maxDate.toISOString())).toEqual(
+      expect(CojUtilities.getStatusText(maxDate.toISOString())).toEqual(
         "Not signed, available from " + expectedDate.toLocaleDateString()
       );
     });
 
     it("should return not signed when start date after coj epoch", () => {
       const maxDate = new Date(8640000000000000);
-      const expectedDate = new Date(maxDate.getTime() - SIGNABLE_OFFSET);
+      const expectedDate = new Date(
+        maxDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
+      );
 
-      expect(getStatusText(maxDate.toISOString())).toEqual(
+      expect(CojUtilities.getStatusText(maxDate.toISOString())).toEqual(
         "Not signed, available from " + expectedDate.toLocaleDateString()
       );
     });
@@ -38,29 +40,29 @@ describe("CojUtilities", () => {
 
   describe("getVersionText", () => {
     it("should return formatted Gold Guide version when GGx format", () => {
-      expect(getVersionText("GG0")).toEqual("Gold Guide 0");
-      expect(getVersionText("GG1")).toEqual("Gold Guide 1");
-      expect(getVersionText("GG2")).toEqual("Gold Guide 2");
-      expect(getVersionText("GG3")).toEqual("Gold Guide 3");
-      expect(getVersionText("GG4")).toEqual("Gold Guide 4");
-      expect(getVersionText("GG5")).toEqual("Gold Guide 5");
-      expect(getVersionText("GG6")).toEqual("Gold Guide 6");
-      expect(getVersionText("GG7")).toEqual("Gold Guide 7");
-      expect(getVersionText("GG8")).toEqual("Gold Guide 8");
-      expect(getVersionText("GG9")).toEqual("Gold Guide 9");
+      expect(CojUtilities.getVersionText("GG0")).toEqual("Gold Guide 0");
+      expect(CojUtilities.getVersionText("GG1")).toEqual("Gold Guide 1");
+      expect(CojUtilities.getVersionText("GG2")).toEqual("Gold Guide 2");
+      expect(CojUtilities.getVersionText("GG3")).toEqual("Gold Guide 3");
+      expect(CojUtilities.getVersionText("GG4")).toEqual("Gold Guide 4");
+      expect(CojUtilities.getVersionText("GG5")).toEqual("Gold Guide 5");
+      expect(CojUtilities.getVersionText("GG6")).toEqual("Gold Guide 6");
+      expect(CojUtilities.getVersionText("GG7")).toEqual("Gold Guide 7");
+      expect(CojUtilities.getVersionText("GG8")).toEqual("Gold Guide 8");
+      expect(CojUtilities.getVersionText("GG9")).toEqual("Gold Guide 9");
     });
 
     it("should return formatted Gold Guide version when GGxx format", () => {
-      expect(getVersionText("GG12")).toEqual("Gold Guide 12");
+      expect(CojUtilities.getVersionText("GG12")).toEqual("Gold Guide 12");
     });
 
     it("should return unknown when incorrect format", () => {
-      expect(getVersionText("prefixGG1")).toEqual("Unknown");
-      expect(getVersionText("GG1suffix")).toEqual("Unknown");
-      expect(getVersionText("prefixGG1suffix")).toEqual("Unknown");
-      expect(getVersionText("GG")).toEqual("Unknown");
-      expect(getVersionText("abc")).toEqual("Unknown");
-      expect(getVersionText("123")).toEqual("Unknown");
+      expect(CojUtilities.getVersionText("prefixGG1")).toEqual("Unknown");
+      expect(CojUtilities.getVersionText("GG1suffix")).toEqual("Unknown");
+      expect(CojUtilities.getVersionText("prefixGG1suffix")).toEqual("Unknown");
+      expect(CojUtilities.getVersionText("GG")).toEqual("Unknown");
+      expect(CojUtilities.getVersionText("abc")).toEqual("Unknown");
+      expect(CojUtilities.getVersionText("123")).toEqual("Unknown");
     });
   });
 });

--- a/utilities/__test__/CojUtilities.test.ts
+++ b/utilities/__test__/CojUtilities.test.ts
@@ -1,4 +1,8 @@
-import { getStatusText, getVersionText } from "../CojUtilities";
+import {
+  SIGNABLE_OFFSET,
+  getStatusText,
+  getVersionText
+} from "../CojUtilities";
 
 describe("CojUtilities", () => {
   describe("getStatusText", () => {
@@ -13,13 +17,22 @@ describe("CojUtilities", () => {
       );
     });
 
-    it("should return not signed when start date equal to coj epoch", () => {
-      expect(getStatusText("2023-08-01")).toEqual("Not signed");
+    it("should return Not signed, available from 02/05/2023 when start date equal to coj epoch and earlier than 13 weeks", () => {
+      const maxDate = new Date("2023-10-31");
+      const expectedDate = new Date(maxDate.getTime() - SIGNABLE_OFFSET);
+
+      expect(getStatusText(maxDate.toISOString())).toEqual(
+        "Not signed, available from " + expectedDate.toLocaleDateString()
+      );
     });
 
     it("should return not signed when start date after coj epoch", () => {
-      const maxDate = new Date(8640000000000000).toISOString();
-      expect(getStatusText(maxDate)).toEqual("Not signed");
+      const maxDate = new Date(8640000000000000);
+      const expectedDate = new Date(maxDate.getTime() - SIGNABLE_OFFSET);
+
+      expect(getStatusText(maxDate.toISOString())).toEqual(
+        "Not signed, available from " + expectedDate.toLocaleDateString()
+      );
     });
   });
 

--- a/utilities/__test__/CojUtilities.test.ts
+++ b/utilities/__test__/CojUtilities.test.ts
@@ -1,4 +1,5 @@
 import { CojUtilities } from "../CojUtilities";
+import { DateUtilities } from "../DateUtilities";
 
 describe("CojUtilities", () => {
   const SIGNING_WINDOW_OFFSET_IN_MS = 13 * 7 * 24 * 60 * 60 * 1000; // 13 weeks
@@ -36,8 +37,9 @@ describe("CojUtilities", () => {
 
       jest.setSystemTime(new Date(signableDate.getTime() - DAY_IN_MS));
 
+      const availableDate = DateUtilities.ToLocalDate(signableDate);
       expect(CojUtilities.getStatusText(startDate.toISOString())).toEqual(
-        `Not signed, available from ${signableDate.toLocaleDateString()}`
+        `Not signed, available from ${availableDate}`
       );
     });
 
@@ -49,8 +51,9 @@ describe("CojUtilities", () => {
 
       jest.setSystemTime(new Date(signableDate.getTime() - DAY_IN_MS));
 
+      const availableDate = DateUtilities.ToLocalDate(signableDate);
       expect(CojUtilities.getStatusText(startDate.toISOString())).toEqual(
-        `Not signed, available from ${signableDate.toLocaleDateString()}`
+        `Not signed, available from ${availableDate}`
       );
     });
 

--- a/utilities/__test__/CojUtilities.test.ts
+++ b/utilities/__test__/CojUtilities.test.ts
@@ -1,22 +1,22 @@
 import { CojUtilities } from "../CojUtilities";
 
 describe("CojUtilities", () => {
+  const SIGNING_WINDOW_OFFSET_IN_MS = 13 * 7 * 24 * 60 * 60 * 1000; // 13 weeks
+  const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+  const COJ_EPOCH = "2023-08-01";
+  const PRE_COJ_EPOCH = "2023-07-31";
+  const POST_COJ_EPOCH = "2023-08-02";
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   describe("getStatusText", () => {
-    const SIGNING_WINDOW_OFFSET_IN_MS = 13 * 7 * 24 * 60 * 60 * 1000; // 13 weeks
-    const DAY_IN_MS = 24 * 60 * 60 * 1000;
-
-    const COJ_EPOCH = "2023-08-01";
-    const PRE_COJ_EPOCH = "2023-07-31";
-    const POST_COJ_EPOCH = "2023-08-02";
-
-    beforeAll(() => {
-      jest.useFakeTimers();
-    });
-
-    afterAll(() => {
-      jest.useRealTimers();
-    });
-
     it("should return unknown when start date is null", () => {
       expect(CojUtilities.getStatusText(null)).toEqual("Unknown status");
     });
@@ -106,6 +106,107 @@ describe("CojUtilities", () => {
       expect(CojUtilities.getVersionText("GG")).toEqual("Unknown");
       expect(CojUtilities.getVersionText("abc")).toEqual("Unknown");
       expect(CojUtilities.getVersionText("123")).toEqual("Unknown");
+    });
+  });
+
+  describe("canBeSigned", () => {
+    it("should return false when start date before coj epoch and currently before signing window", () => {
+      const startDate = new Date(PRE_COJ_EPOCH);
+      const signableDate = new Date(
+        startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
+      );
+
+      jest.setSystemTime(new Date(signableDate.getTime()));
+
+      expect(CojUtilities.canBeSigned(startDate)).toEqual(false);
+    });
+
+    it("should return false when start date before coj epoch and currently equal to signing window", () => {
+      const startDate = new Date(PRE_COJ_EPOCH);
+      const signableDate = new Date(
+        startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
+      );
+
+      jest.setSystemTime(new Date(signableDate.getTime() - DAY_IN_MS));
+
+      expect(CojUtilities.canBeSigned(startDate)).toEqual(false);
+    });
+
+    it("should return false when start date before coj epoch and currently after signing window", () => {
+      const startDate = new Date(PRE_COJ_EPOCH);
+      const signableDate = new Date(
+        startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
+      );
+
+      jest.setSystemTime(new Date(signableDate.getTime() + DAY_IN_MS));
+
+      expect(CojUtilities.canBeSigned(startDate)).toEqual(false);
+    });
+
+    it("should return false when start date equal to coj epoch and currently before signing window", () => {
+      const startDate = new Date(COJ_EPOCH);
+      const signableDate = new Date(
+        startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
+      );
+
+      jest.setSystemTime(new Date(signableDate.getTime() - DAY_IN_MS));
+
+      expect(CojUtilities.canBeSigned(startDate)).toEqual(false);
+    });
+
+    it("should return false when start date equal to coj epoch and currently equal to signing window", () => {
+      const startDate = new Date(COJ_EPOCH);
+      const signableDate = new Date(
+        startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
+      );
+
+      jest.setSystemTime(new Date(signableDate.getTime()));
+
+      expect(CojUtilities.canBeSigned(startDate)).toEqual(true);
+    });
+
+    it("should return false when start date equal to coj epoch and currently after signing window", () => {
+      const startDate = new Date(COJ_EPOCH);
+      const signableDate = new Date(
+        startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
+      );
+
+      jest.setSystemTime(new Date(signableDate.getTime() + DAY_IN_MS));
+
+      expect(CojUtilities.canBeSigned(startDate)).toEqual(true);
+    });
+
+    it("should return false when start date after coj epoch and currently before signing window", () => {
+      const startDate = new Date(POST_COJ_EPOCH);
+      const signableDate = new Date(
+        startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
+      );
+
+      jest.setSystemTime(new Date(signableDate.getTime() - DAY_IN_MS));
+
+      expect(CojUtilities.canBeSigned(startDate)).toEqual(false);
+    });
+
+    it("should true false when start date after coj epoch and currently equal to signing window", () => {
+      const startDate = new Date(POST_COJ_EPOCH);
+      const signableDate = new Date(
+        startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
+      );
+
+      jest.setSystemTime(new Date(signableDate.getTime()));
+
+      expect(CojUtilities.canBeSigned(startDate)).toEqual(true);
+    });
+
+    it("should true false when start date after coj epoch and currently after signing window", () => {
+      const startDate = new Date(POST_COJ_EPOCH);
+      const signableDate = new Date(
+        startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
+      );
+
+      jest.setSystemTime(new Date(signableDate.getTime() + DAY_IN_MS));
+
+      expect(CojUtilities.canBeSigned(startDate)).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
Display a link to sign the COJ when the start date meets the below criteria, this is a refactor (plus fixes) of #843 but the branch history was a bit messy so I've squashed and cleaned up to avoid having too many individual commits which fail checks/tests. As of the time this PR was raised, all comments on #843 have been accounted for.

Criteria
 - Start date after the "COJ epoch" (currently 2023-08-01)
 - Current date within 13 weeks of the start date
 - The COJ has not already been signed