### PR TITLE
fix: signCoj service function passing null body

### DIFF
--- a/services/TraineeProfileService.ts
+++ b/services/TraineeProfileService.ts
@@ -13,8 +13,10 @@ export class TraineeProfileService extends ApiService {
   }
 
   async signCoj(
-    programmeMembershipId : string
+    programmeMembershipId: string
   ): Promise<AxiosResponse<ProgrammeMembership>> {
-    return this.post<ProgrammeMembership>(`/programme-membership/${programmeMembershipId}/sign-coj`, null);
+    return this.post<ProgrammeMembership>(
+      `/programme-membership/${programmeMembershipId}/sign-coj`
+    );
   }
 }

--- a/services/__test__/TraineeProfileService.test.ts
+++ b/services/__test__/TraineeProfileService.test.ts
@@ -1,8 +1,12 @@
 import { AxiosResponse } from "axios";
 import { TraineeProfileService } from "../TraineeProfileService";
-import { mockTraineeProfile } from "../../mock-data/trainee-profile";
+import {
+  mockProgrammeMemberships,
+  mockTraineeProfile
+} from "../../mock-data/trainee-profile";
 import { errorResponse } from "../../mock-data/service-api-err-res";
 import { TraineeProfile } from "../../models/TraineeProfile";
+import { ProgrammeMembership } from "../../models/ProgrammeMembership";
 
 const mockService = new TraineeProfileService();
 describe("TraineeProfileService", () => {
@@ -25,6 +29,29 @@ describe("TraineeProfileService", () => {
     jest.spyOn(mockService, "get").mockRejectedValue(errorResponse);
 
     mockService.getTraineeProfile().catch(res => {
+      expect(res).toEqual(errorResponse);
+    });
+  });
+
+  it("signCoj method should return success response", () => {
+    const successResponse: Promise<AxiosResponse<ProgrammeMembership>> =
+      Promise.resolve({
+        data: mockProgrammeMemberships[0],
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {}
+      });
+
+    jest.spyOn(mockService, "post").mockReturnValue(successResponse);
+
+    expect(mockService.signCoj("1")).toEqual(successResponse);
+  });
+
+  it("signCoj method should return failure response", () => {
+    jest.spyOn(mockService, "post").mockRejectedValue(errorResponse);
+
+    mockService.signCoj("1").catch(res => {
       expect(res).toEqual(errorResponse);
     });
   });

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -38,7 +38,7 @@ export class ApiService {
 
   post<T = any>(
     endpoint: string,
-    formData: T,
+    formData?: T,
     params?: any
   ): Promise<AxiosResponse<T>> {
     return this.axiosInstance.post(endpoint, formData, params);

--- a/utilities/__test__/CojUtilities.test.ts
+++ b/utilities/__test__/CojUtilities.test.ts
@@ -190,7 +190,7 @@ describe("CojUtilities", () => {
       expect(CojUtilities.canBeSigned(startDate)).toEqual(false);
     });
 
-    it("should true false when start date after coj epoch and currently equal to signing window", () => {
+    it("should return true when start date after coj epoch and currently equal to signing window", () => {
       const startDate = new Date(POST_COJ_EPOCH);
       const signableDate = new Date(
         startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS
@@ -201,7 +201,7 @@ describe("CojUtilities", () => {
       expect(CojUtilities.canBeSigned(startDate)).toEqual(true);
     });
 
-    it("should true false when start date after coj epoch and currently after signing window", () => {
+    it("should return true when start date after coj epoch and currently after signing window", () => {
       const startDate = new Date(POST_COJ_EPOCH);
       const signableDate = new Date(
         startDate.getTime() - SIGNING_WINDOW_OFFSET_IN_MS


### PR DESCRIPTION
The `TraineeProfileService.signCoj()` function passes `null` for the POST request body, but that is not allowed.
Update the `ApiService` to allow the POST request form data to be optional.

TIS21-4389
TIS21-4374