### PR TITLE
fix: alerts object

### DIFF
--- a/components/main/GlobalAlert.tsx
+++ b/components/main/GlobalAlert.tsx
@@ -1,5 +1,5 @@
 import { NavLink, useLocation } from "react-router-dom";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import React from "react";
 import { useAppSelector } from "../../redux/hooks/hooks";
 
@@ -10,12 +10,15 @@ const GlobalAlert = () => {
   );
   const showCojAlert = hasSignableCoj && !currentPath.includes("/sign-coj");
 
-  const alerts = {
-    coj: {
-      status: showCojAlert,
-      component: <CojAlert />
-    }
-  };
+  const alerts = useMemo(
+    () => ({
+      coj: {
+        status: showCojAlert,
+        component: <CojAlert />
+      }
+    }),
+    [showCojAlert]
+  );
 
   const [hasAlerts, setHasAlerts] = useState(false);
   useEffect(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.63.1",
+  "version": "0.65.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.61.3",
+      "version": "0.65.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^4.2.1",
         "@cypress/code-coverage": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.65.0",
+  "version": "0.65.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^4.2.1",


### PR DESCRIPTION
Wrap the alerts object in a useMemo hook to prevent unnecessary re-renders. At the moment, it makes the dependencies of the useEffect change on every render - which is not good for performance. It will now only be re-evaluated when the showCojAlert value changes.

JFDI