### PR TITLE
refactor: style COJ actions as links

### DIFF
--- a/components/programmes/ConditionsOfJoining.tsx
+++ b/components/programmes/ConditionsOfJoining.tsx
@@ -1,4 +1,5 @@
-import { Button, SummaryList } from "nhsuk-react-components";
+import { SummaryList } from "nhsuk-react-components";
+import { Link } from "react-router-dom";
 import { ConditionsOfJoining as ConditionsOfJoiningModel } from "../../models/ProgrammeMembership";
 import {
   updatedsigningCoj,
@@ -8,7 +9,6 @@ import {
 import store from "../../redux/store/store";
 import { CojUtilities } from "../../utilities/CojUtilities";
 import { DateUtilities } from "../../utilities/DateUtilities";
-import history from "../navigation/history";
 
 type ConditionsOfJoiningProps = {
   conditionsOfJoining: ConditionsOfJoiningModel;
@@ -42,13 +42,13 @@ export function ConditionsOfJoining({
       </SummaryList.Row>
       <SummaryList.Row>
         <SummaryList.Actions style={{ borderBottom: 0 }}>
-          <Button
-            secondary
-            onClick={() => viewCoj(programmeMembershipId, programmeName)}
+          <Link
+            to={`/programmes/${programmeMembershipId}/sign-coj`}
+            onClick={() => setCojState(programmeMembershipId, programmeName)}
             data-cy={`cojViewBtn-${programmeMembershipId}`}
           >
             View
-          </Button>
+          </Link>
         </SummaryList.Actions>
       </SummaryList.Row>
     </SummaryList>
@@ -60,13 +60,13 @@ export function ConditionsOfJoining({
         </SummaryList.Value>
         {startDate && CojUtilities.canBeSigned(new Date(startDate)) ? (
           <SummaryList.Actions style={{ borderBottom: 0 }}>
-            <Button
-              secondary
-              onClick={() => viewCoj(programmeMembershipId, programmeName)}
+            <Link
+              to={`/programmes/${programmeMembershipId}/sign-coj`}
+              onClick={() => setCojState(programmeMembershipId, programmeName)}
               data-cy={`cojSignBtn-${programmeMembershipId}`}
             >
               Sign
-            </Button>
+            </Link>
           </SummaryList.Actions>
         ) : null}
       </SummaryList.Row>
@@ -74,9 +74,8 @@ export function ConditionsOfJoining({
   );
 }
 
-function viewCoj(programmeMembershipId: string, programmeName: string) {
+function setCojState(programmeMembershipId: string, programmeName: string) {
   store.dispatch(updatedsigningCojProgName(programmeName));
   store.dispatch(updatedsigningCojPmId(programmeMembershipId));
   store.dispatch(updatedsigningCoj(true));
-  history.push(`/programmes/${programmeMembershipId}/sign-coj`);
 }

--- a/cypress/component/programmes/ConditionsOfJoining.cy.tsx
+++ b/cypress/component/programmes/ConditionsOfJoining.cy.tsx
@@ -4,6 +4,7 @@ import { COJ_EPOCH } from "../../../utilities/Constants";
 import { ConditionsOfJoining } from "../../../components/programmes/ConditionsOfJoining";
 import { ConditionsOfJoining as ConditionsOfJoiningModel } from "../../../models/ProgrammeMembership";
 import { DateUtilities } from "../../../utilities/DateUtilities";
+import { BrowserRouter } from "react-router-dom";
 
 describe("ConditionsOfJoining", () => {
   beforeEach(() => {
@@ -18,12 +19,14 @@ describe("ConditionsOfJoining", () => {
 
     it("should display signed COJ fields", () => {
       mount(
-        <ConditionsOfJoining
-          conditionsOfJoining={conditionsOfJoining}
-          startDate={COJ_EPOCH.toISOString()}
-          programmeMembershipId={""}
-          programmeName={""}
-        />
+        <BrowserRouter>
+          <ConditionsOfJoining
+            conditionsOfJoining={conditionsOfJoining}
+            startDate={COJ_EPOCH.toISOString()}
+            programmeMembershipId={""}
+            programmeName={""}
+          />
+        </BrowserRouter>
       );
 
       cy.get("[data-cy=signedCoj]").should("exist");
@@ -31,12 +34,14 @@ describe("ConditionsOfJoining", () => {
 
     it("should not display unsigned COJ fields", () => {
       mount(
-        <ConditionsOfJoining
-          conditionsOfJoining={conditionsOfJoining}
-          startDate={COJ_EPOCH.toISOString()}
-          programmeMembershipId={""}
-          programmeName={""}
-        />
+        <BrowserRouter>
+          <ConditionsOfJoining
+            conditionsOfJoining={conditionsOfJoining}
+            startDate={COJ_EPOCH.toISOString()}
+            programmeMembershipId={""}
+            programmeName={""}
+          />
+        </BrowserRouter>
       );
 
       cy.get("[data-cy=unsignedCoj]").should("not.exist");
@@ -44,12 +49,14 @@ describe("ConditionsOfJoining", () => {
 
     it("should display signed date", () => {
       mount(
-        <ConditionsOfJoining
-          conditionsOfJoining={conditionsOfJoining}
-          startDate={COJ_EPOCH.toISOString()}
-          programmeMembershipId={""}
-          programmeName={""}
-        />
+        <BrowserRouter>
+          <ConditionsOfJoining
+            conditionsOfJoining={conditionsOfJoining}
+            startDate={COJ_EPOCH.toISOString()}
+            programmeMembershipId={""}
+            programmeName={""}
+          />
+        </BrowserRouter>
       );
 
       cy.get("[data-cy=cojSignedDate]")
@@ -59,12 +66,14 @@ describe("ConditionsOfJoining", () => {
 
     it("should display signed gold guide version when GGxx format", () => {
       mount(
-        <ConditionsOfJoining
-          conditionsOfJoining={conditionsOfJoining}
-          startDate={COJ_EPOCH.toISOString()}
-          programmeMembershipId={""}
-          programmeName={""}
-        />
+        <BrowserRouter>
+          <ConditionsOfJoining
+            conditionsOfJoining={conditionsOfJoining}
+            startDate={COJ_EPOCH.toISOString()}
+            programmeMembershipId={""}
+            programmeName={""}
+          />
+        </BrowserRouter>
       );
 
       cy.get("[data-cy=cojSignedVersion]")
@@ -74,12 +83,14 @@ describe("ConditionsOfJoining", () => {
 
     it("should display unknown version when not GGxx format", () => {
       mount(
-        <ConditionsOfJoining
-          conditionsOfJoining={{ ...conditionsOfJoining, version: "v123" }}
-          startDate={COJ_EPOCH.toISOString()}
-          programmeMembershipId={""}
-          programmeName={""}
-        />
+        <BrowserRouter>
+          <ConditionsOfJoining
+            conditionsOfJoining={{ ...conditionsOfJoining, version: "v123" }}
+            startDate={COJ_EPOCH.toISOString()}
+            programmeMembershipId={""}
+            programmeName={""}
+          />
+        </BrowserRouter>
       );
 
       cy.get("[data-cy=cojSignedVersion]")
@@ -96,12 +107,14 @@ describe("ConditionsOfJoining", () => {
 
     it("should display unsigned COJ fields", () => {
       mount(
-        <ConditionsOfJoining
-          conditionsOfJoining={conditionsOfJoining}
-          startDate={COJ_EPOCH.toISOString()}
-          programmeMembershipId={""}
-          programmeName={""}
-        />
+        <BrowserRouter>
+          <ConditionsOfJoining
+            conditionsOfJoining={conditionsOfJoining}
+            startDate={COJ_EPOCH.toISOString()}
+            programmeMembershipId={""}
+            programmeName={""}
+          />
+        </BrowserRouter>
       );
 
       cy.get("[data-cy=unsignedCoj]").should("exist");
@@ -109,12 +122,14 @@ describe("ConditionsOfJoining", () => {
 
     it("should not display signed COJ fields", () => {
       mount(
-        <ConditionsOfJoining
-          conditionsOfJoining={conditionsOfJoining}
-          startDate={COJ_EPOCH.toISOString()}
-          programmeMembershipId={""}
-          programmeName={""}
-        />
+        <BrowserRouter>
+          <ConditionsOfJoining
+            conditionsOfJoining={conditionsOfJoining}
+            startDate={COJ_EPOCH.toISOString()}
+            programmeMembershipId={""}
+            programmeName={""}
+          />
+        </BrowserRouter>
       );
 
       cy.get("[data-cy=signedCoj]").should("not.exist");
@@ -122,12 +137,14 @@ describe("ConditionsOfJoining", () => {
 
     it("should show unknown status when no start date", () => {
       mount(
-        <ConditionsOfJoining
-          conditionsOfJoining={conditionsOfJoining}
-          startDate={null}
-          programmeMembershipId={""}
-          programmeName={""}
-        />
+        <BrowserRouter>
+          <ConditionsOfJoining
+            conditionsOfJoining={conditionsOfJoining}
+            startDate={null}
+            programmeMembershipId={""}
+            programmeName={""}
+          />
+        </BrowserRouter>
       );
 
       cy.get("[data-cy=cojStatusText]")
@@ -137,14 +154,16 @@ describe("ConditionsOfJoining", () => {
 
     it("should show submitted to LO when start date before COJ epoch", () => {
       mount(
-        <ConditionsOfJoining
-          conditionsOfJoining={conditionsOfJoining}
-          startDate={new Date(
-            COJ_EPOCH.getTime() - 24 * 60 * 60 * 1000
-          ).toISOString()}
-          programmeMembershipId={""}
-          programmeName={""}
-        />
+        <BrowserRouter>
+          <ConditionsOfJoining
+            conditionsOfJoining={conditionsOfJoining}
+            startDate={new Date(
+              COJ_EPOCH.getTime() - 24 * 60 * 60 * 1000
+            ).toISOString()}
+            programmeMembershipId={""}
+            programmeName={""}
+          />
+        </BrowserRouter>
       );
 
       cy.get("[data-cy=cojStatusText]")
@@ -154,14 +173,16 @@ describe("ConditionsOfJoining", () => {
 
     it("should show available signing date when start date after COJ epoch but outside 13 weeks", () => {
       mount(
-        <ConditionsOfJoining
-          conditionsOfJoining={conditionsOfJoining}
-          startDate={new Date(
-            COJ_EPOCH.getTime() + 14 * 7 * 24 * 60 * 60 * 1000
-          ).toISOString()}
-          programmeMembershipId={""}
-          programmeName={""}
-        />
+        <BrowserRouter>
+          <ConditionsOfJoining
+            conditionsOfJoining={conditionsOfJoining}
+            startDate={new Date(
+              COJ_EPOCH.getTime() + 14 * 7 * 24 * 60 * 60 * 1000
+            ).toISOString()}
+            programmeMembershipId={""}
+            programmeName={""}
+          />
+        </BrowserRouter>
       );
 
       cy.get("[data-cy=cojStatusText]")
@@ -176,12 +197,14 @@ describe("ConditionsOfJoining", () => {
 
     it("should show not signed when start date after COJ epoch and inside 13 weeks", () => {
       mount(
-        <ConditionsOfJoining
-          conditionsOfJoining={conditionsOfJoining}
-          startDate={COJ_EPOCH.toISOString()}
-          programmeMembershipId={""}
-          programmeName={""}
-        />
+        <BrowserRouter>
+          <ConditionsOfJoining
+            conditionsOfJoining={conditionsOfJoining}
+            startDate={COJ_EPOCH.toISOString()}
+            programmeMembershipId={""}
+            programmeName={""}
+          />
+        </BrowserRouter>
       );
 
       cy.get("[data-cy=cojStatusText]")
@@ -191,12 +214,14 @@ describe("ConditionsOfJoining", () => {
 
     it("should allow signing when start date after COJ epoch and inside 13 weeks", () => {
       mount(
-        <ConditionsOfJoining
-          conditionsOfJoining={conditionsOfJoining}
-          startDate={COJ_EPOCH.toISOString()}
-          programmeMembershipId={"1"}
-          programmeName={"pmName"}
-        />
+        <BrowserRouter>
+          <ConditionsOfJoining
+            conditionsOfJoining={conditionsOfJoining}
+            startDate={COJ_EPOCH.toISOString()}
+            programmeMembershipId={"1"}
+            programmeName={"pmName"}
+          />
+        </BrowserRouter>
       );
 
       cy.get("[data-cy=cojSignBtn-1]").should("exist");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.65.4",
+  "version": "0.65.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.65.6",
+  "version": "0.65.7",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^4.2.1",


### PR DESCRIPTION
The COJ actions are currently a button, but should be styled as links instead.
Swap the `button` element for `Link`s and refactor the `viewCoj` function in to `setCojState` with the navigation done within the link itself.

Update the ConditionOfJoining component tests to wrap the component in a `BrowserRouter` so that the `Link`s can work during testing.

TIS21-4544
TIS21-4533