### PR TITLE
build: handle GHA deprecation

### DIFF
--- a/.github/workflows/pr-analysis.yml
+++ b/.github/workflows/pr-analysis.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get modified files
         id: changed-files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.2.0
 
       - name: Check modified files
         id: check-files


### PR DESCRIPTION
The `jitterbit/get-changed-files` action is outdated and no longer appears to be maintained. It will shortly stop working when Node 12 and `set-output` commands are deprecated.
Replace it with the `Ana06/get-changed-files` fork, which has resolved these issues.

TIS21-4561