### PR TITLE
fix: the form states

### DIFF
--- a/cypress/component/forms/formr-part-a/FormA.cy.tsx
+++ b/cypress/component/forms/formr-part-a/FormA.cy.tsx
@@ -100,13 +100,12 @@ describe("FormA (form creation)", () => {
       '[data-cy="immigrationStatus"] > .autocomplete-select > .react-select__control > .react-select__value-container > .react-select__input-container'
     )
       .click()
-      .type("ot")
+      .type("brit")
       .get(".react-select__menu")
       .find(".react-select__option")
       .first()
       .click();
-    cy.get(".react-select__value-container").contains("Other");
-    cy.get('[data-cy="otherImmigrationStatus-label"]').should("exist");
+    cy.get(".react-select__value-container").contains("British");
 
     // test datepicker
     cy.get('[data-cy="dateAttained-label"]').should("exist");

--- a/cypress/e2e/formr-a/FormRA.spec.ts
+++ b/cypress/e2e/formr-a/FormRA.spec.ts
@@ -55,25 +55,23 @@ describe("Name of the group", () => {
 
         // -- personal details section --
         // immigration status
-        const immigrationTxt = "Dependent - other immigration category";
+        const immigrationTxt = "Refugee in the UK";
         cy.get(
           '[data-cy="immigrationStatus"] > .autocomplete-select > .react-select__control > .react-select__value-container > .react-select__input-container'
         )
           .click()
-          .type("ot")
+          .type("ref")
           .get(".react-select__menu")
           .find(".react-select__option")
           .first()
           .click();
         cy.get('[data-cy="immigrationStatus"] ').contains(immigrationTxt);
-        cy.get('[data-cy="otherImmigrationStatus-label"]').should("exist");
 
         // Test the local storage is updated
         // put a wait here to give time for the local storage to update
         cy.wait(5000)
           .getLocalStorage("formA")
           .then(formA => {
-            console.log("formA", formA && JSON.parse(formA));
             const parsedForm = formA && JSON.parse(formA);
             const immigrationStatus = parsedForm.immigrationStatus;
             console.log("immigrationStatus", immigrationStatus);
@@ -201,11 +199,9 @@ describe("Name of the group", () => {
           .should("exist")
           .should("include.text", "Please think carefully before submitting");
         cy.get(".MuiDialogActions-root > :nth-child(2)").click();
-        cy.get('[data-cy="Submit new form"]').should("exist");
 
-        // wait for the forms plus new form to reload
-        cy.wait(5000);
         cy.contains("Submitted forms").should("exist");
+        cy.get('[data-cy="Submit new form"]').should("exist");
         cy.get("[data-cy=submittedForm]").first().click();
         cy.get('[data-cy="email-value"]').should(
           "have.text",

--- a/cypress/e2e/formr-b/FormRB.spec.ts
+++ b/cypress/e2e/formr-b/FormRB.spec.ts
@@ -33,7 +33,7 @@ describe("Form R (Part B)", () => {
     cy.get("[data-cy=BtnMenu]").should("exist").click();
     cy.contains("Form R (Part B)").click();
     cy.visit("/formr-b", { failOnStatusCode: false });
-    cy.get("[data-cy=btnLoadNewForm]").click();
+    cy.get('[data-cy="Submit new form"]').click();
     cy.get("body").then($body => {
       if ($body.find(".MuiDialog-container").length) {
         cy.get(".MuiDialogContentText-root").should(
@@ -52,7 +52,7 @@ describe("Form R (Part B)", () => {
     cy.contains("Support").click();
     cy.get("[data-cy=BtnMenu]").click();
     cy.contains("Form R (Part B)").click();
-    cy.get("[data-cy=btnLoadNewForm]").click();
+    cy.get('[data-cy="Submit new form"]').click();
     cy.get("body").then($body => {
       if ($body.find(".MuiDialog-container").length) {
         cy.get(".MuiDialogActions-root > :nth-child(2)").click();
@@ -328,7 +328,7 @@ describe("Form R (Part B)", () => {
     cy.get("[data-cy=BtnSaveDraft]").click();
 
     // -------------- Retrieve saved draft form ----------------------------------
-    cy.get("[data-cy=btnEditSavedForm]").should("exist").click();
+    cy.get('[data-cy="btn-Edit saved draft form"]').should("exist").click();
     cy.get(".nhsuk-warning-callout").should("exist");
     cy.get("[data-cy=gmcNumber]").should("exist");
 
@@ -354,7 +354,7 @@ describe("Form R (Part B)", () => {
       .should("include.text", "Please think carefully before submitting");
     cy.get(".MuiDialogActions-root > :nth-child(2)").click();
     cy.checkForSuccessNotif("Success");
-    cy.get("[data-cy=btnLoadNewForm]").should("exist");
+    cy.get('[data-cy="Submit new form"]').should("exist");
     cy.contains("Submitted forms").should("exist");
     cy.get("[data-cy=formsTrueHint]").should("exist");
     cy.log(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.68.0",
+  "version": "0.68.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^4.2.1",


### PR DESCRIPTION
The last merge did reset the JSON form fields to their defaults when navigating away from the form but had numerous unintended consequences 💥 . This commit fixes those issues and brings the formBuilder back to the state before the "fix". 

The Cypress tests have also been updated to:
1. remove the otherImmigrationStatus test from FormRA as the "other" immigration options are not on prod.
2. Update the formsList btn text in FormRB

TODO
1. Fix the bug (without breaking everything else) where fields made visible by a conditional are not reset when navigating away from the form.