### PR TITLE
fix: 2 formBuilder bugs

### DIFF
--- a/components/forms/FormsListBtn.tsx
+++ b/components/forms/FormsListBtn.tsx
@@ -17,7 +17,7 @@ import {
   resetLocalStorageFormData
 } from "../../utilities/FormBuilderUtilities";
 import { LifeCycleState } from "../../models/LifeCycleState";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 interface IFormsListBtn {
   draftFormProps: DraftFormProps | null;
   pathName: string;
@@ -33,10 +33,16 @@ const FormsListBtn = ({
   const dispatch = useAppDispatch();
   const traineeProfileData = useAppSelector(selectTraineeProfile);
   const formName: string = pathName === "/formr-a" ? "formA" : "formB";
-  const resetForm = (pName: string) =>
-    pName === "/formr-b"
-      ? dispatch(resetToInitFormB())
-      : dispatch(resetToInitFormA());
+  const resetForm = useCallback(
+    (pName: string) => {
+      if (pName === "/formr-b") {
+        dispatch(resetToInitFormB());
+      } else {
+        dispatch(resetToInitFormA());
+      }
+    },
+    [dispatch]
+  );
 
   useEffect(() => {
     resetLocalStorageFormData(formName);

--- a/cypress/e2e/formr-a/FormRA.spec.ts
+++ b/cypress/e2e/formr-a/FormRA.spec.ts
@@ -160,6 +160,15 @@ describe("Name of the group", () => {
           .find(".react-select__option")
           .first()
           .click();
+
+        cy.get(
+          '[data-cy="startDate"]> .react-datepicker-wrapper > .react-datepicker__input-container > .nhsuk-input'
+        )
+          .click()
+          .clear()
+          .type(startDate);
+
+        cy.get('[data-cy="programmeMembershipType-input"]').clear().type("LAT");
         cy.get('[data-cy="wholeTimeEquivalent-input"]').clear().type("1");
 
         cy.get('[data-cy="BtnContinue"]')
@@ -212,7 +221,7 @@ describe("Name of the group", () => {
         // Navigate back to the list
         cy.get(".nhsuk-back-link__link").should("exist").click();
         cy.contains("Submitted forms").should("exist");
-        cy.get('[data-cy="Submit new form"]').should("exist");
+        cy.get('[data-cy="Submit new form"]').should("exist").click();
       });
   });
 });

--- a/cypress/e2e/formr-a/FormRA.spec.ts
+++ b/cypress/e2e/formr-a/FormRA.spec.ts
@@ -15,7 +15,7 @@ const startDate = dayjs()
   .subtract(dayjs.duration({ months: 9, days: 30 }))
   .format("YYYY-MM-DD");
 
-describe("Name of the group", () => {
+describe("Form R Part A - Basic Form completion and submission", () => {
   before(() => {
     cy.wait(30000);
     cy.visit("/");
@@ -121,8 +121,9 @@ describe("Name of the group", () => {
           "Part 2 of 3 - Programme Declarations"
         );
         cy.get(
-          '[data-cy="declarationType-I will be seeking specialist registration by application for a CESR-input"]'
+          '[data-cy="declarationType-I have been appointed to a programme leading to award of CCT-input"]'
         ).click();
+
         cy.get(
           '[data-cy="programmeSpecialty"] > .autocomplete-select > .react-select__control > .react-select__value-container > .react-select__input-container'
         )
@@ -131,6 +132,15 @@ describe("Name of the group", () => {
           .find(".react-select__option")
           .first()
           .click();
+        cy.get(
+          '   [data-cy="cctSpecialty1"] > .autocomplete-select > .react-select__control > .react-select__value-container > .react-select__input-container'
+        )
+          .click()
+          .get(".react-select__menu")
+          .find(".react-select__option")
+          .first()
+          .click();
+
         cy.get(
           '[data-cy="college"] > .autocomplete-select > .react-select__control > .react-select__value-container > .react-select__input-container'
         )
@@ -167,7 +177,7 @@ describe("Name of the group", () => {
           .click()
           .clear()
           .type(startDate);
-
+        cy.get(".nhsuk-card__heading").click(); // to remove date picker focus
         cy.get('[data-cy="programmeMembershipType-input"]').clear().type("LAT");
         cy.get('[data-cy="wholeTimeEquivalent-input"]').clear().type("1");
 
@@ -175,32 +185,12 @@ describe("Name of the group", () => {
           .should("have.text", "Review & submit")
           .click();
 
-        // Save draft
         cy.get('[data-cy="warningConfirmation"]').should("exist");
         cy.get('[data-cy="email-value"]').should(
           "have.text",
           "traineeui.tester@hee.nhs.uk"
         );
         cy.get('[data-cy="edit-Personal Details"]').should("exist");
-        cy.get('[data-cy="BtnSaveDraft"]').should("exist").click();
-
-        // open the saved draft form
-        cy.get('[data-cy="btn-Edit saved draft form"]').should("exist").click();
-        cy.get('[data-cy="progress-header"] > h3').should(
-          "contain.text",
-          "Part 1 of 3 - Personal Details"
-        );
-        cy.get('[data-cy="BtnContinue"]').click();
-        cy.get('[data-cy="progress-header"] > h3').should(
-          "contain.text",
-          "Part 2 of 3 - Programme Declarations"
-        );
-        cy.get('[data-cy="BtnContinue"]').click();
-        cy.get('[data-cy="progress-header"] > h3').should(
-          "contain.text",
-          "Part 3 of 3 - Programme Details"
-        );
-        cy.get('[data-cy="BtnContinue"]').click();
 
         // Submit form
         cy.get("[data-cy=BtnSubmit]").scrollIntoView().should("exist").click();
@@ -221,7 +211,123 @@ describe("Name of the group", () => {
         // Navigate back to the list
         cy.get(".nhsuk-back-link__link").should("exist").click();
         cy.contains("Submitted forms").should("exist");
-        cy.get('[data-cy="Submit new form"]').should("exist").click();
       });
+  });
+});
+
+describe("Form R Part A - JSON form fields visibility status checks", () => {
+  before(() => {
+    cy.wait(30000);
+    cy.visit("/");
+    cy.signIn();
+  });
+  it("should persist the updated dependent field visibility status to trigger any expected validation  when a draft form is re-opened.", () => {
+    cy.contains("Form R (Part A)").click();
+    cy.visit("/formr-a", { failOnStatusCode: false });
+    cy.get('[data-cy="Submit new form"]').should("exist").click();
+    cy.get("body").then($body => {
+      if ($body.find(".MuiDialog-container").length) {
+        cy.get(".MuiDialogContentText-root").should(
+          "include.text",
+          "You recently submitted a form"
+        );
+        cy.get(".MuiDialogActions-root > :nth-child(2)").click();
+      }
+    });
+    cy.get(
+      '[data-cy="immigrationStatus"] > .autocomplete-select > .react-select__control > .react-select__value-container > .react-select__input-container'
+    )
+      .click()
+      .type("ref")
+      .get(".react-select__menu")
+      .find(".react-select__option")
+      .first()
+      .click();
+    cy.get('[data-cy="email-input"]')
+      .focus()
+      .clear()
+      .type("traineeui.tester@hee.nhs.uk");
+
+    cy.get('[data-cy="BtnContinue"]').click();
+
+    cy.log(
+      "################ Check that the changed dependent field visibility prop is persisted when a draft form is saved and re-opened so that the validation still fires correctly ###################"
+    );
+    cy.get(
+      '[data-cy="declarationType-I have been appointed to a programme leading to award of CCT-input"]'
+    ).click();
+    cy.get('[data-cy="BtnSaveDraft"]').click();
+    cy.get('[data-cy="btn-Edit saved draft form"]').should("exist").click();
+    cy.get('[data-cy="BtnContinue"]').click();
+    cy.get(
+      '[data-cy="declarationType-I have been appointed to a programme leading to award of CCT-input"]'
+    ).should("be.checked");
+    cy.get(
+      '[data-cy="cctSpecialty1"] > .autocomplete-select > .react-select__control > .react-select__value-container > .react-select__input-container'
+    ).should("exist");
+    cy.get('[data-cy="BtnContinue"]').click();
+    cy.get(".nhsuk-error-summary").should("exist");
+    cy.get(
+      '[data-cy="programmeSpecialty"] > .autocomplete-select > .react-select__control > .react-select__value-container > .react-select__input-container'
+    )
+      .click()
+      .get(".react-select__menu")
+      .find(".react-select__option")
+      .first()
+      .click();
+    cy.get(
+      '   [data-cy="cctSpecialty1"] > .autocomplete-select > .react-select__control > .react-select__value-container > .react-select__input-container'
+    )
+      .click()
+      .get(".react-select__menu")
+      .find(".react-select__option")
+      .first()
+      .click();
+
+    cy.get(
+      '[data-cy="college"] > .autocomplete-select > .react-select__control > .react-select__value-container > .react-select__input-container'
+    )
+      .click()
+      .get(".react-select__menu")
+      .find(".react-select__option")
+      .first()
+      .click();
+    cy.get(
+      '[data-cy="completionDate"] > .react-datepicker-wrapper > .react-datepicker__input-container > .nhsuk-input'
+    )
+      .click()
+      .clear()
+      .type(completionDate);
+    cy.get('[data-cy="BtnContinue"]').click();
+    cy.get(
+      '[data-cy="trainingGrade"] > .autocomplete-select > .react-select__control > .react-select__value-container > .react-select__input-container'
+    )
+      .click()
+      .get(".react-select__menu")
+      .find(".react-select__option")
+      .first()
+      .click();
+    cy.get(
+      '[data-cy="startDate"]> .react-datepicker-wrapper > .react-datepicker__input-container > .nhsuk-input'
+    )
+      .click()
+      .clear()
+      .type(startDate);
+    cy.get(".nhsuk-card__heading").click(); // to remove date picker focus
+    cy.get('[data-cy="programmeMembershipType-input"]').clear().type("LAT");
+    cy.get('[data-cy="wholeTimeEquivalent-input"]').clear().type("1");
+
+    cy.get('[data-cy="BtnContinue"]')
+      .should("have.text", "Review & submit")
+      .click();
+    // Submit form
+    cy.get("[data-cy=BtnSubmit]").scrollIntoView().should("exist").click();
+    cy.get(".MuiDialog-container")
+      .should("exist")
+      .should("include.text", "Please think carefully before submitting");
+    cy.get(".MuiDialogActions-root > :nth-child(2)").click();
+
+    cy.contains("Submitted forms").should("exist");
+    cy.get('[data-cy="Submit new form"]').should("exist");
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.68.1",
+  "version": "0.69.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^4.2.1",


### PR DESCRIPTION
Fixed (hopefully without breaking anything else) bugs:
1. JSON form fields' visibility were not reset when navigating away then opening a new form. This was fixed by not directly mutuating the (JSON forms) fields.

2. When completing a form and making a dependent field visible via a click event on the parent (e.g. programme specialty radio click unhides the 2 cct fields), these fields should remain visible and therefore subject to validation. However, a bug meant that these dependent fields' visibility was reset to the default hidden when the saved draft form was reopened so the validation did not fire when navigating to the next page. This was fixed by Initialising the dependent (JSON form) fields' visibility based on their parent field's (fetchedFormData) value/state.

TODO: Added  an e2e test for the first fix but need to work out a way to set up Cypress to test the first. (follow-up ticket)

ps. Haven't got the will to fix that code smell today!