### PR TITLE
fix: toot validation bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.71.0",
+  "version": "0.71.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.71.0",
+      "version": "0.71.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^4.2.1",
         "@cypress/code-coverage": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.71.0",
+  "version": "0.71.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^4.2.1",

--- a/utilities/StringUtilities.ts
+++ b/utilities/StringUtilities.ts
@@ -15,10 +15,15 @@ export class StringUtilities {
     return args.filter((a): a is string => a !== null).join(" ");
   }
 
-  public static validateInteger(val: number) {
-    const strVal: string = val.toString();
-    if (!/^\d+$/.test(strVal)) {
-      return "Whole numbers only. No decimals please";
+  public static validateInteger(val: number | null | undefined) {
+    if (val === null || val === undefined) {
+      return null;
+    } else {
+      const strVal = val.toString();
+      if (!/^\d+$/.test(strVal)) {
+        return "Whole numbers only. No decimals please.";
+      }
+      return null;
     }
   }
 }

--- a/utilities/__test__/StringUtilities.test.ts
+++ b/utilities/__test__/StringUtilities.test.ts
@@ -33,4 +33,20 @@ describe("StringUtilities", () => {
       "Placement Type Placement Spec"
     );
   });
+
+  // validate integer
+  it("should return null if the value is null", () => {
+    expect(StringUtilities.validateInteger(null)).toBe(null);
+  });
+  it("should return null if the value is undefined", () => {
+    expect(StringUtilities.validateInteger(undefined)).toBe(null);
+  });
+  it("should return null if the value is a valid integer", () => {
+    expect(StringUtilities.validateInteger(42)).toBe(null);
+  });
+  it("should return an error message if the value is a decimal", () => {
+    expect(StringUtilities.validateInteger(3.14)).toBe(
+      "Whole numbers only. No decimals please."
+    );
+  });
 });


### PR DESCRIPTION
Fix TOOT field bug so when a user clears a TOOT field, saves draft, reopens form and attempts to navigate to the next section the form field validation will now fire for null (and undefined) field value.

TIS21-4677