### PR TITLE
Chore/remove redundant what's new code

### DIFF
--- a/components/home/TssUpdates.tsx
+++ b/components/home/TssUpdates.tsx
@@ -1,49 +1,16 @@
 import { ListPanel } from "nhsuk-react-components";
 import { useAppSelector } from "../../redux/hooks/hooks";
-import { useMemo } from "react";
 import { Post } from "../../models/WPPost";
 
 type PostSummary = Pick<Post, "id" | "title" | "excerpt">;
 
 export const TssUpdates: React.FC = () => {
   const whatsNewHeader = "What's New";
-  const wpUpdatesUrl =
-    "https://tis-support.hee.nhs.uk/about-tis/welcome-to-the-tss-updates/";
   const whatsNewStatus = useAppSelector(state => state.tssUpdates.status);
-  const whatsNewPosts: Post[] = useAppSelector(
+  const whatsNewPost: Post = useAppSelector(
     state => state.tssUpdates.tssUpdates
-  );
-  const newSummaryPosts = useMemo(() => {
-    const summaryPosts: PostSummary[] = [];
-    if (whatsNewPosts?.length > 0) {
-      for (const post of whatsNewPosts) {
-        summaryPosts.push({
-          id: post.id,
-          title: post.title,
-          excerpt: post.excerpt
-        });
-      }
-    } else return [];
-    return summaryPosts;
-  }, [whatsNewPosts]);
-
-  const addWhatsNewPosts = (): JSX.Element[] | JSX.Element => {
-    if (newSummaryPosts.length === 0) {
-      return <p data-cy="noUpdates">No new updates available at the moment.</p>;
-    }
-    return newSummaryPosts.map(post => {
-      return (
-        <ListPanel.Item key={post.id}>
-          <h3 className="list-panel-header" data-cy={`postTitle${post.id}`}>
-            {post.title.rendered}
-          </h3>
-          <p data-cy={`postExcerpt${post.id}`}>
-            {extractTextFromHTML(post.excerpt.rendered)}
-          </p>
-        </ListPanel.Item>
-      );
-    });
-  };
+  )[0];
+  const { id, title, excerpt }: PostSummary = whatsNewPost ?? {};
 
   if (whatsNewStatus === "loading") {
     return (
@@ -72,23 +39,28 @@ export const TssUpdates: React.FC = () => {
     );
   }
 
+  if (!whatsNewPost) {
+    return (
+      <div className="tss-updates-content" data-cy="tssUpdatesContainer">
+        <WhatsNewHeader />
+        <p data-cy="noUpdates">No new updates available at the moment.</p>
+      </div>
+    );
+  }
+
   return (
     <div className="tss-updates-content" data-cy="tssUpdatesContainer">
-      <h2 data-cy="whatsNewHeader">
-        <AnchorEl
-          clName="nhsuk-link custom-link"
-          hRef={wpUpdatesUrl}
-          text={whatsNewHeader}
-        />
-      </h2>
-      <ListPanel>{addWhatsNewPosts()}</ListPanel>
-      {whatsNewPosts.length > 1 && (
-        <AnchorEl
-          clName="nhsuk-link custom-link"
-          hRef={wpUpdatesUrl}
-          text="Click here to read more"
-        />
-      )}
+      <WhatsNewHeader />
+      <ListPanel>
+        <ListPanel.Item key={id}>
+          <h3 className="list-panel-header" data-cy={`postTitle${id}`}>
+            {title.rendered}
+          </h3>
+          <p data-cy={`postExcerpt${id}`}>
+            {extractTextFromHTML(excerpt.rendered)}
+          </p>
+        </ListPanel.Item>
+      </ListPanel>
     </div>
   );
 };
@@ -103,23 +75,21 @@ function extractTextFromHTML(html: string): string {
   return html;
 }
 
-type AnchorElProps = {
-  clName: string;
-  hRef: string;
-  text: string;
-};
-
-function AnchorEl({ clName, hRef, text }: AnchorElProps): JSX.Element {
+function WhatsNewHeader(): JSX.Element {
+  const wpUpdatesUrl =
+    "https://tis-support.hee.nhs.uk/about-tis/welcome-to-the-tss-updates/";
   return (
-    <a
-      data-cy={`anchorEl_${text}`}
-      title="Click here for more details"
-      className={clName}
-      href={hRef}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {text}
-    </a>
+    <h2 data-cy="whatsNewHeader">
+      <a
+        data-cy="anchorEl_What's New"
+        title="Click here for more details"
+        className="nhsuk-link custom-link"
+        href={wpUpdatesUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        What's New
+      </a>
+    </h2>
   );
 }

--- a/components/home/TssUpdates.tsx
+++ b/components/home/TssUpdates.tsx
@@ -88,7 +88,7 @@ function WhatsNewHeader(): JSX.Element {
         target="_blank"
         rel="noopener noreferrer"
       >
-        What's New
+        What&apos;s New
       </a>
     </h2>
   );

--- a/cypress/component/home/TssUpdates.cy.tsx
+++ b/cypress/component/home/TssUpdates.cy.tsx
@@ -49,10 +49,7 @@ describe("TssUpdates", () => {
     );
   });
 
-  it("should display 'no updates' msg when no posts (no categories 19) ", () => {
-    const postsWithoutCat19 = tssUpdatesWp.filter(
-      post => !post.categories.includes(19)
-    );
+  it("should display 'no updates' msg when no posts", () => {
     const MockedTssUpdatesNone = () => {
       const dispatch = useAppDispatch();
       dispatch(updatedTssUpdatesStatus("Succeeded"));
@@ -75,7 +72,7 @@ describe("TssUpdates", () => {
   it("should display TssUpdates", () => {
     const MockedTssUpdates = () => {
       const dispatch = useAppDispatch();
-      dispatch(updatedTssUpdates(tssUpdatesWp));
+      dispatch(updatedTssUpdates([tssUpdatesWp[0]]));
       return <TssUpdates />;
     };
     mount(
@@ -85,14 +82,7 @@ describe("TssUpdates", () => {
         </Router>
       </Provider>
     );
-
-    cy.get(".tss-updates-content").then($element => {
-      // Check if the element's content exceeds its visible height
-      const canScroll = $element[0].scrollHeight > $element[0].clientHeight;
-      if (canScroll) {
-        cy.get(".tss-updates-content").should("have.css", "overflow-y", "auto");
-      }
-    });
+    cy.get(".tss-updates-content").should("exist");
     cy.get('[data-cy="whatsNewHeader"]').should("contain", "What's New");
     cy.get('[data-cy="anchorEl_What\'s New"]')
       .should("contain.text", "What's New")
@@ -106,40 +96,5 @@ describe("TssUpdates", () => {
       "contain",
       "This is the excerpt of post 1."
     );
-    cy.get('[data-cy="postTitle2"]').should("contain", "Post 2 Title");
-    cy.get('[data-cy="postExcerpt2"]').should(
-      "contain",
-      "This is the excerpt of post 2."
-    );
-    cy.get('[data-cy="anchorEl_Click here to read more"]')
-      .should("contain.text", "Click here to read more")
-      .should(
-        "have.attr",
-        "href",
-        "https://tis-support.hee.nhs.uk/about-tis/welcome-to-the-tss-updates/"
-      );
-  });
-  it("should display no footer anchor when only 1 post", () => {
-    const singlePost = tssUpdatesWp[0];
-    const MockedSingleTssUpdate = () => {
-      const dispatch = useAppDispatch();
-      dispatch(updatedTssUpdates([singlePost]));
-      return <TssUpdates />;
-    };
-    mount(
-      <Provider store={store}>
-        <Router history={history}>
-          <MockedSingleTssUpdate />
-        </Router>
-      </Provider>
-    );
-    cy.get('[data-cy="anchorEl_What\'s New"]')
-      .should("contain.text", "What's New")
-      .should(
-        "have.attr",
-        "href",
-        "https://tis-support.hee.nhs.uk/about-tis/welcome-to-the-tss-updates/"
-      );
-    cy.get('[data-cy="anchorEl_Click here to read more"]').should("not.exist");
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.75.0",
+  "version": "0.75.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.75.0",
+      "version": "0.75.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^4.2.1",
         "@cypress/code-coverage": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.75.0",
+  "version": "0.75.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^4.2.1",

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -499,40 +499,7 @@ ol[type="a"] {
 .tss-updates-content {
   box-sizing: border-box;
   border: solid #ffffff33 2px;
-  overflow-y: auto;
   padding: 16px;
-  max-height: 25vh;
-}
-
-// Note - Is there a generic @media to rule them all!? (Didn't spend much time looking as the nested scroll may not pass the quality checks on preprod anyway.)
-@media only screen and (max-height: 800px) and (orientation: landscape) {
-  .tss-updates-content {
-    max-height: 35vh;
-  }
-}
-
-@media only screen and (max-height: 600px) and (orientation: landscape) {
-  .tss-updates-content {
-    max-height: 45vh;
-  }
-}
-
-@media only screen and (max-height: 450px) and (orientation: landscape) {
-  .tss-updates-content {
-    max-height: 55vh;
-  }
-}
-
-@media only screen and (max-height: 350px) and (orientation: landscape) {
-  .tss-updates-content {
-    max-height: 65vh;
-  }
-}
-
-@media only screen and (max-height: 250px) and (orientation: landscape) {
-  .tss-updates-content {
-    max-height: 75vh;
-  }
 }
 
 .list-panel-header {


### PR DESCRIPTION
Given that we're sticking to the AC's 😁 and only showing the latest 'what's new' post, we can ditch some useless TS / CSS.
Also tidied up the styling for when there is no post to show.

NO TICKET