### PR TITLE
build: deploy to versioned directory in parallel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,8 @@ jobs:
         run: |
           mv ./out/[[...app]].html ./out/index.html
           aws s3 sync ./out/ s3://${{ secrets.AWS_S3_BUCKET_PREPROD }} --delete
+          PKG_VERSION=$(npm pkg get version | xargs)
+          aws s3 sync ./out/ s3://${{ secrets.AWS_S3_BUCKET_PREPROD }}/$PKG_VERSION --delete
 
       - name: Invalidate CDN Cache
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID}} --paths /static/*
@@ -184,6 +186,8 @@ jobs:
         run: |
           mv ./out/[[...app]].html ./out/index.html
           aws s3 sync ./out/ s3://${{ secrets.AWS_S3_BUCKET_PROD }} --delete
+          PKG_VERSION=$(npm pkg get version | xargs)
+          aws s3 sync ./out/ s3://${{ secrets.AWS_S3_BUCKET_PREPROD }}/$PKG_VERSION --delete
 
       - name: Invalidate CDN Cache
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID}} --paths /static/*


### PR DESCRIPTION
Deploy the app to a versioned directory in parallel to the existing deployment, this ensures correct working before implementing the cloudfront changes.

TIS21-4852
TIS21-3784