### PR TITLE
build: update cloudfront origin path on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,15 +34,23 @@ jobs:
         env:
           ENV: preprod
 
+      - name: Get App Version
+        run: echo "app_version=$(npm pkg get version | xargs)" >> "$GITHUB_ENV"
+
       - name: Deploy app build to S3 bucket
         run: |
           mv ./out/[[...app]].html ./out/index.html
-          aws s3 sync ./out/ s3://${{ secrets.AWS_S3_BUCKET_PREPROD }} --delete
-          PKG_VERSION=$(npm pkg get version | xargs)
-          aws s3 sync ./out/ s3://${{ secrets.AWS_S3_BUCKET_PREPROD }}/$PKG_VERSION --delete
+          aws s3 sync ./out/ s3://${{ secrets.AWS_S3_BUCKET_PREPROD }}/${{ env.app_version }} --delete
 
-      - name: Invalidate CDN Cache
-        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID}} --paths /static/*
+      - name: Update Cloudfront Origin Path
+        run: |
+          aws cloudfront get-distribution-config --id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} > ${{ env.ORIGINAL_CONFIG_FILENAME }}
+          etag=`jq '.ETag' ${{ env.ORIGINAL_CONFIG_FILENAME }} | xargs`
+          jq '.DistributionConfig | (.Origins.Items[] | select(.Id | contains("website")).OriginPath) = "/${{ env.app_version }}"' ${{ env.ORIGINAL_CONFIG_FILENAME }} > ${{ env.UPDATED_CONFIG_FILENAME }}
+          aws cloudfront update-distribution --id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --if-match ${ etag } --distribution-config file://${{ env.UPDATED_CONFIG_FILENAME }}
+        env:
+          ORIGINAL_CONFIG_FILENAME: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID}}_get.json
+          UPDATED_CONFIG_FILENAME: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID}}_update.json
 
   cypress-e2e:
     continue-on-error: ${{ matrix.experimental }}
@@ -182,12 +190,20 @@ jobs:
       - name: Build React App
         run: npm install && npm run build
 
+      - name: Get App Version
+        run: echo "app_version=$(npm pkg get version | xargs)" >> "$GITHUB_ENV"
+
       - name: Deploy app build to S3 bucket
         run: |
           mv ./out/[[...app]].html ./out/index.html
-          aws s3 sync ./out/ s3://${{ secrets.AWS_S3_BUCKET_PROD }} --delete
-          PKG_VERSION=$(npm pkg get version | xargs)
-          aws s3 sync ./out/ s3://${{ secrets.AWS_S3_BUCKET_PREPROD }}/$PKG_VERSION --delete
+          aws s3 sync ./out/ s3://${{ secrets.AWS_S3_BUCKET_PREPROD }}/${{ env.app_version }} --delete
 
-      - name: Invalidate CDN Cache
-        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID}} --paths /static/*
+      - name: Update Cloudfront Origin Path
+        run: |
+          aws cloudfront get-distribution-config --id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} > ${{ env.ORIGINAL_CONFIG_FILENAME }}
+          etag=`jq '.ETag' ${{ env.ORIGINAL_CONFIG_FILENAME }} | xargs`
+          jq '.DistributionConfig | (.Origins.Items[] | select(.Id | contains("website")).OriginPath) = "/${{ env.app_version }}"' ${{ env.ORIGINAL_CONFIG_FILENAME }} > ${{ env.UPDATED_CONFIG_FILENAME }}
+          aws cloudfront update-distribution --id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --if-match ${ etag } --distribution-config file://${{ env.UPDATED_CONFIG_FILENAME }}
+        env:
+          ORIGINAL_CONFIG_FILENAME: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID}}_get.json
+          UPDATED_CONFIG_FILENAME: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID}}_update.json


### PR DESCRIPTION
When a versioned deploy is complete, update the cloudfront origin path to point to the new deploy folder.

Remove the cache invalidation step, as it is automatically performed when switching origin paths.

TIS21-3784
TIS21-4852
TIS21-4853