### PR TITLE
build: deploy prod to correct bucket

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Deploy app build to S3 bucket
         run: |
           mv ./out/[[...app]].html ./out/index.html
-          aws s3 sync ./out/ s3://${{ secrets.AWS_S3_BUCKET_PREPROD }}/${{ env.app_version }} --delete
+          aws s3 sync ./out/ s3://${{ secrets.AWS_S3_BUCKET_PROD }}/${{ env.app_version }} --delete
 
       - name: Update Cloudfront Origin Path
         run: |


### PR DESCRIPTION
The prod deployment step was incorrectly deploying to the preprod bucket, update the deploy command to publish to the correct bucket.

TIS21-3784