### PR TITLE
Group/ categorise the placements by date 

### DIFF
--- a/cypress/component/placements/Placements.cy.tsx
+++ b/cypress/component/placements/Placements.cy.tsx
@@ -22,7 +22,7 @@ import {
 
 describe("Placements with no MFA set up", () => {
   it("should not display Placements page if NOMFA", () => {
-    const MockedProgrammesFail = () => {
+    const MockedPlacementsNoMfa = () => {
       const dispatch = useAppDispatch();
       dispatch(
         updatedTraineeProfileData({
@@ -38,7 +38,7 @@ describe("Placements with no MFA set up", () => {
     mount(
       <Provider store={store}>
         <Router history={history}>
-          <MockedProgrammesFail />
+          <MockedPlacementsNoMfa />
         </Router>
       </Provider>
     );
@@ -80,14 +80,20 @@ describe("Placements with MFA set up", () => {
       .first()
       .should("exist")
       .should("contain.text", "Addenbrookes Hospital (siteNo)");
-    cy.get('[data-cy="wholeTimeEquivalent1Val"]')
-      .last()
+    cy.get('[data-cy="wholeTimeEquivalent0Val"]')
+      .first()
       .should("exist")
       .should("contain.text", "0.75");
-    cy.get('[data-cy="employingBody1Val"]')
-      .last()
+    cy.get('[data-cy="employingBody0Val"]')
+      .first()
       .should("exist")
       .should("contain.text", "None provided");
+
+    cy.get('[data-cy="futureExpand"]').click();
+    cy.get('[data-cy="futureWarningText"]').should(
+      "have.text",
+      "The information we have for future placements with a start date more than 12 weeks from today is not yet finalised and may be subject to change."
+    );
   });
 
   it("should show alternative text when no panel data available", () => {
@@ -111,7 +117,10 @@ describe("Placements with MFA set up", () => {
         </Router>
       </Provider>
     );
-    cy.get("[data-cy=notAssignedplacements]")
+    cy.get('[data-cy="upcomingExpand"]').click();
+    cy.get(
+      '[data-cy="upcomingExpand"] > .nhsuk-details__text > .nhsuk-grid-row > .nhsuk-card > [data-cy="notAssignedplacements"]'
+    )
       .should("exist")
       .should("contain.text", "You are not assigned to any Placements");
   });

--- a/mock-data/trainee-profile.ts
+++ b/mock-data/trainee-profile.ts
@@ -3,6 +3,13 @@ import { TraineeProfile } from "../models/TraineeProfile";
 import { Status } from "../models/Status";
 import { ProgrammeMembership } from "../models/ProgrammeMembership";
 import { Placement } from "../models/Placement";
+import {
+  oneWeekAgo,
+  today,
+  twelveWeeksAhead,
+  twelveWeeksAheadPlusOneDay,
+  yesterday
+} from "../utilities/DateUtilities";
 
 export const mockPersonalDetails: PersonalDetails = {
   surname: "Gilliam",
@@ -335,3 +342,66 @@ export const mockTraineeProfileNoGMC: TraineeProfile = {
   programmeMemberships: mockProgrammeMemberships,
   placements: mockPlacements
 };
+
+export const mockPlacementsForGrouping: Placement[] = [
+  // Past
+  {
+    tisId: "1",
+    site: "site1",
+    siteLocation: "siteLocation1",
+    siteKnownAs: "siteKnownAs1",
+    startDate: oneWeekAgo,
+    endDate: yesterday,
+    wholeTimeEquivalent: "wholeTimeEquivalent1",
+    specialty: "specialty1",
+    grade: "grade1",
+    placementType: "placementType1",
+    employingBody: "employingBody1",
+    trainingBody: "trainingBody1"
+  },
+  // Current
+  {
+    tisId: "2",
+    site: "site2",
+    siteLocation: "siteLocation2",
+    siteKnownAs: "siteKnownAs2",
+    startDate: today,
+    endDate: today,
+    wholeTimeEquivalent: "wholeTimeEquivalent2",
+    specialty: "specialty2",
+    grade: "grade2",
+    placementType: "placementType2",
+    employingBody: "employingBody2",
+    trainingBody: "trainingBody2"
+  },
+  // Upcoming
+  {
+    tisId: "3",
+    site: "site3",
+    siteLocation: "siteLocation3",
+    siteKnownAs: "siteKnownAs3",
+    startDate: twelveWeeksAhead,
+    endDate: twelveWeeksAheadPlusOneDay,
+    wholeTimeEquivalent: "wholeTimeEquivalent3",
+    specialty: "specialty3",
+    grade: "grade3",
+    placementType: "placementType3",
+    employingBody: "employingBody3",
+    trainingBody: "trainingBody3"
+  },
+  // Future
+  {
+    tisId: "4",
+    site: "site4",
+    siteLocation: "siteLocation4",
+    siteKnownAs: "siteKnownAs4",
+    startDate: twelveWeeksAheadPlusOneDay,
+    endDate: twelveWeeksAheadPlusOneDay,
+    wholeTimeEquivalent: "wholeTimeEquivalent4",
+    specialty: "specialty4",
+    grade: "grade4",
+    placementType: "placementType4",
+    employingBody: "employingBody4",
+    trainingBody: "trainingBody4"
+  }
+];

--- a/models/Placement.ts
+++ b/models/Placement.ts
@@ -32,3 +32,10 @@ export const placementPanelTemplate: Placement = {
   employingBody: "",
   trainingBody: ""
 };
+
+export interface PlacementGroup {
+  future: Placement[];
+  upcoming: Placement[];
+  current: Placement[];
+  past: Placement[];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.77.1",
+  "version": "0.78.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.77.1",
+      "version": "0.78.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^4.2.1",
         "@cypress/code-coverage": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.77.2",
+  "version": "0.78.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^4.2.1",

--- a/utilities/DateUtilities.ts
+++ b/utilities/DateUtilities.ts
@@ -2,6 +2,7 @@ import day from "dayjs";
 import isBetween from "dayjs/plugin/isBetween";
 import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
 import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
+import { Placement } from "../models/Placement";
 
 day.extend(isBetween);
 day.extend(isSameOrBefore);
@@ -142,3 +143,40 @@ export const isWithinRange = (
 ): boolean => {
   return date ? day(dateToCompare).diff(date, unit) < range : false;
 };
+
+// Utils for Grouping Placements by Date
+
+export const today = day(new Date()).format("YYYY-MM-DD");
+export const yesterday = day(today).subtract(1, "day").format("YYYY-MM-DD");
+export const oneWeekAgo = day(today).subtract(7, "day").format("YYYY-MM-DD");
+export const twelveWeeksAhead = day(new Date())
+  .add(12, "week")
+  .format("YYYY-MM-DD");
+export const twelveWeeksAheadPlusOneDay = day(twelveWeeksAhead)
+  .add(1, "day")
+  .format("YYYY-MM-DD");
+
+export function isPastIt(date: DateType): boolean {
+  return day(date).format("YYYY-MM-DD") < today;
+}
+
+export function isCurrentPl(pl: Placement): boolean {
+  const { startDate, endDate } = pl;
+  return (
+    day(endDate).format("YYYY-MM-DD") >= today &&
+    day(startDate).format("YYYY-MM-DD") <= today
+  );
+}
+
+export function isUpcomingPl(pl: Placement): boolean {
+  const { startDate } = pl;
+  return (
+    day(startDate).format("YYYY-MM-DD") > today &&
+    day(startDate).format("YYYY-MM-DD") <= twelveWeeksAhead
+  );
+}
+
+export function isFuturePl(pl: Placement): boolean {
+  const { startDate } = pl;
+  return day(startDate).format("YYYY-MM-DD") > twelveWeeksAhead;
+}

--- a/utilities/ProfileUtilities.ts
+++ b/utilities/ProfileUtilities.ts
@@ -1,8 +1,8 @@
 import { FormRPartB, Work } from "../models/FormRPartB";
 import { NEW_WORK, MEDICAL_CURRICULUM } from "./Constants";
-import { Placement } from "../models/Placement";
+import { Placement, PlacementGroup } from "../models/Placement";
 import { Curriculum, ProgrammeMembership } from "../models/ProgrammeMembership";
-import dayjs from "dayjs";
+import { isCurrentPl, isPastIt, isUpcomingPl, today } from "./DateUtilities";
 
 export type ProfileSType = string | null | undefined;
 export class ProfileUtilities {
@@ -83,8 +83,6 @@ export class ProfileUtilities {
   }
 
   public static trimmedFutureWork(works: Work[]) {
-    const today = dayjs(new Date()).format("YYYY-MM-DD");
-
     const firstFutureWorks = works
       .filter(w => w.startDate > today)
       .sort((a, b) => (a.startDate > b.startDate ? 1 : -1));
@@ -103,4 +101,30 @@ export class ProfileUtilities {
 
     return trimmedWork;
   }
+
+  public static groupPlacementsByDate = (
+    placements: Placement[]
+  ): PlacementGroup => {
+    const groupedPlacements: PlacementGroup = {
+      future: [],
+      upcoming: [],
+      current: [],
+      past: []
+    };
+
+    return placements.reduce(
+      (grouped: PlacementGroup, placement: Placement) => {
+        const { future, upcoming, current, past } = grouped;
+        if (isPastIt(placement.endDate)) {
+          past.push(placement);
+        } else if (isCurrentPl(placement)) {
+          current.push(placement);
+        } else if (isUpcomingPl(placement)) {
+          upcoming.push(placement);
+        } else future.push(placement);
+        return grouped;
+      },
+      groupedPlacements
+    );
+  };
 }

--- a/utilities/__test__/ProfileUtilities.test.ts
+++ b/utilities/__test__/ProfileUtilities.test.ts
@@ -1,5 +1,11 @@
 import { ProfileUtilities } from "../ProfileUtilities";
 import {
+  isCurrentPl,
+  isFuturePl,
+  isPastIt,
+  isUpcomingPl
+} from "../DateUtilities";
+import {
   draftFormRPartB,
   draftFormRPartBWithNoLeaveTotal,
   draftFormRPartBWithNullCareerBreak
@@ -9,7 +15,8 @@ import {
   mockProgrammeMembershipNoCurricula,
   mockProgrammeMembershipNoMedicalCurricula,
   mockProgrammeMembershipDuplicateCurriculaStart,
-  mockPlacements
+  mockPlacements,
+  mockPlacementsForGrouping
 } from "../../mock-data/trainee-profile";
 import { NEW_WORK } from "../Constants";
 import {
@@ -117,5 +124,33 @@ describe("ProfileUtilities", () => {
     expect(trimmedAndSorted2).toEqual(
       trimmedAndSortedWorkArrWithTwoFutureOnSameDay
     );
+  });
+});
+
+describe("Profile utilities - groupPlacementsByDate", () => {
+  it("should classify a placement correctly", () => {
+    expect(isPastIt(mockPlacementsForGrouping[0].endDate)).toBe(true);
+    expect(isPastIt(mockPlacementsForGrouping[1].endDate)).toBe(false);
+    expect(isCurrentPl(mockPlacementsForGrouping[1])).toBe(true);
+    expect(isCurrentPl(mockPlacementsForGrouping[0])).toBe(false);
+    expect(isCurrentPl(mockPlacementsForGrouping[2])).toBe(false);
+    expect(isCurrentPl(mockPlacementsForGrouping[3])).toBe(false);
+    expect(isUpcomingPl(mockPlacementsForGrouping[2])).toBe(true);
+    expect(isUpcomingPl(mockPlacementsForGrouping[3])).toBe(false);
+    expect(isUpcomingPl(mockPlacementsForGrouping[1])).toBe(false);
+    expect(isUpcomingPl(mockPlacementsForGrouping[0])).toBe(false);
+    expect(isFuturePl(mockPlacementsForGrouping[3])).toBe(true);
+    expect(isFuturePl(mockPlacementsForGrouping[2])).toBe(false);
+  });
+
+  it("should group placements correctly", () => {
+    expect(
+      ProfileUtilities.groupPlacementsByDate(mockPlacementsForGrouping)
+    ).toEqual({
+      future: [mockPlacementsForGrouping[3]],
+      upcoming: [mockPlacementsForGrouping[2]],
+      current: [mockPlacementsForGrouping[1]],
+      past: [mockPlacementsForGrouping[0]]
+    });
   });
 });


### PR DESCRIPTION
- Group the placements in this order (the most useful first?) from top of the Placements page to bottom: Current, upcoming (within 12 weeks), future(>12 weeks), past .
- Current placements expander defaults to open (others are closed)
- Add warning text on future to say subject to change etc.

TIS21-4869