### PR TITLE
feat: display other sites on placement panel

### DIFF
--- a/components/common/PanelsCreator.tsx
+++ b/components/common/PanelsCreator.tsx
@@ -10,6 +10,7 @@ import style from "../Common.module.scss";
 import { DspIssueBtn } from "../dsp/DspIssueBtn";
 import { ConditionsOfJoining } from "../programmes/ConditionsOfJoining";
 import { Curricula } from "../programmes/Curricula";
+import { OtherSites } from "../placements/OtherSites";
 
 type PanelsCreatorProps = {
   panelsArr: ProfileType[];
@@ -139,6 +140,8 @@ function displayTheCorrectListItem(panelProp: string, panel: any) {
           programmeName={panel.programmeName}
         />
       );
+    case "otherSites":
+      return <OtherSites otherSites={panel[panelProp]} />;
     default:
       return displayListVal(panel[panelProp], panelProp);
   }

--- a/components/placements/OtherSites.tsx
+++ b/components/placements/OtherSites.tsx
@@ -1,0 +1,23 @@
+import { Site } from "../../models/Placement";
+import style from "../Common.module.scss";
+
+type OtherSitesProps = {
+  otherSites: Site[];
+};
+
+export function OtherSites({ otherSites }: OtherSitesProps) {
+  if (otherSites?.length > 0) {
+    return (
+      <>
+        {otherSites.map(
+          ({ siteKnownAs, siteLocation }: Site, index: number): JSX.Element => (
+            <div key={index} className={style.cItems}>
+              <div data-cy={`otherSiteKnownAs${index}Val`}>{siteKnownAs}</div>
+              <div data-cy={`otherSiteLocation${index}Val`}>{siteLocation}</div>
+            </div>
+          )
+        )}
+      </>
+    );
+  } else return <div>None provided</div>;
+}

--- a/components/placements/OtherSites.tsx
+++ b/components/placements/OtherSites.tsx
@@ -10,10 +10,17 @@ export function OtherSites({ otherSites }: OtherSitesProps) {
     return (
       <>
         {otherSites.map(
-          ({ siteKnownAs, siteLocation }: Site, index: number): JSX.Element => (
+          (
+            { site, siteKnownAs, siteLocation }: Site,
+            index: number
+          ): JSX.Element => (
             <div key={index} className={style.cItems}>
-              <div data-cy={`otherSiteKnownAs${index}Val`}>{siteKnownAs}</div>
-              <div data-cy={`otherSiteLocation${index}Val`}>{siteLocation}</div>
+              <div data-cy={`otherSite${index}Val`}>{siteKnownAs || site}</div>
+              {siteLocation && (
+                <div data-cy={`otherSiteLocation${index}Val`}>
+                  {siteLocation}
+                </div>
+              )}
             </div>
           )
         )}

--- a/cypress/component/placements/Placements.cy.tsx
+++ b/cypress/component/placements/Placements.cy.tsx
@@ -7,7 +7,8 @@ import Placements from "../../../components/placements/Placements";
 import {
   mockPlacements,
   mockPlacementNonTemplatedField,
-  mockPersonalDetails
+  mockPersonalDetails,
+  mockPlacementNoOtherSites
 } from "../../../mock-data/trainee-profile";
 import history from "../../../components/navigation/history";
 import React from "react";
@@ -80,6 +81,22 @@ describe("Placements with MFA set up", () => {
       .first()
       .should("exist")
       .should("contain.text", "Addenbrookes Hospital (siteNo)");
+    cy.get('[data-cy="otherSiteKnownAs0Val"]')
+      .first()
+      .should("exist")
+      .should("contain.text", "Huddersfield Royal Infirmary");
+    cy.get('[data-cy="otherSiteLocation0Val"]')
+      .first()
+      .should("exist")
+      .should("contain.text", "Acre Street Lindley Huddersfield");
+    cy.get('[data-cy="otherSiteKnownAs1Val"]')
+      .first()
+      .should("exist")
+      .should("contain.text", "Great North Children's Hospital (RTD10)");
+    cy.get('[data-cy="otherSiteLocation1Val"]')
+      .first()
+      .should("exist")
+      .should("contain.text", "Queen Victoria Road Newcastle upon Tyne");
     cy.get('[data-cy="wholeTimeEquivalent0Val"]')
       .first()
       .should("exist")
@@ -94,6 +111,33 @@ describe("Placements with MFA set up", () => {
       "have.text",
       "The information we have for future placements with a start date more than 12 weeks from today is not yet finalised and may be subject to change."
     );
+  });
+
+  it("should show alternative text when no Other Sites", () => {
+    const MockedPlacementsSuccess = () => {
+      const dispatch = useAppDispatch();
+      dispatch(
+        updatedTraineeProfileData({
+          traineeTisId: "12345",
+          personalDetails: mockPersonalDetails,
+          programmeMemberships: [],
+          placements: [mockPlacementNoOtherSites]
+        })
+      );
+      dispatch(updatedTraineeProfileStatus("succeeded"));
+      return <Placements />;
+    };
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <MockedPlacementsSuccess />
+        </Router>
+      </Provider>
+    );
+
+    cy.get("[data-cy=otherSites0Val]")
+      .should("exist")
+      .should("contain.text", "None provided");
   });
 
   it("should show alternative text when no panel data available", () => {

--- a/cypress/component/placements/Placements.cy.tsx
+++ b/cypress/component/placements/Placements.cy.tsx
@@ -8,7 +8,8 @@ import {
   mockPlacements,
   mockPlacementNonTemplatedField,
   mockPersonalDetails,
-  mockPlacementNoOtherSites
+  mockPlacementNoOtherSites,
+  mockPlacementPartialOtherSites
 } from "../../../mock-data/trainee-profile";
 import history from "../../../components/navigation/history";
 import React from "react";
@@ -81,7 +82,7 @@ describe("Placements with MFA set up", () => {
       .first()
       .should("exist")
       .should("contain.text", "Addenbrookes Hospital (siteNo)");
-    cy.get('[data-cy="otherSiteKnownAs0Val"]')
+    cy.get('[data-cy="otherSite0Val"]')
       .first()
       .should("exist")
       .should("contain.text", "Huddersfield Royal Infirmary");
@@ -89,7 +90,7 @@ describe("Placements with MFA set up", () => {
       .first()
       .should("exist")
       .should("contain.text", "Acre Street Lindley Huddersfield");
-    cy.get('[data-cy="otherSiteKnownAs1Val"]')
+    cy.get('[data-cy="otherSite1Val"]')
       .first()
       .should("exist")
       .should("contain.text", "Great North Children's Hospital (RTD10)");
@@ -111,6 +112,50 @@ describe("Placements with MFA set up", () => {
       "have.text",
       "The information we have for future placements with a start date more than 12 weeks from today is not yet finalised and may be subject to change."
     );
+  });
+
+  it("should show available data when partial Other Sites", () => {
+    const MockedPlacementsSuccess = () => {
+      const dispatch = useAppDispatch();
+      dispatch(
+        updatedTraineeProfileData({
+          traineeTisId: "12345",
+          personalDetails: mockPersonalDetails,
+          programmeMemberships: [],
+          placements: [mockPlacementPartialOtherSites]
+        })
+      );
+      dispatch(updatedTraineeProfileStatus("succeeded"));
+      return <Placements />;
+    };
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <MockedPlacementsSuccess />
+        </Router>
+      </Provider>
+    );
+
+    cy.get('[data-cy="otherSite0Val"]')
+      .first()
+      .should("exist")
+      .should("contain.text", "site known as");
+    cy.get('[data-cy="otherSiteLocation0Val"]').should("not.exist");
+
+    cy.get('[data-cy="otherSite1Val"]')
+      .first()
+      .should("exist")
+      .should("contain.text", "site with missing known as");
+    cy.get('[data-cy="otherSiteLocation1Val"]')
+      .first()
+      .should("exist")
+      .should("contain.text", "site location");
+
+    cy.get('[data-cy="otherSite2Val"]')
+      .first()
+      .should("exist")
+      .should("contain.text", "site with only name");
+    cy.get('[data-cy="otherSiteLocation2Val"]').should("not.exist");
   });
 
   it("should show alternative text when no Other Sites", () => {

--- a/mock-data/trainee-profile.ts
+++ b/mock-data/trainee-profile.ts
@@ -318,6 +318,35 @@ export const mockPlacements: Placement[] = [
   }
 ];
 
+export const mockPlacementPartialOtherSites = {
+  endDate: new Date("2020-12-31"),
+  grade: "ST1",
+  tisId: "315",
+  placementType: "In Post",
+  site: "Addenbrookes Hospital",
+  siteLocation: "Site location",
+  siteKnownAs: "Addenbrookes Hospital (siteNo)",
+  otherSites: [
+    {
+      site: "site with missing location",
+      siteKnownAs: "site known as"
+    },
+    {
+      site: "site with missing known as",
+      siteLocation: "site location"
+    },
+    {
+      site: "site with only name"
+    }
+  ],
+  specialty: "Dermatology",
+  startDate: new Date("2019-01-01"),
+  status: Status.Current,
+  employingBody: "Employing body",
+  trainingBody: "Training body",
+  wholeTimeEquivalent: "0.5"
+};
+
 export const mockPlacementNoOtherSites = {
   endDate: new Date("2020-12-31"),
   grade: "ST1",

--- a/mock-data/trainee-profile.ts
+++ b/mock-data/trainee-profile.ts
@@ -281,6 +281,7 @@ export const mockPlacements: Placement[] = [
     site: "Addenbrookes Hospital",
     siteLocation: "Site location",
     siteKnownAs: "Addenbrookes Hospital (siteNo)",
+    otherSites: [],
     specialty: "Dermatology",
     startDate: new Date("2019-01-01"),
     status: Status.Current,
@@ -296,6 +297,18 @@ export const mockPlacements: Placement[] = [
     site: "Addenbrookes Hospital",
     siteLocation: "Site location",
     siteKnownAs: "Addenbrookes Hospital (siteNo)",
+    otherSites: [
+      {
+        site: "Huddersfield Royal Infirmary",
+        siteKnownAs: "Huddersfield Royal Infirmary (RWY01)",
+        siteLocation: "Acre Street Lindley Huddersfield"
+      },
+      {
+        site: "Great North Children's Hospital",
+        siteKnownAs: "Great North Children's Hospital (RTD10)",
+        siteLocation: "Queen Victoria Road Newcastle upon Tyne"
+      }
+    ],
     specialty: "Dermatology",
     startDate: new Date("2020-01-01"),
     status: Status.Current,
@@ -305,6 +318,23 @@ export const mockPlacements: Placement[] = [
   }
 ];
 
+export const mockPlacementNoOtherSites = {
+  endDate: new Date("2020-12-31"),
+  grade: "ST1",
+  tisId: "315",
+  placementType: "In Post",
+  site: "Addenbrookes Hospital",
+  siteLocation: "Site location",
+  siteKnownAs: "Addenbrookes Hospital (siteNo)",
+  otherSites: [],
+  specialty: "Dermatology",
+  startDate: new Date("2019-01-01"),
+  status: Status.Current,
+  employingBody: "Employing body",
+  trainingBody: "Training body",
+  wholeTimeEquivalent: "0.5"
+};
+
 export const mockPlacementNonTemplatedField = {
   endDate: new Date("2020-12-31"),
   grade: "ST1",
@@ -313,6 +343,7 @@ export const mockPlacementNonTemplatedField = {
   site: "Addenbrookes Hospital",
   siteLocation: "Site location",
   siteKnownAs: "Addenbrookes Hospital (siteNo)",
+  otherSites: [],
   specialty: "Dermatology",
   startDate: new Date("2019-01-01"),
   status: Status.Current,
@@ -350,6 +381,7 @@ export const mockPlacementsForGrouping: Placement[] = [
     site: "site1",
     siteLocation: "siteLocation1",
     siteKnownAs: "siteKnownAs1",
+    otherSites: [],
     startDate: oneWeekAgo,
     endDate: yesterday,
     wholeTimeEquivalent: "wholeTimeEquivalent1",
@@ -365,6 +397,7 @@ export const mockPlacementsForGrouping: Placement[] = [
     site: "site2",
     siteLocation: "siteLocation2",
     siteKnownAs: "siteKnownAs2",
+    otherSites: [],
     startDate: today,
     endDate: today,
     wholeTimeEquivalent: "wholeTimeEquivalent2",
@@ -380,6 +413,7 @@ export const mockPlacementsForGrouping: Placement[] = [
     site: "site3",
     siteLocation: "siteLocation3",
     siteKnownAs: "siteKnownAs3",
+    otherSites: [],
     startDate: twelveWeeksAhead,
     endDate: twelveWeeksAheadPlusOneDay,
     wholeTimeEquivalent: "wholeTimeEquivalent3",
@@ -395,6 +429,7 @@ export const mockPlacementsForGrouping: Placement[] = [
     site: "site4",
     siteLocation: "siteLocation4",
     siteKnownAs: "siteKnownAs4",
+    otherSites: [],
     startDate: twelveWeeksAheadPlusOneDay,
     endDate: twelveWeeksAheadPlusOneDay,
     wholeTimeEquivalent: "wholeTimeEquivalent4",

--- a/models/Placement.ts
+++ b/models/Placement.ts
@@ -6,6 +6,7 @@ export interface Placement {
   site: string;
   siteLocation: string;
   siteKnownAs: string;
+  otherSites: Site[];
   startDate: Date | string;
   endDate: Date | string;
   wholeTimeEquivalent: string;
@@ -23,6 +24,7 @@ export const placementPanelTemplate: Placement = {
   site: "",
   siteLocation: "",
   siteKnownAs: "",
+  otherSites: [],
   startDate: "",
   endDate: "",
   wholeTimeEquivalent: "",
@@ -32,6 +34,12 @@ export const placementPanelTemplate: Placement = {
   employingBody: "",
   trainingBody: ""
 };
+
+export interface Site {
+  site: string;
+  siteKnownAs: string;
+  siteLocation: string;
+}
 
 export interface PlacementGroup {
   future: Placement[];

--- a/models/Placement.ts
+++ b/models/Placement.ts
@@ -37,8 +37,8 @@ export const placementPanelTemplate: Placement = {
 
 export interface Site {
   site: string;
-  siteKnownAs: string;
-  siteLocation: string;
+  siteKnownAs?: string;
+  siteLocation?: string;
 }
 
 export interface PlacementGroup {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.79.1",
+  "version": "0.80.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.79.1",
+      "version": "0.80.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^4.2.1",
         "@cypress/code-coverage": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.79.4",
+  "version": "0.80.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^4.2.1",

--- a/utilities/Constants.ts
+++ b/utilities/Constants.ts
@@ -154,6 +154,7 @@ export const PANEL_KEYS: any = {
   site: "Site",
   siteLocation: "Site Location",
   siteKnownAs: "Site Known As",
+  otherSites: "Other Sites",
   startDate: "Starts",
   endDate: "Ends",
   wholeTimeEquivalent: "Whole Time Equivalent",


### PR DESCRIPTION
Add "Other Sites" to the Placement panel, showing each "Site Known As" and "Site Location".
The site name is excluded to avoid overcrowding the panel, but the underlying data remains available in the profile.

TIS21-4971
TIS21-4396