### PR TITLE
docs: required permissions for deploy workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,31 @@
+# Deploy Workflow
+
+## Required Permissions
+
+### AWS
+
+#### CloudFront
+
+These permissions are required to manage the associated CloudFront distribution.
+
+- `cloudfront:GetDistributionConfig`
+- `cloudfront:UpdateDistribution`
+
+#### Simple Storage Solution (S3)
+
+##### Static Content
+
+These permissions are required to deploy static website content to the relevant S3 buckets.
+
+- `s3:ListBucket`
+- `s3:GetObject`
+- `s3:PutObject`
+- `s3:DeleteObject`
+
+##### Build Artifacts
+
+These permissions are required to back up build artifacts to the relevant S3 buckets.
+
+- `s3:ListBucket`
+- `s3:GetObject`
+- `s3:PutObject`


### PR DESCRIPTION
Document the required AWS permissions for running the deployment workflow.

Specifically, those required to:
 - Back up build artifacts to S3
 - Deploy static website content to S3
 - Update the CloudFront distribution

 TIS21-4996
 TIS21-4949