### PR TITLE
chore: clear outdated runs in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -166,6 +166,12 @@ jobs:
           workflow=$(echo ${{ github.workflow }} | sed -e 's/\W/-/g' -e 's/\(.*\)/\L\1/')
           aws s3 sync build-artifacts s3://tis-build-artifacts/${{ github.event.repository.name }}/$workflow/${{ github.run_number }}
 
+  clear-outdated-runs:
+    needs: [cypress-e2e]
+    uses: health-education-england/.github/.github/workflows/clear-runs.yml@main
+    with:
+      environment: prod
+
   deploy-prod:
     name: Deploy to Prod
     runs-on: ubuntu-latest


### PR DESCRIPTION
Using the `clear-runs` workflow from .github repo to reject outdated runs. Environment `prod` is passed in to trigger clear-runs after prod deployment approval.

The PR is a draft one as it needs to wait until this [PR on .github repo](https://github.com/Health-Education-England/.github/pull/51) is merged.

TIS21-1209
TIS21-5130