### PR TITLE
From UTC to London (time zone) minus the fudge 

### DIFF
--- a/components/forms/AutosaveMessage.tsx
+++ b/components/forms/AutosaveMessage.tsx
@@ -23,8 +23,8 @@ export const AutosaveMessage: React.FC<AutoSaveMessageProps> = ({
   const statusMessages: { [key in AutosaveStatusProps]: string } = {
     idle: "Waiting for new changes...",
     saving: "In progress...",
-    succeeded: `Success (${latestTimeStamp})`,
-    failed: `Fail (last autosave success: ${latestTimeStamp})`
+    succeeded: `Success - ${latestTimeStamp}`,
+    failed: `Fail - Last autosave success: ${latestTimeStamp}`
   };
 
   const message = statusMessages[autoSaveStatus];

--- a/components/forms/SubmittedFormsList.tsx
+++ b/components/forms/SubmittedFormsList.tsx
@@ -37,9 +37,9 @@ const SubmittedFormsList = ({
             }
             data-cy="submittedForm"
           >
-            {`Form submitted on ${DateUtilities.ToLocalDateTime(
+            {`Form submitted on ${DateUtilities.ConvertToLondonTime(
               formData.submissionDate
-            )} (GMT)`}
+            )}`}
           </ActionLink>
         </td>
       </Table.Row>
@@ -67,9 +67,9 @@ const SubmittedFormsList = ({
             </WarningCallout.Label>
             {isWithinRange(latestSubDate, 31, "d") && (
               <p>
-                {`Your previous form was submitted recently on ${DateUtilities.ToLocalDateTime(
+                {`Your previous form was submitted recently on ${DateUtilities.ConvertToLondonTime(
                   latestSubDate
-                )} (GMT).`}
+                )}`}
               </p>
             )}
             <h4>Need to amend a recently-submitted form?</h4>

--- a/cypress/component/forms/AutosaveMessage.cy.tsx
+++ b/cypress/component/forms/AutosaveMessage.cy.tsx
@@ -15,7 +15,8 @@ import {
 import { DateUtilities } from "../../../utilities/DateUtilities";
 
 describe("AutosaveMessage", () => {
-  const timeStamp = DateUtilities.NowToGbDateTimeString();
+  const lastModDate: string = "2023-09-26T09:54:27.47";
+  const timeStamp = DateUtilities.ConvertToLondonTime(lastModDate, true);
   const renderAutosaveMessage = (autosaveStatus: AutosaveStatusProps) => {
     const MockedAutosaveMessage = () => {
       const dispatch = useAppDispatch();
@@ -43,7 +44,7 @@ describe("AutosaveMessage", () => {
       .should("exist")
       .should(
         "contain",
-        `Autosave status: Fail (last autosave success: none this session)`
+        `Autosave status: Fail - Last autosave success: none this session`
       );
   });
   it("should render the 'saving' autosave message when the form is being saved", () => {
@@ -68,7 +69,7 @@ describe("AutosaveMessage", () => {
     );
     cy.get('[data-cy="autosaveStatusMsg"]')
       .should("exist")
-      .should("contain", `Autosave status: Success (${timeStamp})`);
+      .should("contain", `Autosave status: Success - ${timeStamp}`);
   });
   it("should render the 'failed' autosave message and last successful timestamp when the form is saved unsuccessfully after one successful autosave.", () => {
     renderAutosaveMessage("failed");
@@ -76,7 +77,7 @@ describe("AutosaveMessage", () => {
       .should("exist")
       .should(
         "contain",
-        `Autosave status: Fail (last autosave success: ${timeStamp})`
+        `Autosave status: Fail - Last autosave success: ${timeStamp}`
       );
   });
 });

--- a/cypress/component/forms/SubmittedFormsList.cy.tsx
+++ b/cypress/component/forms/SubmittedFormsList.cy.tsx
@@ -53,10 +53,10 @@ describe("SubmittedFormsList", () => {
     cy.get("[data-cy=noSubmittedFormsMsg]").should("not.exist");
     cy.get(
       ":nth-child(1) > td > .nhsuk-action-link > [data-cy=submittedForm] > .nhsuk-action-link__text"
-    ).should("contain.text", "Form submitted on 02/07/2022 13:12 (GMT)");
+    ).should("contain.text", "Form submitted on 02/07/2022 14:12 (BST)");
     cy.get(
       ":nth-child(4) > td > .nhsuk-action-link > [data-cy=submittedForm] > .nhsuk-action-link__text"
-    ).should("contain.text", "Form submitted on 22/04/2020 00:00 (GMT)");
+    ).should("contain.text", "Form submitted on 22/04/2020 01:00 (BST)");
     cy.get("[data-cy=formsListWarning]")
       .should("exist")
       .should("contain.text", "Important")

--- a/cypress/component/forms/formr-part-a/FormA.cy.tsx
+++ b/cypress/component/forms/formr-part-a/FormA.cy.tsx
@@ -343,14 +343,14 @@ describe("FormA (form creation)", () => {
       .get(".react-select__menu")
       .find(".react-select__option")
       .first()
-      .click();  
+      .click();
     cy.get(".nhsuk-error-summary").should("not.exist");
     cy.wait(2000);
     cy.get('[data-cy="autosaveStatusMsg"]')
       .should("exist")
       .should(
         "contain.text",
-        "Autosave status: Fail (last autosave success: none this session)"
+        "Autosave status: Fail - Last autosave success: none this session"
       );
   });
 });

--- a/cypress/component/forms/formr-part-a/View.cy.tsx
+++ b/cypress/component/forms/formr-part-a/View.cy.tsx
@@ -25,6 +25,7 @@ describe("View", () => {
     cy.get("[data-cy=warningConfirmation]").should("not.exist");
   });
   it("should render view component with save PDF btn/link for submitted form.", () => {
+    const expectedSubStr = "Form submitted on: 02/07/2022 14:12 (BST)";
     const MockedView = () => {
       const dispatch = useAppDispatch();
       dispatch(updatedFormA(submittedFormRPartAs[0]));
@@ -57,13 +58,10 @@ describe("View", () => {
     cy.get("[data-cy=submissionDateTop]").should("exist");
     cy.get("[data-cy=submissionDateTop]").should(
       "include.text",
-      "Form Submitted on: 02/07/2022"
+      expectedSubStr
     );
     cy.get("[data-cy=submissionDate]").should("exist");
-    cy.get("[data-cy=submissionDate]").should(
-      "include.text",
-      "Form Submitted on: 02/07/2022"
-    );
+    cy.get("[data-cy=submissionDate]").should("include.text", expectedSubStr);
   });
   it("should render view component with no save PDF btn/link for unsubmitted form", () => {
     const MockedViewUnsubmitted = () => {

--- a/cypress/component/forms/formr-part-b/View.cy.tsx
+++ b/cypress/component/forms/formr-part-b/View.cy.tsx
@@ -24,6 +24,7 @@ describe("View", () => {
     cy.get("[data-cy=sectionHeader1]").should("not.exist");
   });
   it("should render view component with save PDF btn/link and declarations for submitted form.", () => {
+    const expectedSubStr = "Form submitted on: 22/04/2020 01:00 (BST)";
     const MockedView = () => {
       const dispatch = useAppDispatch();
       dispatch(updatedFormB(submittedFormRPartBs[0]));
@@ -56,13 +57,10 @@ describe("View", () => {
     cy.get("[data-cy=submissionDateTop]").should("exist");
     cy.get("[data-cy=submissionDateTop]").should(
       "include.text",
-      "Form Submitted on: 22/04/2020"
+      expectedSubStr
     );
     cy.get("[data-cy=submissionDate]").should("exist");
-    cy.get("[data-cy=submissionDate]").should(
-      "include.text",
-      "Form Submitted on: 22/04/2020"
-    );
+    cy.get("[data-cy=submissionDate]").should("include.text", expectedSubStr);
     cy.get("[data-cy=sectionHeader8]")
       .should("exist")
       .should("include.text", "Declarations");

--- a/cypress/component/forms/formr-part-b/viewSections/ViewSection2.cy.tsx
+++ b/cypress/component/forms/formr-part-b/viewSections/ViewSection2.cy.tsx
@@ -59,6 +59,8 @@ describe("View", () => {
   });
 
   it("should render the correct work data", () => {
-    workData.forEach((workObj, index) => cy.testData(workObj, index + 1));
+    workData.forEach((workObj, index) => {
+      cy.testData(workObj, index + 1);
+    });
   });
 });

--- a/cypress/component/forms/formr-part-b/viewSections/ViewSection4.cy.tsx
+++ b/cypress/component/forms/formr-part-b/viewSections/ViewSection4.cy.tsx
@@ -52,7 +52,9 @@ describe("View", () => {
   });
 
   it("should render the correct declaration data", () => {
-    prevDecs.forEach((decObj, index) => cy.testData(decObj, index + 1));
+    prevDecs.forEach((decObj, index) => {
+      cy.testData(decObj, index + 1);
+    });
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.82.5",
+  "version": "0.83.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.82.4",
+      "version": "0.83.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.82.5",
+  "version": "0.83.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/redux/slices/formASlice.ts
+++ b/redux/slices/formASlice.ts
@@ -159,7 +159,10 @@ const formASlice = createSlice({
       .addCase(autoSaveFormA.fulfilled, (state, action) => {
         state.autosaveStatus = "succeeded";
         state.formAData = action.payload;
-        state.autoSaveLatestTimeStamp = DateUtilities.NowToGbDateTimeString();
+        state.autoSaveLatestTimeStamp = DateUtilities.ConvertToLondonTime(
+          action.payload.lastModifiedDate,
+          true
+        );
       })
       .addCase(autoSaveFormA.rejected, state => {
         state.autosaveStatus = "failed";
@@ -170,7 +173,10 @@ const formASlice = createSlice({
       .addCase(autoUpdateFormA.fulfilled, (state, action) => {
         state.autosaveStatus = "succeeded";
         state.formAData = action.payload;
-        state.autoSaveLatestTimeStamp = DateUtilities.NowToGbDateTimeString();
+        state.autoSaveLatestTimeStamp = DateUtilities.ConvertToLondonTime(
+          action.payload.lastModifiedDate,
+          true
+        );
       })
       .addCase(autoUpdateFormA.rejected, state => {
         state.autosaveStatus = "failed";

--- a/redux/slices/formBSlice.ts
+++ b/redux/slices/formBSlice.ts
@@ -184,7 +184,10 @@ const formBSlice = createSlice({
       .addCase(autoSaveFormB.fulfilled, (state, action) => {
         state.autosaveStatus = "succeeded";
         state.formBData = action.payload;
-        state.autoSaveLatestTimeStamp = DateUtilities.NowToGbDateTimeString();
+        state.autoSaveLatestTimeStamp = DateUtilities.ConvertToLondonTime(
+          action.payload.lastModifiedDate,
+          true
+        );
       })
       .addCase(autoSaveFormB.rejected, state => {
         state.autosaveStatus = "failed";
@@ -195,7 +198,10 @@ const formBSlice = createSlice({
       .addCase(autoUpdateFormB.fulfilled, (state, action) => {
         state.autosaveStatus = "succeeded";
         state.formBData = action.payload;
-        state.autoSaveLatestTimeStamp = DateUtilities.NowToGbDateTimeString();
+        state.autoSaveLatestTimeStamp = DateUtilities.ConvertToLondonTime(
+          action.payload.lastModifiedDate,
+          true
+        );
       })
       .addCase(autoUpdateFormB.rejected, state => {
         state.autosaveStatus = "failed";

--- a/utilities/DateUtilities.ts
+++ b/utilities/DateUtilities.ts
@@ -121,6 +121,15 @@ export class DateUtilities {
     return true;
   }
 
+  private static isAmbiguousOctoberDate(date: day.Dayjs): boolean {
+    const octoberDate = day(date).month(9).date(31);
+    const lastSundayInOctober = octoberDate.day(0);
+    return date.isBetween(
+      lastSundayInOctober.hour(1).minute(0),
+      lastSundayInOctober.hour(2).minute(0)
+    );
+  }
+
   public static ConvertToLondonTime(
     givenDate: DateType,
     includeSecs?: boolean
@@ -128,13 +137,20 @@ export class DateUtilities {
     if (!givenDate) return "No date provided";
     const utcDate = day.utc(givenDate);
     if (!utcDate.isValid()) return "Invalid date provided";
-    const londonDate = utcDate.tz("Europe/London");
-    const offset = londonDate.utcOffset();
-    const daylightSavingStr = offset === 0 ? "GMT" : "BST";
-    const formattedLondonDate = londonDate.format(
-      includeSecs ? "DD/MM/YYYY HH:mm:ss" : "DD/MM/YYYY HH:mm"
-    );
-    return `${formattedLondonDate} (${daylightSavingStr})`;
+    const isOctAmbiguous = this.isAmbiguousOctoberDate(utcDate);
+    if (isOctAmbiguous) {
+      return `${utcDate.format(
+        includeSecs ? "DD/MM/YYYY HH:mm:ss" : "DD/MM/YYYY HH:mm"
+      )} (GMT)`;
+    } else {
+      const londonDate = utcDate.tz("Europe/London");
+      const offset = londonDate.utcOffset();
+      const daylightSavingStr = offset === 0 ? "GMT" : "BST";
+      const formattedLondonDate = londonDate.format(
+        includeSecs ? "DD/MM/YYYY HH:mm:ss" : "DD/MM/YYYY HH:mm"
+      );
+      return `${formattedLondonDate} (${daylightSavingStr})`;
+    }
   }
 
   private static gSorter<T>(

--- a/utilities/DateUtilities.ts
+++ b/utilities/DateUtilities.ts
@@ -3,7 +3,11 @@ import isBetween from "dayjs/plugin/isBetween";
 import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
 import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
 import { Placement } from "../models/Placement";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
 
+day.extend(utc);
+day.extend(timezone);
 day.extend(isBetween);
 day.extend(isSameOrBefore);
 day.extend(isSameOrAfter);
@@ -117,17 +121,20 @@ export class DateUtilities {
     return true;
   }
 
-  public static NowToGbDateTimeString() {
-    const timeZoneOptions: any = {
-      timeZone: "Europe/London",
-      hour12: false,
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit"
-    };
-    const gbDate = new Date().toLocaleDateString("en-GB");
-    const gbTime = new Date().toLocaleTimeString("en-GB", timeZoneOptions);
-    return `${gbDate} ${gbTime}`;
+  public static ConvertToLondonTime(
+    givenDate: DateType,
+    includeSecs?: boolean
+  ): string {
+    if (!givenDate) return "No date provided";
+    const utcDate = day.utc(givenDate);
+    if (!utcDate.isValid()) return "Invalid date provided";
+    const londonDate = utcDate.tz("Europe/London");
+    const offset = londonDate.utcOffset();
+    const daylightSavingStr = offset === 0 ? "GMT" : "BST";
+    const formattedLondonDate = londonDate.format(
+      includeSecs ? "DD/MM/YYYY HH:mm:ss" : "DD/MM/YYYY HH:mm"
+    );
+    return `${formattedLondonDate} (${daylightSavingStr})`;
   }
 
   private static gSorter<T>(

--- a/utilities/FormRUtilities.tsx
+++ b/utilities/FormRUtilities.tsx
@@ -21,6 +21,7 @@ import { ProfileToFormRPartAInitialValues } from "../models/ProfileToFormRPartAI
 import { TraineeProfile } from "../models/TraineeProfile";
 import { ProfileToFormRPartBInitialValues } from "../models/ProfileToFormRPartBInitialValues";
 import { DateType, DateUtilities } from "./DateUtilities";
+import { Label } from "nhsuk-react-components";
 export class FormRUtilities {
   public static makeFormRBSections(covidFlag: boolean) {
     if (!covidFlag) return defaultSections;
@@ -64,9 +65,9 @@ export class FormRUtilities {
 
   public static displaySubmissionDate(date: DateType, cyTag: string) {
     return (
-      <h3 data-cy={cyTag}>
-        Form Submitted on: {DateUtilities.ToLocalDate(date)}
-      </h3>
+      <Label data-cy={cyTag}>
+        Form submitted on: {DateUtilities.ConvertToLondonTime(date)}
+      </Label>
     );
   }
 

--- a/utilities/__test__/DateUtilities.test.ts
+++ b/utilities/__test__/DateUtilities.test.ts
@@ -140,12 +140,12 @@ describe("DateUtilities", () => {
     const expectedDate = "29/10/2023 02:00 (GMT)";
     expect(DateUtilities.ConvertToLondonTime(inputDate)).toEqual(expectedDate);
   });
-  it("should return the UK timezone date plus BST for a given date that falls within BST", () => {
+  it("should default to GMT when an ambiguous October UTC date provided", () => {
     const inputDate = new Date("2023-10-29T01:59:59.995683500Z");
-    const expectedDate = "29/10/2023 01:59 (BST)";
+    const expectedDate = "29/10/2023 01:59 (GMT)";
     expect(DateUtilities.ConvertToLondonTime(inputDate)).toEqual(expectedDate);
   });
-  it("should return a valid date for a valid date string type ", () => {
+  it("should return a valid BST date for a valid date string type ", () => {
     const inputDate = "2023-03-26T01:00:00.065683500Z";
     const expectedDate = "26/03/2023 02:00 (BST)";
     expect(DateUtilities.ConvertToLondonTime(inputDate)).toEqual(expectedDate);

--- a/utilities/__test__/DateUtilities.test.ts
+++ b/utilities/__test__/DateUtilities.test.ts
@@ -96,7 +96,6 @@ describe("DateUtilities", () => {
   it("IsMoreThanMinDate should return true if null value ", () => {
     expect(DateUtilities.IsLessThanMaxDate(null)).toEqual(true);
   });
-  // isWithinRange
   it("isWithinRange should return false if given date is undefined", () => {
     expect(isWithinRange(undefined)).toEqual(false);
   });
@@ -136,6 +135,41 @@ describe("DateUtilities", () => {
       DateUtilities.genericSort(mockPlacements, "startDate", false)
     ).toEqual(mockPlacements);
   });
+  it("should return the UK timezone date plus GMT for a given date that falls within GMT", () => {
+    const inputDate = new Date("2023-10-29T02:00:00.995683500Z");
+    const expectedDate = "29/10/2023 02:00 (GMT)";
+    expect(DateUtilities.ConvertToLondonTime(inputDate)).toEqual(expectedDate);
+  });
+  it("should return the UK timezone date plus BST for a given date that falls within BST", () => {
+    const inputDate = new Date("2023-10-29T01:59:59.995683500Z");
+    const expectedDate = "29/10/2023 01:59 (BST)";
+    expect(DateUtilities.ConvertToLondonTime(inputDate)).toEqual(expectedDate);
+  });
+  it("should return a valid date for a valid date string type ", () => {
+    const inputDate = "2023-03-26T01:00:00.065683500Z";
+    const expectedDate = "26/03/2023 02:00 (BST)";
+    expect(DateUtilities.ConvertToLondonTime(inputDate)).toEqual(expectedDate);
+  });
+  it("should return the UK timezone date plus seconds if the includeSecs param is true ", () => {
+    const inputDate = new Date("2023-03-26T00:59:59.065683500Z");
+    const expectedDate = "26/03/2023 00:59:59 (GMT)";
+    expect(DateUtilities.ConvertToLondonTime(inputDate, true)).toEqual(
+      expectedDate
+    );
+  });
+  it("should return No date provided msg for no date ", () => {
+    let inputDate = undefined;
+    const expectedDate = "No date provided";
+    expect(DateUtilities.ConvertToLondonTime(inputDate)).toEqual(expectedDate);
+    inputDate = null;
+    expect(DateUtilities.ConvertToLondonTime(inputDate)).toEqual(expectedDate);
+  });
+  it("should return Invalid date provided msg for invalid date ", () => {
+    const inputDate = "invalid date";
+    const expectedDate = "Invalid date provided";
+    expect(DateUtilities.ConvertToLondonTime(inputDate)).toEqual(expectedDate);
+  });
+
   // Note: Some test conditions covered by cypress comp tests so tried not to duplicate.
   // See coverage.json generated on PR or locally via 'npm run local:report-combined' for more info.
 });


### PR DESCRIPTION
With an eye on the main bit of FE work for the DSP timestamp ticket https://hee-tis.atlassian.net/browse/TIS21-5138, the aim of this ticket is to have a consistent way of displaying the London time zone date/time minus the need to hardcode the time zone part (we currently add 'GMT' to all form submission dates whatever the season which is a bit 💩).

**Proposed solution** 
- Create a function to convert the UTC date to the London time zone (BST/GMT) date..
- Use this function to display a form submission date (without the seconds in the 'time' part as is - but we may want to change this?), and an autosave timestamp (with the seconds included in the 'time' part as is).
- The function now checks if the given date falls within an “ambiguous” period (between 1am and 2am on the last Sunday in October - which technically occurs  twice due to the change from BST to GMT. ). If the date is ambiguous then 'GMT' is appended to the end of the date string (as is the case now via hardcoded 'GMT')

NO TICKET 
