### PR TITLE
fix: Build Type error

### DIFF
--- a/components/dsp/DspIssueBtn.tsx
+++ b/components/dsp/DspIssueBtn.tsx
@@ -128,9 +128,11 @@ function chooseProfileArr(pName: string, id: string) {
     pName === TraineeProfileName.Programmes
       ? store.getState().traineeProfile.traineeProfileData.programmeMemberships
       : store.getState().traineeProfile.traineeProfileData.placements;
-  const matchedProfile = profileArr.find(
+  const matchedIndex = profileArr.findIndex(
     (pObj: ProfileType) => pObj.tisId === id
   );
+  const matchedProfile = profileArr[matchedIndex];
+
   if (matchedProfile) store.dispatch(updatedDspPanelObj(matchedProfile));
 }
 

--- a/cypress/component/dsp/CredentialIssue.cy.tsx
+++ b/cypress/component/dsp/CredentialIssue.cy.tsx
@@ -10,8 +10,9 @@ import {
 } from "../../../redux/slices/dspSlice";
 import { mount } from "cypress/react18";
 import RenderSearchParams from "./RenderSearchParams";
+import { ProfileType } from "../../../models/TraineeProfile";
 
-const panelData = {
+const panelData: ProfileType = {
   tisId: "321",
   programmeTisId: "2",
   programmeName: "General Practice",
@@ -19,7 +20,8 @@ const panelData = {
   startDate: "2020-01-01",
   endDate: "2028-01-01",
   managingDeanery: "West of England",
-  curricula: []
+  curricula: [],
+  conditionsOfJoining: { signedAt: new Date(), version: "blaa" }
 };
 
 describe("CredentialIssue", () => {

--- a/cypress/component/dsp/CredentialIssued.cy.tsx
+++ b/cypress/component/dsp/CredentialIssued.cy.tsx
@@ -17,7 +17,8 @@ const panelData = {
   startDate: "2020-01-01",
   endDate: "2028-01-01",
   managingDeanery: "West of England",
-  curricula: []
+  curricula: [],
+  conditionsOfJoining: { signedAt: new Date(), version: "blaa" }
 };
 
 describe("CredentialIssued success", () => {

--- a/cypress/component/dsp/CredentialVerify.cy.tsx
+++ b/cypress/component/dsp/CredentialVerify.cy.tsx
@@ -17,7 +17,8 @@ const panelData = {
   startDate: "2020-01-01",
   endDate: "2028-01-01",
   managingDeanery: "West of England",
-  curricula: []
+  curricula: [],
+  conditionsOfJoining: { signedAt: new Date(), version: "blaa" }
 };
 
 describe("CredentialVerify", () => {

--- a/mock-data/dsp-credentials.ts
+++ b/mock-data/dsp-credentials.ts
@@ -6,16 +6,14 @@ export const mockDspPlacementCredentials: CredentialDsp[] = [
     traineeId: "3bd3f009-9c7a-4352-bcc6-9dff8eac07d6",
     credentialType: "issue.TrainingPlacement",
     tisId: "99",
-    issuedAt: new Date("2023-07-28T17:40:54.000+00:00"),
-    revokedAt: undefined
+    issuedAt: new Date("2023-07-28T17:40:54.000+00:00")
   },
   {
     credentialId: "911850c6-66c7-47ac-b78a-b54688a748b7",
     traineeId: "11111",
     credentialType: "issue.TrainingPlacement",
     tisId: "1",
-    issuedAt: new Date("2023-07-28T17:40:54.000+00:00"),
-    revokedAt: null
+    issuedAt: new Date("2023-07-28T17:40:54.000+00:00")
   },
   {
     credentialId: "33ccc908-1439-11ee-be56-0242ac120002",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.84.0",
+  "version": "0.84.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",


### PR DESCRIPTION
Replace .find with .findIndex in chooseProfileArr (DspIssueBtn.tsx) - which plays nicely with union types.

Fix a few more non-blocking Type errors in the test files and tidy-up the dsp-credential mock data (no need for revokedAt null value and explicitly typed undefined in the CredentialDsp object).