### PR TITLE
fix: TOOT limited to 999

### DIFF
--- a/components/forms/formr-part-b/ValidationSchema.ts
+++ b/components/forms/formr-part-b/ValidationSchema.ts
@@ -14,7 +14,7 @@ const leaveValidation = (fieldName: string) =>
     .integer(`${fieldName} must be rounded up to a whole number`)
     .typeError(`${fieldName} must be a positive number or zero`)
     .min(0, `${fieldName} must be a positive number or zero`)
-    .max(999, `${fieldName} must not be more than 999`)
+    .max(9999, `${fieldName} must not be more than 9999`)
     .required(`${fieldName} is required`);
 
 const panelSchema = yup.object({

--- a/cypress/component/forms/formr-part-b/Section2.cy.tsx
+++ b/cypress/component/forms/formr-part-b/Section2.cy.tsx
@@ -84,6 +84,15 @@ describe("Section2", () => {
       "Short and Long-term sickness absence must be rounded up to a whole number"
     );
 
+    cy.get("[data-cy=sicknessAbsence]").clear().type("99999");
+    cy.get("#sicknessAbsence--error-message").should(
+      "contain.text",
+      "Short and Long-term sickness absence must not be more than 9999"
+    );
+
+    cy.get("[data-cy=sicknessAbsence]").clear().type("9999");
+    cy.get("#sicknessAbsence--error-message").should("not.exist");
+
     cy.get("[data-cy=sicknessAbsence]").click().clear().type("1");
     cy.get("#sicknessAbsence--error-message").should("not.exist");
     cy.get("[data-cy=otherLeave]").click().clear().type("1");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.84.2",
+  "version": "0.84.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.84.2",
+  "version": "0.84.3",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",


### PR DESCRIPTION
The TOOT fields are limited to three digits, but that is too restrictive for those that may have been on long term leave between Form R submissions.
Increase the limit to 9999, allowing any four digit number gives a large maximum without having to pick an arbitrary limit. Maintaining at least some restriction avoids obvious mistakes or bad data being entered.

TIS21-5293