### PR TITLE
chore: remove deprecated 'next export'

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,8 @@ const nextConfig = {
   sassOptions: {
     includePaths: [path.join(__dirname, "styles")]
   },
-  swcMinify: true
+  swcMinify: true,
+  output: "export"
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.85.2",
+  "version": "0.85.3",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",
@@ -84,7 +84,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "bash build.sh && next export",
+    "build": "bash build.sh",
     "start": "next start",
     "lint": "next lint",
     "stylelint": "stylelint \"**/*.scss\" \"**/*.css\" --fix",


### PR DESCRIPTION
⚠ "next export" is deprecated in favor of "output: export" in next.config.js https://nextjs.org/docs/advanced-features/static-html-export

TIS21-5307