### PR TITLE
build: update sonar action version

### DIFF
--- a/.github/workflows/pr-analysis.yml
+++ b/.github/workflows/pr-analysis.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Analyse quality
         if: steps.check-files.outputs.do-analysis == 'true'
-        uses: SonarSource/sonarcloud-github-action@v1.9
+        uses: SonarSource/sonarcloud-github-action@v2.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Sonar will shortly stop accepting scans done using java version 11.
Update the sonarcloud action to use the latest.

TIS21-SHED