### PR TITLE
Add Action Summary (home) and Alert (other pages)

### DIFF
--- a/components/forms/CreateList.tsx
+++ b/components/forms/CreateList.tsx
@@ -21,7 +21,6 @@ import {
 } from "../../redux/slices/formBSlice";
 import { Col, Container, Row } from "nhsuk-react-components";
 import { StartOverButton } from "./StartOverButton";
-import path from "path";
 
 const CreateList = () => {
   const dispatch = useAppDispatch();

--- a/components/forms/CreateList.tsx
+++ b/components/forms/CreateList.tsx
@@ -11,10 +11,17 @@ import { fetchFeatureFlags } from "../../redux/slices/featureFlagsSlice";
 import FormsListBtn from "../../components/forms/FormsListBtn";
 import { useLocation } from "react-router-dom";
 import SubmittedFormsList from "../../components/forms/SubmittedFormsList";
-import { resetToInitFormA } from "../../redux/slices/formASlice";
-import { resetToInitFormB } from "../../redux/slices/formBSlice";
+import {
+  resetToInitFormA,
+  updatedFormAStatus
+} from "../../redux/slices/formASlice";
+import {
+  resetToInitFormB,
+  updatedFormBStatus
+} from "../../redux/slices/formBSlice";
 import { Col, Container, Row } from "nhsuk-react-components";
 import { StartOverButton } from "./StartOverButton";
+import path from "path";
 
 const CreateList = () => {
   const dispatch = useAppDispatch();
@@ -33,6 +40,9 @@ const CreateList = () => {
   useEffect(() => {
     dispatch(fetchForms(pathname));
     dispatch(updatedFormsRefreshNeeded(false));
+    if (pathname === "/formr-a") {
+      dispatch(updatedFormAStatus("idle"));
+    } else dispatch(updatedFormBStatus("idle"));
   }, [dispatch, pathname, needFormsRefresh]);
 
   useEffect(() => {

--- a/components/forms/conditionOfJoining/CojView.tsx
+++ b/components/forms/conditionOfJoining/CojView.tsx
@@ -1,6 +1,9 @@
 import { Formik } from "formik";
 import { Button, SummaryList } from "nhsuk-react-components";
-import { signCoj } from "../../../redux/slices/traineeProfileSlice";
+import {
+  signCoj,
+  updatedTraineeProfileStatus
+} from "../../../redux/slices/traineeProfileSlice";
 import store from "../../../redux/store/store";
 import history from "../../navigation/history";
 import MultiChoiceInputField from "../MultiChoiceInputField";
@@ -15,9 +18,11 @@ import { DateUtilities } from "../../../utilities/DateUtilities";
 import FormSavePDF from "../FormSavePDF";
 
 export default function CojView() {
-  const signingCoj = store.getState().user.signingCoj;
-  const progName = store.getState().user.signingCojProgName;
-  const signedDate = store.getState().user.signingCojSignedDate;
+  const {
+    signingCojProgName: progName,
+    signingCojSignedDate: signedDate,
+    signingCoj
+  } = store.getState().user;
 
   if (!signingCoj) return <Redirect to="/programmes" />;
   return progName ? (
@@ -57,6 +62,7 @@ function CojDeclarationSection({
         const signingCojPmId = store.getState().user.signingCojPmId;
         await store.dispatch(signCoj(signingCojPmId));
         store.dispatch(updatedsigningCoj(false));
+        store.dispatch(updatedTraineeProfileStatus("idle"));
         history.push("/programmes");
       }}
     >

--- a/components/home/Home.tsx
+++ b/components/home/Home.tsx
@@ -5,6 +5,9 @@ import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
 import { resetMfaJourney } from "../../redux/slices/userSlice";
 import history from "../navigation/history";
 import style from "../Common.module.scss";
+import ActionSummary from "./actionSummary/ActionSummary";
+import { loadFormAList } from "../../redux/slices/formASlice";
+import { loadFormBList } from "../../redux/slices/formBSlice";
 
 const handleClick = (route: string) => history.push(route);
 
@@ -22,6 +25,11 @@ const Home = () => {
     dispatch(resetMfaJourney());
   }, [dispatch]);
 
+  useEffect(() => {
+    dispatch(loadFormAList());
+    dispatch(loadFormBList());
+  }, [dispatch]);
+
   const preferredMfa = useAppSelector(state => state.user.preferredMfa);
 
   if (preferredMfa === "NOMFA") {
@@ -29,6 +37,7 @@ const Home = () => {
   }
   return (
     <div className="nhsuk-width-container nhsuk-u-margin-top-5">
+      <ActionSummary />
       <Card.Group>
         <Card.GroupItem width="one-third">
           <PageCard isClickable={true} route="/profile" linkHeader="Profile">

--- a/components/home/HomeHeaderSection.tsx
+++ b/components/home/HomeHeaderSection.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "react";
-import GlobalAlert from "../main/GlobalAlert";
 import { TssUpdates } from "./TssUpdates";
 import { useAppDispatch } from "../../redux/hooks/hooks";
 import { fetchWhatsNew } from "../../redux/slices/tssUpdatesSlice";
@@ -12,44 +11,41 @@ export const HomeHeaderSection = () => {
   }, [dispatch]);
 
   return (
-    <>
-      <section className="nhsuk-hero">
-        <div className="nhsuk-width-container nhsuk-hero--border app-width-container">
-          <div className="nhsuk-grid-row">
-            <div className="nhsuk-grid-column-two-thirds">
-              <div className="nhsuk-hero__wrapper app-hero__wrapper">
-                <h1
-                  data-cy="homeWelcomeHeaderText"
-                  className="nhsuk-u-margin-bottom-4"
-                >
-                  Welcome to
-                  <br />
-                  TIS Self-Service
-                </h1>
-                <p
-                  data-cy="homeWelcomeSubHeaderText"
-                  className="nhsuk-body-l nhsuk-u-margin-bottom-1"
-                >
-                  Your post-graduate training programme resource
-                </p>
-                <p
-                  data-cy="homeWelcomeBodyText"
-                  className="nhsuk-body-m nhsuk-u-margin-bottom-1"
-                >
-                  Our goal is to improve your training experience by making TIS
-                  Self-Service a one-stop-shop for your training-related admin
-                  tasks. We are in the Private Beta phase of delivery so expect
-                  more features soon.
-                </p>
-              </div>
-            </div>
-            <div className="nhsuk-grid-column-one-third tss-update-column">
-              <TssUpdates />
+    <section className="nhsuk-hero">
+      <div className="nhsuk-width-container nhsuk-hero--border app-width-container">
+        <div className="nhsuk-grid-row">
+          <div className="nhsuk-grid-column-two-thirds">
+            <div className="nhsuk-hero__wrapper app-hero__wrapper">
+              <h1
+                data-cy="homeWelcomeHeaderText"
+                className="nhsuk-u-margin-bottom-4"
+              >
+                Welcome to
+                <br />
+                TIS Self-Service
+              </h1>
+              <p
+                data-cy="homeWelcomeSubHeaderText"
+                className="nhsuk-body-l nhsuk-u-margin-bottom-1"
+              >
+                Your post-graduate training programme resource
+              </p>
+              <p
+                data-cy="homeWelcomeBodyText"
+                className="nhsuk-body-m nhsuk-u-margin-bottom-1"
+              >
+                Our goal is to improve your training experience by making TIS
+                Self-Service a one-stop-shop for your training-related admin
+                tasks. We are in the Private Beta phase of delivery so expect
+                more features soon.
+              </p>
             </div>
           </div>
+          <div className="nhsuk-grid-column-one-third tss-update-column">
+            <TssUpdates />
+          </div>
         </div>
-      </section>
-      <GlobalAlert />
-    </>
+      </div>
+    </section>
   );
 };

--- a/components/home/HomeHeaderSection.tsx
+++ b/components/home/HomeHeaderSection.tsx
@@ -1,51 +1,88 @@
 import { useEffect } from "react";
-import { TssUpdates } from "./TssUpdates";
+import { TssUpdates, WhatsNewHeader } from "./TssUpdates";
 import { useAppDispatch } from "../../redux/hooks/hooks";
 import { fetchWhatsNew } from "../../redux/slices/tssUpdatesSlice";
+import { useIsMobile } from "../../utilities/hooks/useIsMobile";
 
 export const HomeHeaderSection = () => {
   const dispatch = useAppDispatch();
+  const isMobile = useIsMobile();
 
   useEffect(() => {
-    dispatch(fetchWhatsNew());
-  }, [dispatch]);
+    if (!isMobile) dispatch(fetchWhatsNew());
+  }, [dispatch, isMobile]);
 
   return (
     <section className="nhsuk-hero">
       <div className="nhsuk-width-container nhsuk-hero--border app-width-container">
         <div className="nhsuk-grid-row">
-          <div className="nhsuk-grid-column-two-thirds">
-            <div className="nhsuk-hero__wrapper app-hero__wrapper">
-              <h1
-                data-cy="homeWelcomeHeaderText"
-                className="nhsuk-u-margin-bottom-4"
-              >
-                Welcome to
-                <br />
-                TIS Self-Service
-              </h1>
-              <p
-                data-cy="homeWelcomeSubHeaderText"
-                className="nhsuk-body-l nhsuk-u-margin-bottom-1"
-              >
-                Your post-graduate training programme resource
-              </p>
-              <p
-                data-cy="homeWelcomeBodyText"
-                className="nhsuk-body-m nhsuk-u-margin-bottom-1"
-              >
-                Our goal is to improve your training experience by making TIS
-                Self-Service a one-stop-shop for your training-related admin
-                tasks. We are in the Private Beta phase of delivery so expect
-                more features soon.
-              </p>
+          <div
+            className={
+              isMobile
+                ? "nhsuk-grid-column-full"
+                : "nhsuk-grid-column-two-thirds"
+            }
+          >
+            <div
+              className={
+                isMobile
+                  ? "header-wrapper"
+                  : "nhsuk-hero__wrapper app-hero__wrapper"
+              }
+            >
+              <HomeWelcomeHeaderText />
+              <HomeWelcomeSubHeaderText />
+              {isMobile ? (
+                <>
+                  <br />
+                  <WhatsNewHeader />
+                </>
+              ) : (
+                <HomeWelcomeBodyText />
+              )}
             </div>
           </div>
-          <div className="nhsuk-grid-column-one-third tss-update-column">
-            <TssUpdates />
-          </div>
+          {!isMobile && (
+            <div className="nhsuk-grid-column-one-third tss-update-column">
+              <TssUpdates />
+            </div>
+          )}
         </div>
       </div>
     </section>
   );
 };
+
+function HomeWelcomeHeaderText() {
+  return (
+    <h1 data-cy="homeWelcomeHeaderText" className="nhsuk-u-margin-bottom-4">
+      Welcome to
+      <br />
+      TIS Self-Service
+    </h1>
+  );
+}
+
+function HomeWelcomeSubHeaderText() {
+  return (
+    <p
+      data-cy="homeWelcomeSubHeaderText"
+      className="nhsuk-body-l nhsuk-u-margin-bottom-1"
+    >
+      Your post-graduate training programme resource
+    </p>
+  );
+}
+
+function HomeWelcomeBodyText() {
+  return (
+    <p
+      data-cy="homeWelcomeBodyText"
+      className="nhsuk-body-m nhsuk-u-margin-bottom-1"
+    >
+      Our goal is to improve your training experience by making TIS Self-Service
+      a one-stop-shop for your training-related admin tasks. We are in the
+      Private Beta phase of delivery so expect more features soon.
+    </p>
+  );
+}

--- a/components/home/TssUpdates.tsx
+++ b/components/home/TssUpdates.tsx
@@ -76,21 +76,21 @@ function extractTextFromHTML(html: string): string {
   return html;
 }
 
-function WhatsNewHeader(): JSX.Element {
+export function WhatsNewHeader(): JSX.Element {
   const wpUpdatesUrl =
     "https://tis-support.hee.nhs.uk/about-tis/welcome-to-the-tss-updates/";
   return (
-    <h2 data-cy="whatsNewHeader">
+    <p data-cy="whatsNewHeader" className="nhsuk-header whats-new-header">
       <a
         data-cy="anchorEl_What's New"
         title="Click here for more details"
-        className="nhsuk-link custom-link"
+        className="nhsuk-link custom-link whats-new-link"
         href={wpUpdatesUrl}
         target="_blank"
         rel="noopener noreferrer"
       >
         What&apos;s New
       </a>
-    </h2>
+    </p>
   );
 }

--- a/components/home/actionSummary/ActionSummary.tsx
+++ b/components/home/actionSummary/ActionSummary.tsx
@@ -122,7 +122,7 @@ export default function ActionSummary() {
                       <FormMessage
                         formType="A"
                         message="infoLatestSubFormRWithinYear"
-                        latestSubFormDate={DateUtilities.ConvertToLondonTime(
+                        latestSubFormDate={DateUtilities.ToLocalDate(
                           infoActionsA.latestSubDateForm
                         )}
                       />
@@ -133,7 +133,7 @@ export default function ActionSummary() {
                       <FormMessage
                         formType="A"
                         message="infoLatestSubFormRYearPlus"
-                        latestSubFormDate={DateUtilities.ConvertToLondonTime(
+                        latestSubFormDate={DateUtilities.ToLocalDate(
                           infoActionsA.latestSubDateForm
                         )}
                       />
@@ -157,7 +157,7 @@ export default function ActionSummary() {
                       <FormMessage
                         formType="B"
                         message="infoLatestSubFormRWithinYear"
-                        latestSubFormDate={DateUtilities.ConvertToLondonTime(
+                        latestSubFormDate={DateUtilities.ToLocalDate(
                           infoActionsB.latestSubDateForm
                         )}
                       />
@@ -168,7 +168,7 @@ export default function ActionSummary() {
                       <FormMessage
                         formType="B"
                         message="infoLatestSubFormRYearPlus"
-                        latestSubFormDate={DateUtilities.ConvertToLondonTime(
+                        latestSubFormDate={DateUtilities.ToLocalDate(
                           infoActionsB.latestSubDateForm
                         )}
                       />

--- a/components/home/actionSummary/ActionSummary.tsx
+++ b/components/home/actionSummary/ActionSummary.tsx
@@ -116,7 +116,7 @@ export default function ActionSummary() {
                     <FormMessage formType="A" message="infoNoFormEver" />
                   )}
                   {/* **** Form A - SUBMITTED ****/}
-                  {/* **** Form A - LATEST SUB DATE WITHIN LAST YEAR****/}
+                  {/* **** Form A - LATEST SUB DATE WITHIN LAST YEAR ****/}
                   {infoActionsA.latestSubDateForm &&
                     infoActionsA.isForInfoWithinYearSubForm && (
                       <FormMessage
@@ -151,7 +151,7 @@ export default function ActionSummary() {
                     <FormMessage formType="B" message="infoNoFormEver" />
                   )}
                   {/* **** Form B - SUBMITTED ****/}
-                  {/* **** Form B - WITHIN LAST YEAR ****/}
+                  {/* **** Form B - LATEST SUB DATE WITHIN LAST YEAR ****/}
                   {infoActionsB.latestSubDateForm &&
                     infoActionsB.isForInfoWithinYearSubForm && (
                       <FormMessage
@@ -162,7 +162,7 @@ export default function ActionSummary() {
                         )}
                       />
                     )}
-                  {/* **** Form B - MORE THAN YEAR AGO ****/}
+                  {/* **** Form B - LATEST SUB DATE YEAR PLUS ****/}
                   {infoActionsB.latestSubDateForm &&
                     infoActionsB.isForInfoYearPlusSubForm && (
                       <FormMessage

--- a/components/home/actionSummary/ActionSummary.tsx
+++ b/components/home/actionSummary/ActionSummary.tsx
@@ -188,7 +188,7 @@ export default function ActionSummary() {
                         <Label size="l" style={{ color: "#005EB8" }}>
                           Form R (Part A)
                         </Label>
-                        <FormMessage formType="A" message="in progress" />
+                        <FormMessage formType="A" message="inProgress" />
                       </>
                     )}
                     {isInProgressFormB && (
@@ -196,7 +196,7 @@ export default function ActionSummary() {
                         <Label size="l" style={{ color: "#005EB8" }}>
                           Form R (Part B)
                         </Label>
-                        <FormMessage formType="B" message="in progress" />
+                        <FormMessage formType="B" message="inProgress" />
                       </>
                     )}
                     {!isInProgressFormA && !isInProgressFormB && (

--- a/components/home/actionSummary/ActionSummary.tsx
+++ b/components/home/actionSummary/ActionSummary.tsx
@@ -1,0 +1,238 @@
+import { Card, Fieldset, Label } from "nhsuk-react-components";
+import { useAppSelector } from "../../../redux/hooks/hooks";
+import { Link } from "react-router-dom";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faCheckCircle,
+  faExclamationCircle,
+  faQuestionCircle
+} from "@fortawesome/free-solid-svg-icons";
+import Loading from "../../common/Loading";
+import style from "../../Common.module.scss";
+import FormMessage from "./FormMessage";
+import { DateUtilities } from "../../../utilities/DateUtilities";
+import { useOutstandingActions } from "../../../utilities/hooks/action-summary/useOutstandingActions";
+import { useInfoActions } from "../../../utilities/hooks/action-summary/useInfoActions";
+import { useInProgressActions } from "../../../utilities/hooks/action-summary/useInProgressActions";
+import DataSourceMsg from "../../common/DataSourceMsg";
+
+export default function ActionSummary() {
+  // OUTSTANDING ACTIONS
+  const { unsignedCojCount } = useOutstandingActions(); // Note: noSubFormRA and noSubFormRB conditions are in the 'Form R submissions' section for now.
+
+  // IN PROGRESS
+  const { isInProgressFormA, isInProgressFormB } = useInProgressActions();
+
+  // FOR INFORMATION
+  const { noSubFormRA, noSubFormRB, infoActionsA, infoActionsB } =
+    useInfoActions();
+
+  const isformRListLoading = useAppSelector(
+    state =>
+      state.formA.status === "loading" || state.formB.status === "loading"
+  );
+
+  if (isformRListLoading) return <Loading />;
+
+  return (
+    <div>
+      <Fieldset>
+        <Fieldset.Legend
+          isPageHeading
+          className={style.fieldLegHeader}
+          data-cy="actionSummaryHeading"
+        >
+          Action Summary
+        </Fieldset.Legend>
+      </Fieldset>
+      <Card.Group>
+        <Card.GroupItem width="full">
+          <Card>
+            <Card.Content>
+              <Card feature>
+                <Card.Content>
+                  <Card.Heading>Outstanding</Card.Heading>
+                  {/* ----------------- outstanding ------------- */}
+                  {/* **** COJ unsigned ********* */}
+                  <ul className="no-bullet">
+                    <Label size="l" style={{ color: "#005EB8" }}>
+                      Conditions of Joining (Programme)
+                    </Label>
+                    {unsignedCojCount > 0 && (
+                      <li>
+                        <Label size="s">
+                          <FontAwesomeIcon
+                            icon={faExclamationCircle}
+                            color="#DA291C"
+                            size="lg"
+                          />{" "}
+                          You have {unsignedCojCount} unsigned{" "}
+                          <Link to="/programmes">
+                            {`Conditions of Joining Agreement${
+                              unsignedCojCount > 0 ? "s" : ""
+                            }`}
+                          </Link>
+                          .
+                        </Label>
+                      </li>
+                    )}
+                    {unsignedCojCount < 1 && (
+                      <li>
+                        <Label size="s">
+                          <FontAwesomeIcon
+                            icon={faCheckCircle}
+                            color="#007F3B"
+                            size="lg"
+                          />{" "}
+                          All your{" "}
+                          <Link to="/programmes">
+                            Conditions of Joining Agreements
+                          </Link>{" "}
+                          are signed.
+                        </Label>
+                      </li>
+                    )}
+                  </ul>
+                </Card.Content>
+              </Card>
+              {/* ----------------- For information ---------------------- */}
+              <Card feature>
+                <Card.Content>
+                  <Card.Heading>Form R submissions</Card.Heading>
+                  {/* **** Form A - LABEL ****/}
+                  <Label size="l" style={{ color: "#005EB8" }}>
+                    Form R (Part A)
+                  </Label>
+                  {/* **** Form A - NO SUB ****/}
+                  {noSubFormRA && (
+                    <FormMessage formType="A" message="infoNoFormEver" />
+                  )}
+                  {/* **** Form A - SUBMITTED ****/}
+                  {/* **** Form A - LATEST SUB DATE WITHIN LAST YEAR****/}
+                  {infoActionsA.latestSubDateForm &&
+                    infoActionsA.isForInfoWithinYearSubForm && (
+                      <FormMessage
+                        formType="A"
+                        message="infoLatestSubFormRWithinYear"
+                        latestSubFormDate={DateUtilities.ConvertToLondonTime(
+                          infoActionsA.latestSubDateForm
+                        )}
+                      />
+                    )}
+                  {/* **** Form A - LATEST SUB DATE MORE THAN YEAR AGO ****/}
+                  {infoActionsA.latestSubDateForm &&
+                    infoActionsA.isForInfoMoreThanYearSubForm && (
+                      <FormMessage
+                        formType="A"
+                        message="infoLatestSubFormRMoreThanYear"
+                        latestSubFormDate={DateUtilities.ConvertToLondonTime(
+                          infoActionsA.latestSubDateForm
+                        )}
+                      />
+                    )}
+                  {/* **** Form B - LABEL ****/}
+                  <Label size="l" style={{ color: "#005EB8" }}>
+                    Form R (Part B)
+                  </Label>
+                  {/* **** Form B - NO SUB ****/}
+                  {noSubFormRB && (
+                    <FormMessage formType="B" message="infoNoFormEver" />
+                  )}
+                  {/* **** Form B - SUBMITTED ****/}
+                  {/* **** Form B - WITHIN LAST YEAR ****/}
+                  {infoActionsB.latestSubDateForm &&
+                    infoActionsB.isForInfoWithinYearSubForm && (
+                      <FormMessage
+                        formType="B"
+                        message="infoLatestSubFormRWithinYear"
+                        latestSubFormDate={DateUtilities.ConvertToLondonTime(
+                          infoActionsB.latestSubDateForm
+                        )}
+                      />
+                    )}
+                  {/* **** Form B - MORE THAN YEAR AGO ****/}
+                  {infoActionsB.latestSubDateForm &&
+                    infoActionsB.isForInfoMoreThanYearSubForm && (
+                      <FormMessage
+                        formType="B"
+                        message="infoLatestSubFormRMoreThanYear"
+                        latestSubFormDate={DateUtilities.ConvertToLondonTime(
+                          infoActionsB.latestSubDateForm
+                        )}
+                      />
+                    )}
+                </Card.Content>
+              </Card>
+              {/* ----------------- In progress ---------------------- */}
+              <Card feature>
+                <Card.Content>
+                  <Card.Heading>In progress</Card.Heading>
+
+                  <ul className="no-bullet">
+                    {isInProgressFormA && (
+                      <>
+                        <Label size="l" style={{ color: "#005EB8" }}>
+                          Form R (Part A)
+                        </Label>
+                        <FormMessage formType="A" message="in progress" />
+                      </>
+                    )}
+                    {isInProgressFormB && (
+                      <>
+                        <Label size="l" style={{ color: "#005EB8" }}>
+                          Form R (Part B)
+                        </Label>
+                        <FormMessage formType="B" message="in progress" />
+                      </>
+                    )}
+                    {!isInProgressFormA && !isInProgressFormB && (
+                      <>
+                        <Label size="l" style={{ color: "#005EB8" }}>
+                          Form R
+                        </Label>
+                        <li>
+                          <Label size="s">
+                            <FontAwesomeIcon
+                              icon={faCheckCircle}
+                              color="#007F3B"
+                              size="lg"
+                            />{" "}
+                            You have no saved draft forms.
+                          </Label>
+                        </li>
+                      </>
+                    )}
+                  </ul>
+                </Card.Content>
+              </Card>
+              <Card feature>
+                <Card.Content>
+                  <Card.Heading>Other checks</Card.Heading>
+                  <ul className="no-bullet">
+                    <li>
+                      <Label size="s">
+                        <FontAwesomeIcon
+                          icon={faQuestionCircle}
+                          color="#005EB8"
+                          size="lg"
+                        />{" "}
+                        <>
+                          Are your <Link to="/profile">Profile details</Link>,{" "}
+                          <Link to="/placements">Placements</Link>, and{" "}
+                          <Link to="/programmes">Programmes</Link> correct and
+                          up-to-date?
+                        </>
+                      </Label>
+                    </li>
+                  </ul>
+                  <DataSourceMsg />
+                </Card.Content>
+              </Card>
+            </Card.Content>
+          </Card>
+        </Card.GroupItem>
+        <Card.GroupItem width="full"></Card.GroupItem>
+      </Card.Group>
+    </div>
+  );
+}

--- a/components/home/actionSummary/ActionSummary.tsx
+++ b/components/home/actionSummary/ActionSummary.tsx
@@ -71,7 +71,7 @@ export default function ActionSummary() {
                           You have {unsignedCojCount} unsigned{" "}
                           <Link to="/programmes">
                             {`Conditions of Joining Agreement${
-                              unsignedCojCount > 0 ? "s" : ""
+                              unsignedCojCount > 1 ? "s" : ""
                             }`}
                           </Link>
                           .

--- a/components/home/actionSummary/ActionSummary.tsx
+++ b/components/home/actionSummary/ActionSummary.tsx
@@ -20,12 +20,12 @@ export default function ActionSummary() {
   // OUTSTANDING ACTIONS
   const { unsignedCojCount } = useOutstandingActions(); // Note: noSubFormRA and noSubFormRB conditions are in the 'Form R submissions' section for now.
 
-  // IN PROGRESS
-  const { isInProgressFormA, isInProgressFormB } = useInProgressActions();
-
-  // FOR INFORMATION
+  // FORM R SUBMISSIONS (FOR INFO)
   const { noSubFormRA, noSubFormRB, infoActionsA, infoActionsB } =
     useInfoActions();
+
+  // IN PROGRESS
+  const { isInProgressFormA, isInProgressFormB } = useInProgressActions();
 
   const isformRListLoading = useAppSelector(
     state =>
@@ -35,7 +35,7 @@ export default function ActionSummary() {
   if (isformRListLoading) return <Loading />;
 
   return (
-    <div>
+    <div data-cy="actionSummary">
       <Fieldset>
         <Fieldset.Legend
           isPageHeading
@@ -51,7 +51,9 @@ export default function ActionSummary() {
             <Card.Content>
               <Card feature>
                 <Card.Content>
-                  <Card.Heading>Outstanding</Card.Heading>
+                  <Card.Heading data-cy="outstandingHeading">
+                    Outstanding
+                  </Card.Heading>
                   {/* ----------------- outstanding ------------- */}
                   {/* **** COJ unsigned ********* */}
                   <ul className="no-bullet">
@@ -59,7 +61,7 @@ export default function ActionSummary() {
                       Conditions of Joining (Programme)
                     </Label>
                     {unsignedCojCount > 0 && (
-                      <li>
+                      <li data-cy="unsignedCoJ">
                         <Label size="s">
                           <FontAwesomeIcon
                             icon={faExclamationCircle}
@@ -77,7 +79,7 @@ export default function ActionSummary() {
                       </li>
                     )}
                     {unsignedCojCount < 1 && (
-                      <li>
+                      <li data-cy="allCoJSigned">
                         <Label size="s">
                           <FontAwesomeIcon
                             icon={faCheckCircle}
@@ -95,12 +97,18 @@ export default function ActionSummary() {
                   </ul>
                 </Card.Content>
               </Card>
-              {/* ----------------- For information ---------------------- */}
+              {/* ----------------- Form R submissions (for info) ------ */}
               <Card feature>
                 <Card.Content>
-                  <Card.Heading>Form R submissions</Card.Heading>
+                  <Card.Heading data-cy="formRSubsHeading">
+                    Form R submissions
+                  </Card.Heading>
                   {/* **** Form A - LABEL ****/}
-                  <Label size="l" style={{ color: "#005EB8" }}>
+                  <Label
+                    size="l"
+                    style={{ color: "#005EB8" }}
+                    data-cy="formASubHeader"
+                  >
                     Form R (Part A)
                   </Label>
                   {/* **** Form A - NO SUB ****/}
@@ -131,7 +139,11 @@ export default function ActionSummary() {
                       />
                     )}
                   {/* **** Form B - LABEL ****/}
-                  <Label size="l" style={{ color: "#005EB8" }}>
+                  <Label
+                    size="l"
+                    style={{ color: "#005EB8" }}
+                    data-cy="formASubHeader"
+                  >
                     Form R (Part B)
                   </Label>
                   {/* **** Form B - NO SUB ****/}
@@ -166,7 +178,9 @@ export default function ActionSummary() {
               {/* ----------------- In progress ---------------------- */}
               <Card feature>
                 <Card.Content>
-                  <Card.Heading>In progress</Card.Heading>
+                  <Card.Heading data-cy="inProgressHeading">
+                    In progress
+                  </Card.Heading>
 
                   <ul className="no-bullet">
                     {isInProgressFormA && (
@@ -207,7 +221,9 @@ export default function ActionSummary() {
               </Card>
               <Card feature>
                 <Card.Content>
-                  <Card.Heading>Other checks</Card.Heading>
+                  <Card.Heading data-cy="otherChecksHeading">
+                    Other checks
+                  </Card.Heading>
                   <ul className="no-bullet">
                     <li>
                       <Label size="s">

--- a/components/home/actionSummary/ActionSummary.tsx
+++ b/components/home/actionSummary/ActionSummary.tsx
@@ -127,12 +127,12 @@ export default function ActionSummary() {
                         )}
                       />
                     )}
-                  {/* **** Form A - LATEST SUB DATE MORE THAN YEAR AGO ****/}
+                  {/* **** Form A - LATEST SUB DATE YEAR PLUS ****/}
                   {infoActionsA.latestSubDateForm &&
-                    infoActionsA.isForInfoMoreThanYearSubForm && (
+                    infoActionsA.isForInfoYearPlusSubForm && (
                       <FormMessage
                         formType="A"
-                        message="infoLatestSubFormRMoreThanYear"
+                        message="infoLatestSubFormRYearPlus"
                         latestSubFormDate={DateUtilities.ConvertToLondonTime(
                           infoActionsA.latestSubDateForm
                         )}
@@ -164,10 +164,10 @@ export default function ActionSummary() {
                     )}
                   {/* **** Form B - MORE THAN YEAR AGO ****/}
                   {infoActionsB.latestSubDateForm &&
-                    infoActionsB.isForInfoMoreThanYearSubForm && (
+                    infoActionsB.isForInfoYearPlusSubForm && (
                       <FormMessage
                         formType="B"
-                        message="infoLatestSubFormRMoreThanYear"
+                        message="infoLatestSubFormRYearPlus"
                         latestSubFormDate={DateUtilities.ConvertToLondonTime(
                           infoActionsB.latestSubDateForm
                         )}

--- a/components/home/actionSummary/FormMessage.tsx
+++ b/components/home/actionSummary/FormMessage.tsx
@@ -13,7 +13,7 @@ type FormType = "A" | "B";
 type Message =
   | "in progress"
   | "infoLatestSubFormRWithinYear"
-  | "infoLatestSubFormRMoreThanYear"
+  | "infoLatestSubFormRYearPlus"
   | "infoNoFormEver";
 
 type FormMsgProps = {
@@ -58,7 +58,7 @@ export default function FormMessage({
         </>
       );
       break;
-    case "infoLatestSubFormRMoreThanYear":
+    case "infoLatestSubFormRYearPlus":
       icon = faExclamationTriangle;
       color = "#ED8B00";
       text = (

--- a/components/home/actionSummary/FormMessage.tsx
+++ b/components/home/actionSummary/FormMessage.tsx
@@ -63,11 +63,11 @@ export default function FormMessage({
       color = "#ED8B00";
       text = (
         <>
-          Your latest{" "}
+          It is a year at least since you submitted a{" "}
           <Link
             to={`/formr-${formType.toLowerCase()}`}
           >{`Form R (${formType})`}</Link>{" "}
-          was submitted more than a year ago on {latestSubFormDate}.
+          on {latestSubFormDate}.
         </>
       );
       break;
@@ -87,7 +87,7 @@ export default function FormMessage({
   }
 
   return (
-    <li>
+    <li data-cy={`${message}-${formType}`}>
       <Label size="s">
         <FontAwesomeIcon icon={icon} color={color} size={iconSize} /> {text}
       </Label>

--- a/components/home/actionSummary/FormMessage.tsx
+++ b/components/home/actionSummary/FormMessage.tsx
@@ -11,7 +11,7 @@ import { Link } from "react-router-dom";
 
 type FormType = "A" | "B";
 type Message =
-  | "in progress"
+  | "inProgress"
   | "infoLatestSubFormRWithinYear"
   | "infoLatestSubFormRYearPlus"
   | "infoNoFormEver";
@@ -32,7 +32,7 @@ export default function FormMessage({
   let color: string = "#000000";
   let text: JSX.Element = <></>;
   switch (message) {
-    case "in progress":
+    case "inProgress":
       icon = faClock;
       color = "#ED8B00";
       text = (

--- a/components/home/actionSummary/FormMessage.tsx
+++ b/components/home/actionSummary/FormMessage.tsx
@@ -1,0 +1,96 @@
+import {
+  IconDefinition,
+  faCircle,
+  faClock,
+  faInfoCircle,
+  faExclamationTriangle
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Label } from "nhsuk-react-components";
+import { Link } from "react-router-dom";
+
+type FormType = "A" | "B";
+type Message =
+  | "in progress"
+  | "infoLatestSubFormRWithinYear"
+  | "infoLatestSubFormRMoreThanYear"
+  | "infoNoFormEver";
+
+type FormMsgProps = {
+  formType: FormType;
+  message: Message;
+  latestSubFormDate?: string;
+};
+
+export default function FormMessage({
+  formType,
+  message,
+  latestSubFormDate
+}: Readonly<FormMsgProps>) {
+  let icon: IconDefinition = faCircle;
+  let iconSize: "xs" | "sm" | "lg" | "xl" = "lg";
+  let color: string = "#000000";
+  let text: JSX.Element = <></>;
+  switch (message) {
+    case "in progress":
+      icon = faClock;
+      color = "#ED8B00";
+      text = (
+        <>
+          You have a saved draft{" "}
+          <Link
+            to={`/formr-${formType.toLowerCase()}`}
+          >{`Form R (${formType})`}</Link>
+          .
+        </>
+      );
+      break;
+    case "infoNoFormEver":
+      icon = faExclamationTriangle;
+      color = "#ED8B00";
+      text = (
+        <>
+          You have yet to submit a{" "}
+          <Link
+            to={`/formr-${formType.toLowerCase()}`}
+          >{`Form R (${formType})`}</Link>{" "}
+          on TIS Self-Service.
+        </>
+      );
+      break;
+    case "infoLatestSubFormRMoreThanYear":
+      icon = faExclamationTriangle;
+      color = "#ED8B00";
+      text = (
+        <>
+          Your latest{" "}
+          <Link
+            to={`/formr-${formType.toLowerCase()}`}
+          >{`Form R (${formType})`}</Link>{" "}
+          was submitted more than a year ago on {latestSubFormDate}.
+        </>
+      );
+      break;
+    case "infoLatestSubFormRWithinYear":
+      icon = faInfoCircle;
+      color = "#005EB8";
+      text = (
+        <>
+          Your latest{" "}
+          <Link
+            to={`/formr-${formType.toLowerCase()}`}
+          >{`Form R (${formType})`}</Link>{" "}
+          was submitted within the last year on {latestSubFormDate}.
+        </>
+      );
+      break;
+  }
+
+  return (
+    <li>
+      <Label size="s">
+        <FontAwesomeIcon icon={icon} color={color} size={iconSize} /> {text}
+      </Label>
+    </li>
+  );
+}

--- a/components/main/GlobalAlert.tsx
+++ b/components/main/GlobalAlert.tsx
@@ -18,8 +18,8 @@ const GlobalAlert = () => {
     useInfoActions();
 
   const importantInfo: boolean =
-    !!infoActionsA.isForInfoMoreThanYearSubForm ||
-    !!infoActionsB.isForInfoMoreThanYearSubForm;
+    !!infoActionsA.isForInfoYearPlusSubForm ||
+    !!infoActionsB.isForInfoYearPlusSubForm;
 
   const showActionsSummaryAlert =
     unsignedCoJ ||

--- a/components/main/GlobalAlert.tsx
+++ b/components/main/GlobalAlert.tsx
@@ -108,26 +108,28 @@ function ActionsSummaryAlert({
       Please click <Link to="/">here</Link> for details.
     </span>
   );
-  const importantInfoText =
-    "You have important information about your Form R submission dates you might want to check.";
+  const importantInfoText = "Please review your Form R submissions.";
   const conditions = [
     {
       check: () => unsignedCoJ && !inProgressFormR,
-      body: <span>You have outstanding actions to complete.</span>
+      body: <span>You have outstanding actions to complete.</span>,
+      cyTag: "unsignedCoJ"
     },
     {
       check: () => !unsignedCoJ && inProgressFormR,
-      body: <span>You have in progress actions to complete.</span>
+      body: <span>You have in progress actions to complete.</span>,
+      cyTag: "inProgressFormR"
     },
     {
       check: () => unsignedCoJ && inProgressFormR,
       body: (
         <span>You have outstanding and in progress actions to complete.</span>
-      )
+      ),
+      cyTag: "unsignedCoJAndInProgressFormR"
     }
   ];
 
-  const { body } = conditions.find(({ check }) => check()) ?? {
+  const { body, cyTag } = conditions.find(({ check }) => check()) ?? {
     body: null
   };
 
@@ -137,8 +139,10 @@ function ActionsSummaryAlert({
         <div className="app-global-alert__content">
           <div className="app-global-alert__message">
             <h2>Attention</h2>
-            <p>{body}</p>
-            {importantInfo && <p>{importantInfoText}</p>}
+            <p data-cy={cyTag}>{body}</p>
+            {importantInfo && (
+              <p data-cy={"checkFormRSubs"}>{importantInfoText}</p>
+            )}
             <p>{ACTION_LINK}</p>
           </div>
         </div>

--- a/components/main/GlobalAlert.tsx
+++ b/components/main/GlobalAlert.tsx
@@ -26,7 +26,8 @@ const GlobalAlert = () => {
     noSubFormRB;
 
   const showActionsSummaryAlert =
-    unsignedCoJ || inProgressFormR || draftFormProps || importantInfo;
+    (unsignedCoJ || inProgressFormR || draftFormProps || importantInfo) &&
+    preferredMfa !== "NOMFA";
 
   const alerts = {
     bookmark: {
@@ -48,7 +49,7 @@ const GlobalAlert = () => {
   const hasAlerts = Object.values(alerts).some(alert => alert.status);
   const { bookmark, outstandingActions } = alerts;
 
-  return hasAlerts && preferredMfa !== "NOMFA" ? (
+  return hasAlerts ? (
     <aside
       className="app-global-alert"
       id="app-global-alert"

--- a/components/main/GlobalAlert.tsx
+++ b/components/main/GlobalAlert.tsx
@@ -47,6 +47,7 @@ const GlobalAlert = () => {
   };
 
   const hasAlerts = Object.values(alerts).some(alert => alert.status);
+  const { bookmark, outstandingActions } = alerts;
 
   return hasAlerts ? (
     <aside
@@ -55,8 +56,8 @@ const GlobalAlert = () => {
       data-cy="globalAlert"
     >
       <div className="nhsuk-width-container" style={{ marginBottom: "0.5em" }}>
-        {alerts.bookmark.status && <BookmarkAlert />}
-        {alerts.outstandingActions.status && (
+        {bookmark.status && <BookmarkAlert />}
+        {outstandingActions.status && (
           <ActionsSummaryAlert
             unsignedCoJ={unsignedCoJ}
             inProgressFormR={inProgressFormR}

--- a/components/main/Main.tsx
+++ b/components/main/Main.tsx
@@ -27,6 +27,8 @@ import GlobalAlert from "./GlobalAlert";
 import CojView from "../forms/conditionOfJoining/CojView";
 import TSSHeader from "../navigation/TSSHeader";
 import packageJson from "../../package.json";
+import { loadFormAList } from "../../redux/slices/formASlice";
+import { loadFormBList } from "../../redux/slices/formBSlice";
 
 const appVersion = packageJson.version;
 
@@ -35,6 +37,8 @@ export const Main = () => {
   const traineeProfileDataStatus = useAppSelector(
     state => state.traineeProfile.status
   );
+  const formAListStatus = useAppSelector(state => state.formA.status);
+  const formBListStatus = useAppSelector(state => state.formB.status);
   const redirected = useAppSelector(state => state.user.redirected);
   let content;
   const pathname = useLocation().pathname;
@@ -48,6 +52,15 @@ export const Main = () => {
   useEffect(() => {
     dispatch(getCognitoGroups());
   }, [dispatch]);
+
+  useEffect(() => {
+    if (formAListStatus === "idle") {
+      dispatch(loadFormAList());
+    }
+    if (formBListStatus === "idle") {
+      dispatch(loadFormBList());
+    }
+  }, [dispatch, formAListStatus, formBListStatus]);
 
   useEffect(() => {
     // Store whether the user was redirected.

--- a/components/navigation/TSSHeader.tsx
+++ b/components/navigation/TSSHeader.tsx
@@ -40,7 +40,15 @@ const TSSHeader = () => {
       </Header.Container>
       <div className="nhsuk-width-container">
         <span className="tss-name" data-cy="tssName">
-          TIS Self-Service
+          TIS Self-Service{" "}
+          <a
+            className="tss-beta-link"
+            href="https://architecture.digital.nhs.uk/information/glossary"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <i>(Private Beta)</i>
+          </a>
         </span>
       </div>
       <Header.Nav className="header-nav">

--- a/cypress/component/home/Home.cy.tsx
+++ b/cypress/component/home/Home.cy.tsx
@@ -45,6 +45,10 @@ describe("Home with MFA set up", () => {
     );
   });
 
+  it("should display the Action Summary card on the Home page", () => {
+    cy.get("[data-cy=actionSummary]").should("exist");
+  });
+
   homeCards.forEach(card => {
     it(`should display the ${card} card on the Home page`, () => {
       cy.get(`[data-cy="${card}"]`).should("exist");

--- a/cypress/component/home/HomeHeaderSection.cy.tsx
+++ b/cypress/component/home/HomeHeaderSection.cy.tsx
@@ -6,7 +6,8 @@ import { HomeHeaderSection } from "../../../components/home/HomeHeaderSection";
 import history from "../../../components/navigation/history";
 
 describe("HomeHeaderSection", () => {
-  it("should display the homeWelcomeHeaderText", () => {
+  it("should display the homeWelcomeHeaderText, homeWelcomeSubHeaderText, homeWelcomeBodyText, and tssUpdatesContainer on desktop", () => {
+    cy.viewport(1920, 1080);
     mount(
       <Provider store={store}>
         <Router history={history}>
@@ -27,5 +28,26 @@ describe("HomeHeaderSection", () => {
       "Our goal is to improve your training experience by making TIS Self-Service a one-stop-shop "
     );
     cy.get('[data-cy="tssUpdatesContainer"]').should("exist");
+  });
+  it("should not display homeWelcomeBodyText and tssUpdatesContainer on mobile", () => {
+    cy.viewport(375, 812);
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <HomeHeaderSection />
+        </Router>
+      </Provider>
+    );
+    cy.get("[data-cy=homeWelcomeHeaderText]").should(
+      "include.text",
+      "Welcome toTIS Self-Service" // with line break
+    );
+    cy.get("[data-cy=homeWelcomeSubHeaderText]").should(
+      "contain",
+      "Your post-graduate training programme resource"
+    );
+    cy.get("[data-cy=homeWelcomeBodyText]").should("not.exist");
+    cy.get('[data-cy="tssUpdatesContainer"]').should("not.exist");
+    cy.get('[data-cy="anchorEl_What\'s New"]').should("exist");
   });
 });

--- a/cypress/component/home/TssUpdates.cy.tsx
+++ b/cypress/component/home/TssUpdates.cy.tsx
@@ -62,7 +62,7 @@ describe("TssUpdates", () => {
         </Router>
       </Provider>
     );
-    cy.get("h2").should("contain", "What's New");
+    cy.get('[data-cy="whatsNewHeader"]').should("contain", "What's New");
     cy.get("[data-cy=noUpdates]").should(
       "contain",
       "No new updates available at the moment."

--- a/cypress/component/home/action-summary/ActionSummary.cy.tsx
+++ b/cypress/component/home/action-summary/ActionSummary.cy.tsx
@@ -1,0 +1,160 @@
+import day from "dayjs";
+import { mount } from "cypress/react18";
+import { Provider } from "react-redux";
+import { Router } from "react-router-dom";
+import store from "../../../../redux/store/store";
+import ActionSummary from "../../../../components/home/actionSummary/ActionSummary";
+import history from "../../../../components/navigation/history";
+import {
+  updatedFormAList,
+  updatedFormAStatus
+} from "../../../../redux/slices/formASlice";
+import { updatedUnsignedCojs } from "../../../../redux/slices/traineeProfileSlice";
+import { mockProgrammeMembershipCojNotSigned } from "../../../../mock-data/trainee-profile";
+import { mockFormList } from "../../../../mock-data/formr-list";
+import {
+  dateMoreThanYearAgo,
+  dateWithinYear,
+  todayDate
+} from "../../../../utilities/DateUtilities";
+import {
+  updatedFormBList,
+  updatedFormBStatus
+} from "../../../../redux/slices/formBSlice";
+import { IFormR } from "../../../../models/IFormR";
+
+type FormType = "A" | "B";
+
+describe("Action Summary", () => {
+  const selectors = [
+    "actionSummaryHeading",
+    "outstandingHeading",
+    "formRSubsHeading",
+    "inProgressHeading",
+    "otherChecksHeading"
+  ];
+
+  beforeEach(() => {
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <ActionSummary />
+        </Router>
+      </Provider>
+    );
+  });
+
+  selectors.forEach(selector => {
+    it(`should display the ${selector}`, () => {
+      cy.get(`[data-cy=${selector}]`).should("exist");
+    });
+  });
+
+  it("should not display the number of CoJ's to sign when there are no CoJ's to sign", () => {
+    store.dispatch(updatedFormAStatus("success"));
+    store.dispatch(updatedUnsignedCojs([]));
+    cy.get("[data-cy=unsignedCoJ]").should("not.exist");
+    cy.get("[data-cy=allCoJSigned]")
+      .should("exist")
+      .should("contain", "signed");
+  });
+  it("should display the number of CoJ's to sign when there are CoJ's to sign", () => {
+    store.dispatch(updatedFormAStatus("success"));
+    store.dispatch(updatedUnsignedCojs([mockProgrammeMembershipCojNotSigned]));
+    cy.get("[data-cy=unsignedCoJ]")
+      .should("exist")
+      .should("contain", "You have 1 unsigned");
+  });
+
+  const testFormNoSubmissions = (formType: FormType) => {
+    it(`should display the 'yet to submit' message when there are no submitted ${formType}`, () => {
+      formType === "A"
+        ? store.dispatch(updatedFormAStatus("success"))
+        : store.dispatch(updatedFormBStatus("success"));
+      cy.get(`[data-cy=infoNoFormEver-${formType}]`)
+        .should("exist")
+        .should("contain", "yet to submit");
+    });
+  };
+  testFormNoSubmissions("A");
+  testFormNoSubmissions("B");
+
+  const testFormSubmissionWithinYear = (
+    formType: FormType,
+    formList: IFormR[],
+    message: string
+  ) => {
+    it(`should display the 'submitted within the last year' message when the latest submitted Form ${formType} is ${message}`, () => {
+      formType === "A"
+        ? store.dispatch(updatedFormAStatus("success"))
+        : store.dispatch(updatedFormBStatus("success"));
+      store.dispatch(
+        formType === "A"
+          ? updatedFormAList(formList)
+          : updatedFormBList(formList)
+      );
+      cy.get(`[data-cy=infoLatestSubFormRWithinYear-${formType}]`)
+        .should("exist")
+        .should("contain", "submitted within the last year");
+    });
+  };
+
+  const formListWithinYear = [
+    { ...mockFormList[1] },
+    {
+      ...mockFormList[1],
+      submissionDate: day(dateWithinYear).add(1, "day").toISOString()
+    }
+  ];
+  const formListToday = [
+    {
+      ...mockFormList[0]
+    },
+    {
+      ...mockFormList[0],
+      submissionDate: day(todayDate).subtract(1, "day").toISOString()
+    }
+  ];
+  testFormSubmissionWithinYear("A", formListWithinYear, "within a year ago");
+  testFormSubmissionWithinYear("A", formListToday, "today");
+  testFormSubmissionWithinYear("B", formListWithinYear, "within a year ago");
+  testFormSubmissionWithinYear("B", formListToday, "today");
+
+  const testFormSubmissionMoreThanYear = (
+    formType: FormType,
+    formList: IFormR[],
+    message: string
+  ) => {
+    it(`should display the 'a year at least' message when the latest submitted Form ${formType} is ${message} a year ago`, () => {
+      formType === "A"
+        ? store.dispatch(updatedFormAStatus("success"))
+        : store.dispatch(updatedFormBStatus("success"));
+      store.dispatch(
+        formType === "A"
+          ? updatedFormAList(formList)
+          : updatedFormBList(formList)
+      );
+      cy.get(`[data-cy=infoLatestSubFormRMoreThanYear-${formType}]`)
+        .should("exist")
+        .should("contain", "It is a year at least since you submitted");
+    });
+  };
+  const formListMoreThanYear = [
+    { ...mockFormList[3] },
+    {
+      ...mockFormList[3],
+      submissionDate: day(dateMoreThanYearAgo).subtract(1, "day").toISOString()
+    }
+  ];
+  const formListYearAgoExactly = [{ ...mockFormList[2] }];
+
+  testFormSubmissionMoreThanYear("A", formListMoreThanYear, "more than");
+  testFormSubmissionMoreThanYear("A", formListYearAgoExactly, "exactly");
+  testFormSubmissionMoreThanYear("B", formListMoreThanYear, "more than");
+  testFormSubmissionMoreThanYear("B", formListYearAgoExactly, "exactly");
+
+  it("should display the loading spinner when data is loading", () => {
+    store.dispatch(updatedFormAStatus("loading"));
+    cy.get("[data-cy=loading]").should("exist");
+  });
+});

--- a/cypress/component/home/action-summary/ActionSummary.cy.tsx
+++ b/cypress/component/home/action-summary/ActionSummary.cy.tsx
@@ -70,7 +70,8 @@ describe("Action Summary", () => {
   const testCojSign = (
     cojToSign: ProgrammeMembership[],
     shouldExist: boolean,
-    message: string
+    message: string,
+    message2?: string
   ) => {
     it(`should display the ${
       shouldExist ? "'CoJ to sign'" : "'all CoJ signed'"
@@ -81,7 +82,9 @@ describe("Action Summary", () => {
         shouldExist ? "exist" : "not.exist"
       );
       if (shouldExist) {
-        cy.get("[data-cy=unsignedCoJ]").should("contain", message);
+        cy.get("[data-cy=unsignedCoJ]")
+          .should("contain", message)
+          .should("contain", message2);
       } else {
         cy.get("[data-cy=allCoJSigned]")
           .should("exist")
@@ -91,9 +94,16 @@ describe("Action Summary", () => {
   };
   testCojSign([], false, "signed");
   testCojSign(
-    [mockProgrammeMembershipCojNotSigned],
+    [mockProgrammeMembershipCojNotSigned[0]],
     true,
-    "You have 1 unsigned"
+    "1 unsigned",
+    "Agreement"
+  );
+  testCojSign(
+    mockProgrammeMembershipCojNotSigned,
+    true,
+    "You have 2 unsigned",
+    "Agreements"
   );
 
   const testFormNoSubmissions = (formType: FormType) => {

--- a/cypress/component/main/GlobalAlert.cy.tsx
+++ b/cypress/component/main/GlobalAlert.cy.tsx
@@ -1,39 +1,26 @@
 import { mount } from "cypress/react18";
 import { Provider } from "react-redux";
-import { MemoryRouter, Router } from "react-router-dom";
+import { Router } from "react-router-dom";
 import GlobalAlert from "../../../components/main/GlobalAlert";
 import history from "../../../components/navigation/history";
-import {
-  mockPersonalDetails,
-  mockProgrammeMembershipCojNotSigned,
-  mockProgrammeMembershipCojSigned
-} from "../../../mock-data/trainee-profile";
+import { mockProgrammeMembershipCojNotSigned } from "../../../mock-data/trainee-profile";
 import { useAppDispatch } from "../../../redux/hooks/hooks";
-import { updatedTraineeProfileData } from "../../../redux/slices/traineeProfileSlice";
+import { updatedUnsignedCojs } from "../../../redux/slices/traineeProfileSlice";
 import store from "../../../redux/store/store";
 import React from "react";
-import { COJ_EPOCH } from "../../../utilities/Constants";
-import { updatedRedirected } from "../../../redux/slices/userSlice";
+import {
+  updatedPreferredMfa,
+  updatedRedirected
+} from "../../../redux/slices/userSlice";
+import { updatedFormAList } from "../../../redux/slices/formASlice";
+import { mockFormList } from "../../../mock-data/formr-list";
+import { updatedFormBList } from "../../../redux/slices/formBSlice";
 
 describe("GlobalAlert", () => {
-  beforeEach(() => {
-    cy.clock(COJ_EPOCH);
-  });
-
-  it("should not render when no alerts", () => {
+  it("should not render the Global Alert if the user has not set their MFA", () => {
     const MockedGlobalAlert = () => {
-      const dispatch = useAppDispatch();
-      dispatch(
-        updatedTraineeProfileData({
-          traineeTisId: "12345",
-          personalDetails: mockPersonalDetails,
-          programmeMemberships: [mockProgrammeMembershipCojSigned],
-          placements: []
-        })
-      );
       return <GlobalAlert />;
     };
-
     mount(
       <Provider store={store}>
         <Router history={history}>
@@ -41,202 +28,82 @@ describe("GlobalAlert", () => {
         </Router>
       </Provider>
     );
-
     cy.get("[data-cy=globalAlert]").should("not.exist");
   });
 
-  it("should render when alerts available", () => {
-    const MockedGlobalAlert = () => {
+  it("should render the Global Action Summary Alert but no Action Summary if bookmark is false (no redirect) and the Action Summary is true (no submitted Form R)", () => {
+    const MockedGlobalNoBookmarkButAction = () => {
       const dispatch = useAppDispatch();
-      dispatch(
-        updatedTraineeProfileData({
-          traineeTisId: "12345",
-          personalDetails: mockPersonalDetails,
-          programmeMemberships: [
-            {
-              ...mockProgrammeMembershipCojNotSigned,
-              startDate: COJ_EPOCH
-            }
-          ],
-          placements: []
-        })
-      );
+      dispatch(updatedPreferredMfa("SMS"));
       return <GlobalAlert />;
     };
-
     mount(
       <Provider store={store}>
         <Router history={history}>
-          <MockedGlobalAlert />
+          <MockedGlobalNoBookmarkButAction />
         </Router>
       </Provider>
     );
-
     cy.get("[data-cy=globalAlert]").should("exist");
+    cy.get("[data-cy=bookmarkAlert]").should("not.exist");
+    cy.get("[data-cy=actionsSummaryAlert]").should("exist");
   });
 
-  describe("BookmarkAlert", () => {
-    it("should not render when user not redirected", () => {
-      const MockedGlobalAlert = () => {
-        const dispatch = useAppDispatch();
-        dispatch(updatedRedirected(false));
-        return <GlobalAlert />;
-      };
-
-      mount(
-        <Provider store={store}>
-          <Router history={history}>
-            <MockedGlobalAlert />
-          </Router>
-        </Provider>
-      );
-
-      cy.get("[data-cy=bookmarkAlert]").should("not.exist");
-    });
-
-    it("should render when user redirected", () => {
-      const MockedGlobalAlert = () => {
-        const dispatch = useAppDispatch();
-        dispatch(updatedRedirected(true));
-        return <GlobalAlert />;
-      };
-
-      mount(
-        <Provider store={store}>
-          <Router history={history}>
-            <MockedGlobalAlert />
-          </Router>
-        </Provider>
-      );
-
-      cy.get("[data-cy=bookmarkAlert]").should("exist");
-    });
+  it("should render the Global Action Summary Alert but no Bookmark if bookmark is false (no redirect) and the Action Summary is true (year plus since last submitted Form R)", () => {
+    const MockedGlobalNoBookmarkButAction = () => {
+      const dispatch = useAppDispatch();
+      dispatch(updatedFormAList([mockFormList[2]]));
+      dispatch(updatedFormAList([mockFormList[3]]));
+      return <GlobalAlert />;
+    };
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <MockedGlobalNoBookmarkButAction />
+        </Router>
+      </Provider>
+    );
+    cy.get("[data-cy=globalAlert]").should("exist");
+    cy.get("[data-cy=bookmarkAlert]").should("not.exist");
+    cy.get("[data-cy=actionsSummaryAlert]").should("exist");
   });
 
-  describe("CojAlert", () => {
-    it("should not render when no signable COJ", () => {
-      const MockedGlobalAlert = () => {
-        const dispatch = useAppDispatch();
-        dispatch(
-          updatedTraineeProfileData({
-            traineeTisId: "12345",
-            personalDetails: mockPersonalDetails,
-            programmeMemberships: [mockProgrammeMembershipCojSigned],
-            placements: []
-          })
-        );
-        return <GlobalAlert />;
-      };
+  it("should render Global Bookmark alert (redirect is true) but no Action Summary (recent submitted Form R, no unsigned CoJ)", () => {
+    const MockedGlobalBookmarkNoAction = () => {
+      const dispatch = useAppDispatch();
+      dispatch(updatedRedirected(true));
+      dispatch(updatedFormAList([mockFormList[0]]));
+      dispatch(updatedFormBList([mockFormList[1]]));
+      return <GlobalAlert />;
+    };
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <MockedGlobalBookmarkNoAction />
+        </Router>
+      </Provider>
+    );
+    cy.get("[data-cy=globalAlert]").should("exist");
+    cy.get("[data-cy=bookmarkAlert]").should("exist");
+    cy.get("[data-cy=actionsSummaryAlert]").should("not.exist");
+  });
 
-      mount(
-        <Provider store={store}>
-          <Router history={history}>
-            <MockedGlobalAlert />
-          </Router>
-        </Provider>
-      );
-
-      cy.get("[data-cy=cojAlert]").should("not.exist");
-    });
-
-    it("should render when signable COJ available", () => {
-      const MockedGlobalAlert = () => {
-        const dispatch = useAppDispatch();
-        dispatch(
-          updatedTraineeProfileData({
-            traineeTisId: "12345",
-            personalDetails: mockPersonalDetails,
-            programmeMemberships: [
-              {
-                ...mockProgrammeMembershipCojNotSigned,
-                startDate: COJ_EPOCH
-              }
-            ],
-            placements: []
-          })
-        );
-        return <GlobalAlert />;
-      };
-
-      mount(
-        <Provider store={store}>
-          <Router history={history}>
-            <MockedGlobalAlert />
-          </Router>
-        </Provider>
-      );
-
-      cy.get("[data-cy=cojAlert]").should("exist");
-    });
-
-    it("should include programmes nav link when not on programmes view", () => {
-      const MockedGlobalAlert = () => {
-        const dispatch = useAppDispatch();
-        dispatch(
-          updatedTraineeProfileData({
-            traineeTisId: "12345",
-            personalDetails: mockPersonalDetails,
-            programmeMemberships: [
-              {
-                ...mockProgrammeMembershipCojNotSigned,
-                startDate: COJ_EPOCH
-              }
-            ],
-            placements: []
-          })
-        );
-        return <GlobalAlert />;
-      };
-
-      mount(
-        <Provider store={store}>
-          <MemoryRouter initialEntries={["/home"]}>
-            <MockedGlobalAlert />
-          </MemoryRouter>
-        </Provider>
-      );
-
-      cy.get("[data-cy=cojLink]").should("exist");
-    });
-
-    it("should not include programmes nav link when on programmes view", () => {
-      const MockedGlobalAlert = () => {
-        const dispatch = useAppDispatch();
-        dispatch(
-          updatedTraineeProfileData({
-            traineeTisId: "12345",
-            personalDetails: mockPersonalDetails,
-            programmeMemberships: [
-              {
-                ...mockProgrammeMembershipCojNotSigned,
-                startDate: COJ_EPOCH
-              }
-            ],
-            placements: []
-          })
-        );
-        return <GlobalAlert />;
-      };
-
-      mount(
-        <Provider store={store}>
-          <MemoryRouter initialEntries={["/programmes"]}>
-            <MockedGlobalAlert />
-          </MemoryRouter>
-        </Provider>
-      );
-
-      cy.get("[data-cy=cojLink]").should("not.exist");
-    });
-    it("should not render the Coj alert when on the Coj form page", () => {
-      mount(
-        <Provider store={store}>
-          <MemoryRouter initialEntries={["/121/sign-coj"]}>
-            <GlobalAlert />
-          </MemoryRouter>
-        </Provider>
-      );
-      cy.get("[data-cy=cojAlert]").should("not.exist");
-    });
+  it("should render Global Bookmark and Action Summary alerts if redirect is true and unsigned CoJ is true", () => {
+    const MockedGlobalAlertRedirectAndUnsignedCoj = () => {
+      const dispatch = useAppDispatch();
+      dispatch(updatedRedirected(true));
+      dispatch(updatedUnsignedCojs([mockProgrammeMembershipCojNotSigned]));
+      return <GlobalAlert />;
+    };
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <MockedGlobalAlertRedirectAndUnsignedCoj />
+        </Router>
+      </Provider>
+    );
+    cy.get("[data-cy=globalAlert]").should("exist");
+    cy.get("[data-cy=bookmarkAlert]").should("exist");
+    cy.get("[data-cy=actionsSummaryAlert]").should("exist");
   });
 });

--- a/cypress/component/main/GlobalAlert.cy.tsx
+++ b/cypress/component/main/GlobalAlert.cy.tsx
@@ -72,6 +72,7 @@ describe("GlobalAlert", () => {
     cy.get("[data-cy=globalAlert]").should("exist");
     cy.get("[data-cy=bookmarkAlert]").should("not.exist");
     cy.get("[data-cy=actionsSummaryAlert]").should("exist");
+    cy.get("[data-cy=checkFormRSubs]").should("exist");
   });
 
   it("should render the Global Action Summary Alert but no Bookmark alert if bookmark is false (no redirect) and the Action Summary is true (year plus since last submitted Form R)", () => {
@@ -79,6 +80,7 @@ describe("GlobalAlert", () => {
     cy.get("[data-cy=globalAlert]").should("exist");
     cy.get("[data-cy=bookmarkAlert]").should("not.exist");
     cy.get("[data-cy=actionsSummaryAlert]").should("exist");
+    cy.get("[data-cy=checkFormRSubs]").should("exist");
   });
 
   it("should render Global Bookmark alert (redirect is true) but no Action Summary (recent submitted Form R, no unsigned CoJ)", () => {
@@ -94,10 +96,11 @@ describe("GlobalAlert", () => {
       "SMS",
       [mockFormList[0]],
       [mockFormList[1]],
-      [mockProgrammeMembershipCojNotSigned]
+      [mockProgrammeMembershipCojNotSigned[0]]
     );
     cy.get("[data-cy=globalAlert]").should("exist");
     cy.get("[data-cy=bookmarkAlert]").should("exist");
     cy.get("[data-cy=actionsSummaryAlert]").should("exist");
+    cy.get("[data-cy=unsignedCoJ]").should("exist");
   });
 });

--- a/cypress/component/navigation/TSSHeader.cy.tsx
+++ b/cypress/component/navigation/TSSHeader.cy.tsx
@@ -37,7 +37,15 @@ describe("Header with MFA set up", () => {
     cy.get("[data-cy=headerLogo] > a")
       .should("exist")
       .should("have.attr", "href", "/");
-    cy.get("[data-cy=tssName]").should("contain.text", "TIS Self-Service");
+    cy.get("[data-cy=tssName]").should(
+      "contain.text",
+      "TIS Self-Service (Private Beta)"
+    );
+    cy.get("[data-cy=tssName] > a").should(
+      "have.attr",
+      "href",
+      "https://architecture.digital.nhs.uk/information/glossary"
+    );
   });
 
   navLinks.forEach(link => {

--- a/cypress/component/programmes/Programmes.cy.tsx
+++ b/cypress/component/programmes/Programmes.cy.tsx
@@ -253,7 +253,7 @@ describe("Programme summary panel", () => {
           traineeTisId: "12345",
           personalDetails: mockPersonalDetails,
           programmeMemberships: [
-            mockProgrammeMembershipCojNotSigned,
+            mockProgrammeMembershipCojNotSigned[0],
             mockProgrammeMembershipCojSigned
           ],
           placements: []
@@ -294,7 +294,7 @@ describe("Programme summary panel", () => {
           traineeTisId: "12345",
           personalDetails: mockPersonalDetails,
           programmeMemberships: [
-            mockProgrammeMembershipCojNotSigned,
+            mockProgrammeMembershipCojNotSigned[0],
             mockProgrammeMembershipCojSigned
           ],
           placements: []

--- a/cypress/e2e/home/Home.spec.ts
+++ b/cypress/e2e/home/Home.spec.ts
@@ -33,6 +33,8 @@ describe("Home", () => {
       cy.get(".nhsuk-u-margin-bottom-4").should("exist");
     });
 
+    cy.get("[data-cy=actionSummaryHeading]").should("exist");
+
     cy.visit("/home/nonsense", { failOnStatusCode: false });
     cy.get('[data-cy="pageNotFoundText"]')
       .should("exist")

--- a/mock-data/formr-list.ts
+++ b/mock-data/formr-list.ts
@@ -1,4 +1,11 @@
 import { LifeCycleState } from "../models/LifeCycleState";
+import {
+  todayDate,
+  dateWithinYear,
+  dateExactlyYearAgo,
+  dateMoreThanYearAgo
+} from "../utilities/DateUtilities";
+
 export const mockForms = [
   {
     id: "3",
@@ -20,5 +27,33 @@ export const mockForms = [
     id: "4",
     lifecycleState: LifeCycleState.Draft,
     lastModifiedDate: "2023-05-22T12:50:52.589Z"
+  }
+];
+
+// FOR ACTION SUMMARY
+export const mockFormList = [
+  {
+    id: "4",
+    lifecycleState: LifeCycleState.Submitted,
+    submissionDate: todayDate,
+    lastModifiedDate: todayDate
+  },
+  {
+    id: "3",
+    lifecycleState: LifeCycleState.Submitted,
+    submissionDate: dateWithinYear,
+    lastModifiedDate: dateWithinYear
+  },
+  {
+    id: "2",
+    lifecycleState: LifeCycleState.Submitted,
+    submissionDate: dateExactlyYearAgo,
+    lastModifiedDate: dateExactlyYearAgo
+  },
+  {
+    id: "1",
+    lifecycleState: LifeCycleState.Submitted,
+    submissionDate: dateMoreThanYearAgo,
+    lastModifiedDate: dateMoreThanYearAgo
   }
 ];

--- a/mock-data/trainee-profile.ts
+++ b/mock-data/trainee-profile.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { PersonalDetails } from "../models/PersonalDetails";
 import { TraineeProfile } from "../models/TraineeProfile";
 import { Status } from "../models/Status";
@@ -5,12 +6,11 @@ import { ProgrammeMembership } from "../models/ProgrammeMembership";
 import { Placement } from "../models/Placement";
 import {
   oneWeekAgo,
-  today,
+  todayDate,
   twelveWeeksAhead,
   twelveWeeksAheadPlusOneDay,
   yesterday
 } from "../utilities/DateUtilities";
-import dayjs from "dayjs";
 
 export const mockPersonalDetails: PersonalDetails = {
   surname: "Gilliam",
@@ -516,8 +516,8 @@ export const mockPlacementsForGrouping: Placement[] = [
     siteLocation: "siteLocation2",
     siteKnownAs: "siteKnownAs2",
     otherSites: [],
-    startDate: today,
-    endDate: today,
+    startDate: todayDate,
+    endDate: todayDate,
     wholeTimeEquivalent: "wholeTimeEquivalent2",
     specialty: "specialty2",
     subSpecialty: "subSpecialty2",

--- a/mock-data/trainee-profile.ts
+++ b/mock-data/trainee-profile.ts
@@ -259,19 +259,34 @@ export const mockProgrammeMembershipCojSigned: ProgrammeMembership = {
   }
 };
 
-export const mockProgrammeMembershipCojNotSigned: ProgrammeMembership = {
-  tisId: "1",
-  programmeName: "",
-  programmeNumber: "",
-  startDate: new Date("2010-10-14"),
-  endDate: new Date("2011-10-14"),
-  managingDeanery: "",
-  curricula: [],
-  conditionsOfJoining: {
-    signedAt: null,
-    version: "GG8"
+export const mockProgrammeMembershipCojNotSigned: ProgrammeMembership[] = [
+  {
+    tisId: "1",
+    programmeName: "",
+    programmeNumber: "",
+    startDate: new Date("2010-10-14"),
+    endDate: new Date("2011-10-14"),
+    managingDeanery: "",
+    curricula: [],
+    conditionsOfJoining: {
+      signedAt: null,
+      version: "GG8"
+    }
+  },
+  {
+    tisId: "2",
+    programmeName: "",
+    programmeNumber: "",
+    startDate: new Date("2010-10-14"),
+    endDate: new Date("2011-10-14"),
+    managingDeanery: "",
+    curricula: [],
+    conditionsOfJoining: {
+      signedAt: null,
+      version: "GG8"
+    }
   }
-};
+];
 
 export const mockPlacements: Placement[] = [
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7700,11 +7700,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
-      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -7721,6 +7721,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/template": {
       "version": "7.22.15",
@@ -30960,11 +30965,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
-      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+        }
       }
     },
     "@babel/runtime-corejs3": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.86.1",
+  "version": "0.87.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.86.1",
+      "version": "0.87.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.86.1",
+  "version": "0.87.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/redux/slices/formASlice.ts
+++ b/redux/slices/formASlice.ts
@@ -114,6 +114,12 @@ const formASlice = createSlice({
     },
     updatedAutoSaveLatestTimeStamp(state, action: PayloadAction<string>) {
       return { ...state, autoSaveLatestTimeStamp: action.payload };
+    },
+    updatedFormAStatus(state, action: PayloadAction<string>) {
+      return { ...state, status: action.payload };
+    },
+    updatedFormAList(state, action: PayloadAction<IFormR[]>) {
+      return { ...state, formAList: action.payload };
     }
   },
   extraReducers(builder): void {
@@ -237,7 +243,9 @@ export const {
   updatedEditPageNumber,
   updatedCanEdit,
   updatedAutosaveStatus,
-  updatedAutoSaveLatestTimeStamp
+  updatedAutoSaveLatestTimeStamp,
+  updatedFormAStatus,
+  updatedFormAList
 } = formASlice.actions;
 
 export const selectSavedFormA = (state: { formA: IFormA }) =>

--- a/redux/slices/formBSlice.ts
+++ b/redux/slices/formBSlice.ts
@@ -139,6 +139,12 @@ const formBSlice = createSlice({
     },
     updatedIsDirty(state, action: PayloadAction<boolean>) {
       return { ...state, isDirty: action.payload };
+    },
+    updatedFormBStatus(state, action: PayloadAction<string>) {
+      return { ...state, status: action.payload };
+    },
+    updatedFormBList(state, action: PayloadAction<IFormR[]>) {
+      return { ...state, formBList: action.payload };
     }
   },
   extraReducers(builder): void {
@@ -268,7 +274,9 @@ export const {
   updatedCanEditB,
   updatedAutosaveStatus,
   updatedAutoSaveLatestTimeStamp,
-  updatedIsDirty
+  updatedIsDirty,
+  updatedFormBStatus,
+  updatedFormBList
 } = formBSlice.actions;
 
 export const selectSavedFormB = (state: { formB: IFormB }) =>

--- a/redux/slices/traineeProfileSlice.ts
+++ b/redux/slices/traineeProfileSlice.ts
@@ -68,6 +68,9 @@ const traineeProfileSlice = createSlice({
     },
     updatedTraineeProfileStatus(state, action: PayloadAction<string>) {
       return { ...state, status: action.payload };
+    },
+    updatedUnsignedCojs(state, action: PayloadAction<ProgrammeMembership[]>) {
+      return { ...state, unsignedCojs: action.payload };
     }
   },
   extraReducers(builder) {
@@ -135,7 +138,8 @@ export default traineeProfileSlice.reducer;
 export const {
   resetToInit,
   updatedTraineeProfileData,
-  updatedTraineeProfileStatus
+  updatedTraineeProfileStatus,
+  updatedUnsignedCojs
 } = traineeProfileSlice.actions;
 
 export const selectTraineeProfile = (state: { traineeProfile: IProfile }) =>

--- a/redux/slices/traineeProfileSlice.ts
+++ b/redux/slices/traineeProfileSlice.ts
@@ -12,6 +12,7 @@ import { ToastType, showToast } from "../../components/common/ToastMessage";
 interface IProfile {
   traineeProfileData: TraineeProfile;
   hasSignableCoj: boolean;
+  unsignedCojs: ProgrammeMembership[];
   status: string;
   error: any;
 }
@@ -24,6 +25,7 @@ export const initialState: IProfile = {
     placements: []
   },
   hasSignableCoj: false,
+  unsignedCojs: [],
   status: "idle",
   error: ""
 };
@@ -91,6 +93,9 @@ const traineeProfileSlice = createSlice({
         );
         state.traineeProfileData.placements = sortedPlacements;
         state.hasSignableCoj = CojUtilities.canAnyBeSigned(sortedProgrammes);
+        state.unsignedCojs = CojUtilities.unsignedCojs(
+          state.traineeProfileData.programmeMemberships
+        );
       })
       .addCase(fetchTraineeProfileData.rejected, (state, { error }) => {
         state.status = "failed";

--- a/services/FormsService.ts
+++ b/services/FormsService.ts
@@ -3,6 +3,7 @@ import ApiService from "./apiService";
 import { FormRPartA } from "../models/FormRPartA";
 import { FormRPartB } from "../models/FormRPartB";
 import { FeatureFlags } from "../models/FeatureFlags";
+import { IFormR } from "../models/IFormR";
 
 export class FormsService extends ApiService {
   constructor() {
@@ -21,8 +22,8 @@ export class FormsService extends ApiService {
     return this.put<FormRPartA>("/formr-parta", formData);
   }
 
-  async getTraineeFormRPartAList(): Promise<AxiosResponse<FormRPartA[]>> {
-    return this.get<FormRPartA[]>("/formr-partas");
+  async getTraineeFormRPartAList(): Promise<AxiosResponse<IFormR[]>> {
+    return this.get<IFormR[]>("/formr-partas");
   }
 
   async getTraineeFormRPartAByFormId(
@@ -38,8 +39,8 @@ export class FormsService extends ApiService {
     return this.post<FormRPartB>("/formr-partb", newFormData);
   }
 
-  async getTraineeFormRPartBList(): Promise<AxiosResponse<FormRPartB[]>> {
-    return this.get<FormRPartB[]>("/formr-partbs");
+  async getTraineeFormRPartBList(): Promise<AxiosResponse<IFormR[]>> {
+    return this.get<IFormR[]>("/formr-partbs");
   }
 
   async getTraineeFormRPartBByFormId(

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -561,3 +561,9 @@ ol[type="a"] {
   min-width: 100%;
   max-width: 100%;
 }
+
+//ul
+.no-bullet {
+  list-style-type: none;
+  margin-left: -1em;
+}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -480,6 +480,12 @@ ol[type="a"] {
 }
 
 // Home header section
+@media (max-width: 768px) {
+  .header-wrapper {
+    padding: 1.5rem 0;
+  }
+}
+
 .tss-update-column {
   padding: 56px 16px;
 }
@@ -510,7 +516,32 @@ ol[type="a"] {
   text-decoration: none;
 }
 
+.whats-new-header {
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.whats-new-link:focus:visited {
+  color: black !important;
+}
+
+@media (max-width: 768px) {
+  .whats-new-header {
+    font-size: 1.25rem;
+    font-weight: normal;
+  }
+}
+
 // nav header
+.tss-beta-link {
+  color: #fff !important; // needed to override NHSUK default
+  font-size: 1rem;
+}
+
+.tss-beta-link:focus:visited {
+  color: black !important;
+}
+
 .top-nav-container {
   display: flex;
   justify-content: space-between;
@@ -551,6 +582,12 @@ ol[type="a"] {
   color: white;
   font-size: 1.5rem;
   margin-bottom: 1rem;
+}
+
+@media (max-width: 768px) {
+  .tss-name {
+    font-size: 1.25rem;
+  }
 }
 
 .header-nav {

--- a/utilities/ActionSummaryUtilities.ts
+++ b/utilities/ActionSummaryUtilities.ts
@@ -1,0 +1,123 @@
+import dayjs from "dayjs";
+import isBetween from "dayjs/plugin/isBetween";
+import { LifeCycleState } from "../models/LifeCycleState";
+import { ProgrammeMembership } from "../models/ProgrammeMembership";
+import { DateType } from "./DateUtilities";
+import { IFormR } from "../models/IFormR";
+dayjs.extend(isBetween);
+
+export type OutstandingSummaryActions = {
+  unsignedCojCount: number;
+};
+
+// OUTSTANDING (and Global Alert)
+export function getAllOutstandingSummaryActions(
+  unsignedCojs: ProgrammeMembership[]
+): OutstandingSummaryActions {
+  const unsignedCojCount = unsignedCojs.length;
+  return {
+    unsignedCojCount
+  };
+}
+
+// IN PROGRESS
+export function getAllInProgressSummaryActions(
+  formAList: IFormR[],
+  formBList: IFormR[]
+) {
+  const isInProgressFormA = isAnyFormInProgress(formAList);
+  const isInProgressFormB = isAnyFormInProgress(formBList);
+  return {
+    isInProgressFormA,
+    isInProgressFormB
+  };
+}
+
+// info section
+export function getAllInfoFormRSubmissionSummaryActions(
+  formListA: IFormR[],
+  formListB: IFormR[]
+) {
+  const { noSubFormRA, noSubFormRB } = noSubFormR(formListA, formListB);
+
+  const infoA = getInfoActions(formListA, noSubFormRA);
+  const infoB = getInfoActions(formListB, noSubFormRB);
+
+  return {
+    noSubFormRA,
+    noSubFormRB,
+    infoActionsA: infoA,
+    infoActionsB: infoB
+  };
+}
+
+function getInfoActions(formList: IFormR[], noSubFormR: boolean) {
+  if (noSubFormR) {
+    return {
+      isForInfoWithinYearSubForm: false,
+      isForInfoMoreThanYearSubForm: false,
+      latestSubDateForm: null
+    };
+  }
+
+  const latestSubDateForm = getLatestSubDate(formList);
+
+  const isForInfoWithinYearSubForm =
+    latestSubDateForm &&
+    isLatestSubmissionDateWithinLastYear(latestSubDateForm);
+
+  const isForInfoMoreThanYearSubForm =
+    latestSubDateForm && isLatestSubmissionDateMoreThanYear(latestSubDateForm);
+
+  return {
+    isForInfoWithinYearSubForm,
+    isForInfoMoreThanYearSubForm,
+    latestSubDateForm
+  };
+}
+
+export function filterSubmittedFormList(formList: IFormR[]) {
+  return formList.filter(
+    form => form.lifecycleState === LifeCycleState.Submitted
+  );
+}
+
+function isAnyFormInProgress(formList: IFormR[]): boolean {
+  return (
+    formList.filter(form => form.lifecycleState !== LifeCycleState.Submitted)
+      .length > 0
+  );
+}
+
+function noSubFormR(formListA: IFormR[], formListB: IFormR[]) {
+  const filteredSumittedFormListA = filterSubmittedFormList(formListA);
+  const filteredSumittedFormListB = filterSubmittedFormList(formListB);
+  const noSubFormRA = filteredSumittedFormListA.length < 1;
+  const noSubFormRB = filteredSumittedFormListB.length < 1;
+  return { noSubFormRA, noSubFormRB };
+}
+
+export function getLatestSubDate(formList: IFormR[]) {
+  const subFormList = filterSubmittedFormList(formList);
+  const latestSubDateForm = subFormList[0]?.submissionDate;
+  return latestSubDateForm;
+}
+
+export function isLatestSubmissionDateWithinLastYear(
+  lastSubStartDate: DateType
+): boolean {
+  const lastSubDate = dayjs(lastSubStartDate);
+  const today = dayjs();
+  const oneYearAgo = today.subtract(1, "year");
+  return (
+    lastSubDate.isAfter(oneYearAgo) &&
+    (lastSubDate.isBefore(today) || lastSubDate.isSame(today))
+  );
+}
+
+export function isLatestSubmissionDateMoreThanYear(subDate: DateType) {
+  const lastSubDate = dayjs(subDate);
+  const today = dayjs();
+  const oneYearAgo = today.subtract(1, "year");
+  return lastSubDate.isBefore(oneYearAgo);
+}

--- a/utilities/ActionSummaryUtilities.ts
+++ b/utilities/ActionSummaryUtilities.ts
@@ -55,7 +55,7 @@ function getInfoActions(formList: IFormR[], noSubFormR: boolean) {
   if (noSubFormR) {
     return {
       isForInfoWithinYearSubForm: false,
-      isForInfoMoreThanYearSubForm: false,
+      isForInfoYearPlusSubForm: false,
       latestSubDateForm: null
     };
   }
@@ -66,12 +66,12 @@ function getInfoActions(formList: IFormR[], noSubFormR: boolean) {
     latestSubDateForm &&
     isLatestSubmissionDateWithinLastYear(latestSubDateForm);
 
-  const isForInfoMoreThanYearSubForm =
-    latestSubDateForm && isLatestSubmissionDateMoreThanYear(latestSubDateForm);
+  const isForInfoYearPlusSubForm =
+    latestSubDateForm && isLatestSubmissionDateYearPlus(latestSubDateForm);
 
   return {
     isForInfoWithinYearSubForm,
-    isForInfoMoreThanYearSubForm,
+    isForInfoYearPlusSubForm,
     latestSubDateForm
   };
 }
@@ -111,13 +111,13 @@ export function isLatestSubmissionDateWithinLastYear(
   const oneYearAgo = today.subtract(1, "year");
   return (
     lastSubDate.isAfter(oneYearAgo) &&
-    (lastSubDate.isBefore(today) || lastSubDate.isSame(today))
+    (lastSubDate.isBefore(today, "day") || lastSubDate.isSame(today, "day"))
   );
 }
 
-export function isLatestSubmissionDateMoreThanYear(subDate: DateType) {
+export function isLatestSubmissionDateYearPlus(subDate: DateType) {
   const lastSubDate = dayjs(subDate);
   const today = dayjs();
   const oneYearAgo = today.subtract(1, "year");
-  return lastSubDate.isBefore(oneYearAgo);
+  return lastSubDate.isSameOrBefore(oneYearAgo, "day");
 }

--- a/utilities/ActionSummaryUtilities.ts
+++ b/utilities/ActionSummaryUtilities.ts
@@ -38,11 +38,10 @@ export function getAllInfoFormRSubmissionSummaryActions(
   formListA: IFormR[],
   formListB: IFormR[]
 ) {
-  const { noSubFormRA, noSubFormRB } = noSubFormR(formListA, formListB);
-
+  const noSubFormRA = noSubmittedForms(formListA);
+  const noSubFormRB = noSubmittedForms(formListB);
   const infoA = getInfoActions(formListA, noSubFormRA);
   const infoB = getInfoActions(formListB, noSubFormRB);
-
   return {
     noSubFormRA,
     noSubFormRB,
@@ -76,10 +75,18 @@ function getInfoActions(formList: IFormR[], noSubFormR: boolean) {
   };
 }
 
-export function filterSubmittedFormList(formList: IFormR[]) {
+function filterSubmittedFormList(formList: IFormR[]) {
   return formList.filter(
     form => form.lifecycleState === LifeCycleState.Submitted
   );
+}
+
+export function noSubmittedForms(formList: IFormR[]) {
+  if (!formList || formList.length < 1) {
+    return true;
+  }
+  const filteredSubList = filterSubmittedFormList(formList);
+  return filteredSubList.length < 1;
 }
 
 function isAnyFormInProgress(formList: IFormR[]): boolean {
@@ -87,14 +94,6 @@ function isAnyFormInProgress(formList: IFormR[]): boolean {
     formList.filter(form => form.lifecycleState !== LifeCycleState.Submitted)
       .length > 0
   );
-}
-
-function noSubFormR(formListA: IFormR[], formListB: IFormR[]) {
-  const filteredSumittedFormListA = filterSubmittedFormList(formListA);
-  const filteredSumittedFormListB = filterSubmittedFormList(formListB);
-  const noSubFormRA = filteredSumittedFormListA.length < 1;
-  const noSubFormRB = filteredSumittedFormListB.length < 1;
-  return { noSubFormRA, noSubFormRB };
 }
 
 export function getLatestSubDate(formList: IFormR[]) {

--- a/utilities/CojUtilities.ts
+++ b/utilities/CojUtilities.ts
@@ -39,6 +39,14 @@ export class CojUtilities {
     );
   }
 
+  public static unsignedCojs(programmeMemberships: ProgrammeMembership[]) {
+    return programmeMemberships.filter(
+      pm =>
+        !pm.conditionsOfJoining.signedAt &&
+        this.canBeSigned(new Date(pm.startDate))
+    );
+  }
+
   public static canBeSigned(startDate: Date): boolean {
     const now = new Date();
     const signableFrom = this.getSignableFromDate(startDate);

--- a/utilities/DateUtilities.ts
+++ b/utilities/DateUtilities.ts
@@ -12,6 +12,12 @@ day.extend(isBetween);
 day.extend(isSameOrBefore);
 day.extend(isSameOrAfter);
 export const todayDate = day().toDate();
+export const dateWithinYear = day().subtract(1, "year").add(1, "day").toDate();
+export const dateExactlyYearAgo = day().subtract(1, "year").toDate();
+export const dateMoreThanYearAgo = day()
+  .subtract(1, "year")
+  .subtract(1, "day")
+  .toDate();
 export type DateType = Date | string | null | undefined;
 export type DateUnitType =
   | "millisecond"

--- a/utilities/DateUtilities.ts
+++ b/utilities/DateUtilities.ts
@@ -11,7 +11,7 @@ day.extend(timezone);
 day.extend(isBetween);
 day.extend(isSameOrBefore);
 day.extend(isSameOrAfter);
-const todayDate = day().toDate();
+export const todayDate = day().toDate();
 export type DateType = Date | string | null | undefined;
 export type DateUnitType =
   | "millisecond"

--- a/utilities/__test__/ActionSummary.test.ts
+++ b/utilities/__test__/ActionSummary.test.ts
@@ -1,0 +1,24 @@
+import dayjs from "dayjs";
+import { isLatestSubmissionDateWithinLastYear } from "../ActionSummaryUtilities";
+
+describe("isLatestSubmissionDateWithinLastYear", () => {
+  it("should return true when latest submission date is within the last year.", () => {
+    const lastSubStartDate = dayjs().subtract(1, "year").add(1, "day").toDate();
+    expect(isLatestSubmissionDateWithinLastYear(lastSubStartDate)).toBe(true);
+  });
+  it("should return true when latest submission date is today.", () => {
+    const lastSubStartDate = dayjs().toDate();
+    expect(isLatestSubmissionDateWithinLastYear(lastSubStartDate)).toBe(true);
+  });
+  it("should return false when latest submission date is exactly a year ago.", () => {
+    const lastSubStartDate = dayjs().subtract(1, "year").toDate();
+    expect(isLatestSubmissionDateWithinLastYear(lastSubStartDate)).toBe(false);
+  });
+  it("should return false when latest submission date is more than a year ago.", () => {
+    const lastSubStartDate = dayjs()
+      .subtract(1, "year")
+      .subtract(1, "day")
+      .toDate();
+    expect(isLatestSubmissionDateWithinLastYear(lastSubStartDate)).toBe(false);
+  });
+});

--- a/utilities/__test__/ActionSummary.test.ts
+++ b/utilities/__test__/ActionSummary.test.ts
@@ -1,24 +1,26 @@
-import dayjs from "dayjs";
 import { isLatestSubmissionDateWithinLastYear } from "../ActionSummaryUtilities";
+import {
+  dateExactlyYearAgo,
+  dateMoreThanYearAgo,
+  dateWithinYear,
+  todayDate
+} from "../DateUtilities";
 
 describe("isLatestSubmissionDateWithinLastYear", () => {
   it("should return true when latest submission date is within the last year.", () => {
-    const lastSubStartDate = dayjs().subtract(1, "year").add(1, "day").toDate();
-    expect(isLatestSubmissionDateWithinLastYear(lastSubStartDate)).toBe(true);
+    expect(isLatestSubmissionDateWithinLastYear(dateWithinYear)).toBe(true);
   });
   it("should return true when latest submission date is today.", () => {
-    const lastSubStartDate = dayjs().toDate();
-    expect(isLatestSubmissionDateWithinLastYear(lastSubStartDate)).toBe(true);
+    expect(isLatestSubmissionDateWithinLastYear(todayDate)).toBe(true);
   });
   it("should return false when latest submission date is exactly a year ago.", () => {
-    const lastSubStartDate = dayjs().subtract(1, "year").toDate();
-    expect(isLatestSubmissionDateWithinLastYear(lastSubStartDate)).toBe(false);
+    expect(isLatestSubmissionDateWithinLastYear(dateExactlyYearAgo)).toBe(
+      false
+    );
   });
   it("should return false when latest submission date is more than a year ago.", () => {
-    const lastSubStartDate = dayjs()
-      .subtract(1, "year")
-      .subtract(1, "day")
-      .toDate();
-    expect(isLatestSubmissionDateWithinLastYear(lastSubStartDate)).toBe(false);
+    expect(isLatestSubmissionDateWithinLastYear(dateMoreThanYearAgo)).toBe(
+      false
+    );
   });
 });

--- a/utilities/__test__/ActionSummaryUtilities.test.ts
+++ b/utilities/__test__/ActionSummaryUtilities.test.ts
@@ -1,4 +1,7 @@
-import { isLatestSubmissionDateWithinLastYear } from "../ActionSummaryUtilities";
+import {
+  isLatestSubmissionDateYearPlus,
+  isLatestSubmissionDateWithinLastYear
+} from "../ActionSummaryUtilities";
 import {
   dateExactlyYearAgo,
   dateMoreThanYearAgo,
@@ -22,5 +25,17 @@ describe("isLatestSubmissionDateWithinLastYear", () => {
     expect(isLatestSubmissionDateWithinLastYear(dateMoreThanYearAgo)).toBe(
       false
     );
+  });
+});
+
+describe("isLatestSubmissionDateYearPlus", () => {
+  it("should return true when latest submission date is more than a year ago.", () => {
+    expect(isLatestSubmissionDateYearPlus(dateMoreThanYearAgo)).toBe(true);
+  });
+  it("should return false when latest submission date is within the last year.", () => {
+    expect(isLatestSubmissionDateYearPlus(dateWithinYear)).toBe(false);
+  });
+  it("should return true when latest submission date is exactly a year ago.", () => {
+    expect(isLatestSubmissionDateYearPlus(dateExactlyYearAgo)).toBe(true);
   });
 });

--- a/utilities/__test__/CojUtilities.test.ts
+++ b/utilities/__test__/CojUtilities.test.ts
@@ -307,3 +307,21 @@ describe("CojUtilities", () => {
     });
   });
 });
+
+describe("CojUtilities (for Action Summary and Alert) - unsignedCojs", () => {
+  it("should return an unsigned CoJ Programme when no signedAt date", () => {
+    expect(
+      CojUtilities.unsignedCojs([mockProgrammeMembershipCojNotSigned])
+    ).toEqual([mockProgrammeMembershipCojNotSigned]);
+  });
+  it("should return an empty array when all CoJ Programmes are signed", () => {
+    expect(
+      CojUtilities.unsignedCojs([
+        {
+          ...mockProgrammeMembershipCojSigned,
+          conditionsOfJoining: { signedAt: new Date(), version: "GG1" }
+        }
+      ])
+    ).toEqual([]);
+  });
+});

--- a/utilities/__test__/CojUtilities.test.ts
+++ b/utilities/__test__/CojUtilities.test.ts
@@ -228,11 +228,11 @@ describe("CojUtilities", () => {
 
       const signed = mockProgrammeMembershipCojSigned;
       const preCojEpoch = {
-        ...mockProgrammeMembershipCojNotSigned,
+        ...mockProgrammeMembershipCojNotSigned[0],
         startDate: new Date(PRE_COJ_EPOCH)
       };
       const preSignableDate = {
-        ...mockProgrammeMembershipCojNotSigned,
+        ...mockProgrammeMembershipCojNotSigned[0],
         startDate: new Date(
           currentDate.getTime() + SIGNING_WINDOW_OFFSET_IN_MS + DAY_IN_MS
         )
@@ -250,11 +250,11 @@ describe("CojUtilities", () => {
 
       const signed = mockProgrammeMembershipCojSigned;
       const postCojEpoch = {
-        ...mockProgrammeMembershipCojNotSigned,
+        ...mockProgrammeMembershipCojNotSigned[0],
         startDate: new Date(POST_COJ_EPOCH)
       };
       const preSignableDate = {
-        ...mockProgrammeMembershipCojNotSigned,
+        ...mockProgrammeMembershipCojNotSigned[0],
         startDate: new Date(
           currentDate.getTime() + SIGNING_WINDOW_OFFSET_IN_MS + DAY_IN_MS
         )
@@ -272,11 +272,11 @@ describe("CojUtilities", () => {
 
       const signed = mockProgrammeMembershipCojSigned;
       const preCojEpoch = {
-        ...mockProgrammeMembershipCojNotSigned,
+        ...mockProgrammeMembershipCojNotSigned[0],
         startDate: new Date(PRE_COJ_EPOCH)
       };
       const postSignableDate = {
-        ...mockProgrammeMembershipCojNotSigned,
+        ...mockProgrammeMembershipCojNotSigned[0],
         startDate: new Date(currentDate.getTime() + SIGNING_WINDOW_OFFSET_IN_MS)
       };
 
@@ -291,11 +291,11 @@ describe("CojUtilities", () => {
       const currentDate = new Date(COJ_EPOCH);
 
       const postCojEpoch = {
-        ...mockProgrammeMembershipCojNotSigned,
+        ...mockProgrammeMembershipCojNotSigned[0],
         startDate: new Date(POST_COJ_EPOCH)
       };
       const postSignableDate = {
-        ...mockProgrammeMembershipCojNotSigned,
+        ...mockProgrammeMembershipCojNotSigned[0],
         startDate: new Date(currentDate.getTime() + SIGNING_WINDOW_OFFSET_IN_MS)
       };
 
@@ -311,8 +311,8 @@ describe("CojUtilities", () => {
 describe("CojUtilities (for Action Summary and Alert) - unsignedCojs", () => {
   it("should return an unsigned CoJ Programme when no signedAt date", () => {
     expect(
-      CojUtilities.unsignedCojs([mockProgrammeMembershipCojNotSigned])
-    ).toEqual([mockProgrammeMembershipCojNotSigned]);
+      CojUtilities.unsignedCojs([mockProgrammeMembershipCojNotSigned[0]])
+    ).toEqual([mockProgrammeMembershipCojNotSigned[0]]);
   });
   it("should return an empty array when all CoJ Programmes are signed", () => {
     expect(

--- a/utilities/hooks/action-summary/useInProgressActions.ts
+++ b/utilities/hooks/action-summary/useInProgressActions.ts
@@ -1,0 +1,12 @@
+import { useAppSelector } from "../../../redux/hooks/hooks";
+import { getAllInProgressSummaryActions } from "../../ActionSummaryUtilities";
+
+export function useInProgressActions() {
+  const formAList = useAppSelector(state => state.formA.formAList);
+  const formBList = useAppSelector(state => state.formB.formBList);
+
+  const { isInProgressFormA, isInProgressFormB } =
+    getAllInProgressSummaryActions(formAList, formBList);
+
+  return { isInProgressFormA, isInProgressFormB };
+}

--- a/utilities/hooks/action-summary/useInfoActions.ts
+++ b/utilities/hooks/action-summary/useInfoActions.ts
@@ -1,0 +1,17 @@
+import { useAppSelector } from "../../../redux/hooks/hooks";
+import { getAllInfoFormRSubmissionSummaryActions } from "../../../utilities/ActionSummaryUtilities";
+
+export function useInfoActions() {
+  const formAList = useAppSelector(state => state.formA.formAList);
+  const formBList = useAppSelector(state => state.formB.formBList);
+
+  const { noSubFormRA, noSubFormRB, infoActionsA, infoActionsB } =
+    getAllInfoFormRSubmissionSummaryActions(formAList, formBList);
+
+  return {
+    noSubFormRA,
+    noSubFormRB,
+    infoActionsA,
+    infoActionsB
+  };
+}

--- a/utilities/hooks/action-summary/useOutstandingActions.ts
+++ b/utilities/hooks/action-summary/useOutstandingActions.ts
@@ -1,0 +1,16 @@
+import { useAppSelector } from "../../../redux/hooks/hooks";
+import {
+  OutstandingSummaryActions,
+  getAllOutstandingSummaryActions
+} from "../../ActionSummaryUtilities";
+
+export function useOutstandingActions() {
+  const unsignedCojs = useAppSelector(
+    state => state.traineeProfile.unsignedCojs
+  );
+
+  const { unsignedCojCount }: OutstandingSummaryActions =
+    getAllOutstandingSummaryActions(unsignedCojs);
+
+  return { unsignedCojCount };
+}

--- a/utilities/hooks/useIsMobile.ts
+++ b/utilities/hooks/useIsMobile.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+export const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const mobileView = window.innerWidth <= 768;
+      setIsMobile(mobileView);
+    };
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return isMobile;
+};


### PR DESCRIPTION
Work so far:

- Add an Action Summary section to TSS home page
- Add a Action Summary Alert to be displayed on all pages except Home and MFA (when `NOMFA` ) with text indicating outstanding action (CoJ) or other important Form R submission-related info.
-  Minimise TSS Header on mobile so you can at least see the Action Summary header  

Note: The Action Summary Alert state management (mainly around the Form R lists) is a bit messy so will most probably create a follow-up ticket to refactor this.

TIS21-5400
TIS21-5508


TODO 
Once this is merged, Tosin will add the Hotjar surveys to the CoJ and Form R confirm pages https://hee-tis.atlassian.net/browse/TIS21-5514 

