### PR TITLE
feat: re-enable covid declaration flag

### DIFF
--- a/components/forms/formr-part-b/viewSections/View.tsx
+++ b/components/forms/formr-part-b/viewSections/View.tsx
@@ -29,7 +29,9 @@ interface IView {
 const View = ({ canEdit, history }: IView) => {
   const dispatch = useAppDispatch();
   const formData = useAppSelector(selectSavedFormB);
-  const isCovidDeclarationNull = formData.haveCovidDeclarations === null;
+  const enableCovidDeclaration = useAppSelector(state =>
+    state.featureFlags.featureFlags.formRPartB.covidDeclaration.valueOf()
+  );
   const viewCompSection: number = store.getState().formB.sectionNumber;
   let content;
 
@@ -80,7 +82,7 @@ const View = ({ canEdit, history }: IView) => {
         <ViewSection4 {...viewSectionProps} />
         <ViewSection5 {...viewSectionProps} />
         <ViewSection6 {...viewSectionProps} />
-        {isCovidDeclarationNull ? <ViewSection7 {...viewSectionProps} /> : null}
+        {enableCovidDeclaration ? <ViewSection7 {...viewSectionProps} /> : null}
         {!canEdit && <ViewSection8 {...viewSectionProps} />}
         {!canEdit &&
           FormRUtilities.displaySubmissionDate(

--- a/cypress/e2e/formr-b/FormRB.spec.ts
+++ b/cypress/e2e/formr-b/FormRB.spec.ts
@@ -75,7 +75,7 @@ describe("Form R (Part B) - desktop", () => {
   });
 
   it("should complete a new form", () => {
-    isCovid = false;
+    isCovid = true;
 
     // -------- Section 1 - Doctor's details -----------
     cy.get(".progress-step")
@@ -188,11 +188,18 @@ describe("Form R (Part B) - desktop", () => {
     cy.get("[data-cy=LinkToNextSection] > .nhsuk-pagination__page").click();
 
     // -------- COVID Section ------------------------------------------------
-    //should be disabled whilst covide declaration flag is disabled in trainee-forms
     if (isCovid) {
       cy.log("### COVID SECTION CHECK ###");
-      cy.get("[data-cy=LinkToNextSection] > .nhsuk-pagination__page").should("not.exist");
-      cy.get("#haveCovidDeclarations--error-message").should("not.exist");
+      cy.get(".progress-step")
+        .eq(6)
+        .should("have.class", "progress-step-active");
+      cy.get("[data-cy=LinkToNextSection] > .nhsuk-pagination__page").click();
+      cy.get("#haveCovidDeclarations--error-message").should("exist");
+      cy.get(".progress-step")
+        .eq(6)
+        .should("have.class", "progress-step-active");
+      cy.checkAndFillCovidSection();
+      cy.get("[data-cy=LinkToNextSection] > .nhsuk-pagination__page").click();
     }
 
     // -------- Confirm / Review Section --------------------------------------
@@ -203,7 +210,7 @@ describe("Form R (Part B) - desktop", () => {
       "contain.text",
       dayjs(farFutureDate).format("DD/MM/YYYY")
     );
-    //check if Covid section exists or not depending on flag
+    // check if Covid section exists or not depending on flag
     if (isCovid) {
       cy.get("[data-cy=sectionHeader7]").should("exist");
       cy.get("[data-cy=BtnEditSection7]").should("exist");
@@ -221,13 +228,13 @@ describe("Form R (Part B) - desktop", () => {
     }
 
     //check the health statment populates correctly when empty
-    for (let x = 0; x < 4; x++) {
+    for (let x = 0; x < 5; x++) {
       cy.get(
         "[data-cy=LinkToPreviousSection] > .nhsuk-pagination__page"
       ).click();
     }
     cy.get(".nhsuk-form-group > [data-cy=healthStatement]").clear();
-    for (let x = 0; x < 4; x++) {
+    for (let x = 0; x < 5; x++) {
       cy.get("[data-cy=LinkToNextSection] > .nhsuk-pagination__title").click();
     }
     cy.get("[data-cy=healthStatement]").should(
@@ -245,13 +252,13 @@ describe("Form R (Part B) - desktop", () => {
 
     //go back to section 4 and click no previous unresolved declarations
     //check option dissapears from view
-    for (let x = 0; x < 3; x++) {
+    for (let x = 0; x < 4; x++) {
       cy.get(
         "[data-cy=LinkToPreviousSection] > .nhsuk-pagination__page"
       ).click();
     }
     cy.get("[data-cy=havePreviousUnresolvedDeclarations1]").click();
-    for (let x = 0; x < 3; x++) {
+    for (let x = 0; x < 4; x++) {
       cy.get("[data-cy=LinkToNextSection] > .nhsuk-pagination__title").click();
     }
     cy.get(
@@ -260,13 +267,13 @@ describe("Form R (Part B) - desktop", () => {
 
     //go back to section 5 and click no previous unresolved declarations
     //check option dissapears from view
-    for (let x = 0; x < 2; x++) {
+    for (let x = 0; x < 3; x++) {
       cy.get(
         "[data-cy=LinkToPreviousSection] > .nhsuk-pagination__page"
       ).click();
     }
     cy.get("[data-cy=haveCurrentUnresolvedDeclarations1]").click();
-    for (let x = 0; x < 2; x++) {
+    for (let x = 0; x < 3; x++) {
       cy.get("[data-cy=LinkToNextSection] > .nhsuk-pagination__title").click();
     }
     cy.get(
@@ -325,7 +332,7 @@ describe("Form R (Part B) - desktop", () => {
     cy.get("[data-cy=LinkToPreviousSection] > .nhsuk-pagination__page").click();
     cy.get("[data-cy=BtnBackToSubmit]").should("not.exist");
 
-    for (let x = 0; x < 3; x++) {
+    for (let x = 0; x < 4; x++) {
       cy.get("[data-cy=LinkToNextSection] > .nhsuk-pagination__title").click();
       cy.get("[data-cy=BtnBackToSubmit]").should("not.exist");
     }
@@ -346,7 +353,7 @@ describe("Form R (Part B) - desktop", () => {
     cy.get(".nhsuk-warning-callout").should("exist");
     cy.get("[data-cy=gmcNumber]").should("exist");
 
-    for (let x = 0; x < 6; x++) {
+    for (let x = 0; x < 7; x++) {
       cy.get("[data-cy=LinkToNextSection] > .nhsuk-pagination__title").click();
       cy.get("[data-cy=BtnBackToSubmit]").should("not.exist");
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.85.5",
+  "version": "0.85.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.85.4",
+      "version": "0.85.6",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",
@@ -97,9 +97,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg=="
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -24707,9 +24707,9 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA=="
     },
     "@adobe/css-tools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg=="
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw=="
     },
     "@ampproject/remapping": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.85.5",
+  "version": "0.85.6",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",


### PR DESCRIPTION
this has been re-enabled because when a form has been unsubmitted or is in draft and the user has already compleated the covid declaration section before the switch, the user will lose the ability to alter their covid section and will be stuck with their previous changes. which they will also still be able to view.

TIS21-5513