### PR TITLE
Un-nobble the in-progress Action Summary logic

### DIFF
--- a/components/forms/FormsListBtn.tsx
+++ b/components/forms/FormsListBtn.tsx
@@ -66,8 +66,6 @@ function chooseBtnText(lifecycleState: LifeCycleState | undefined) {
   switch (lifecycleState) {
     case LifeCycleState.Draft:
       return "Edit saved draft form";
-    case LifeCycleState.Local:
-      return "Edit unsaved draft form";
     case LifeCycleState.Unsubmitted:
       return "Edit unsubmitted form";
     default:

--- a/models/LifeCycleState.ts
+++ b/models/LifeCycleState.ts
@@ -2,6 +2,5 @@ export enum LifeCycleState {
   New = "NEW",
   Draft = "DRAFT",
   Submitted = "SUBMITTED",
-  Unsubmitted = "UNSUBMITTED",
-  Local = "LOCAL"
+  Unsubmitted = "UNSUBMITTED"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.87.0",
+  "version": "0.87.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.87.0",
+      "version": "0.87.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.87.0",
+  "version": "0.87.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/ActionSummaryUtilities.ts
+++ b/utilities/ActionSummaryUtilities.ts
@@ -91,8 +91,11 @@ export function noSubmittedForms(formList: IFormR[]) {
 
 function isAnyFormInProgress(formList: IFormR[]): boolean {
   return (
-    formList.filter(form => form.lifecycleState !== LifeCycleState.Submitted)
-      .length > 0
+    formList.filter(
+      form =>
+        form.lifecycleState === LifeCycleState.Draft ||
+        form.lifecycleState === LifeCycleState.Unsubmitted
+    ).length > 0
   );
 }
 


### PR DESCRIPTION
**Problem**
Forms service API fetch currently includes the DELETED lifecycle state which has nobbled the FE Action Summary.

**Solution**
Refactor isAnyFormInProgress util function so it only filters draft and unsubmitted lifecycle states. 
(Also, a bit of boy-scouting...remove unused local lifecycle state from enum).

NO TICKET
