### PR TITLE
fix: the 'Hawaii problem'

### DIFF
--- a/components/forms/form-builder/form-r/part-a/formAValidationSchema.ts
+++ b/components/forms/form-builder/form-r/part-a/formAValidationSchema.ts
@@ -15,7 +15,7 @@ export const formAValidationSchema = yup.object({
   gmcNumber: StringValidationSchema("GMC number", 20),
   localOfficeName: StringValidationSchema("Deanery / HEE Local Office"),
   dateOfBirth: dateValidationSchema("Your date of birth")
-    .test("dateOfBirth", "You must be 17 years or above", value =>
+    .test("dateOfBirth", "You must be 18 years or above", value =>
       DateUtilities.IsLegalAge(value)
     )
     .test(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.87.1",
+  "version": "0.87.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.87.1",
+      "version": "0.87.2",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.87.1",
+  "version": "0.87.2",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/ActionSummaryUtilities.ts
+++ b/utilities/ActionSummaryUtilities.ts
@@ -111,10 +111,7 @@ export function isLatestSubmissionDateWithinLastYear(
   const lastSubDate = dayjs(lastSubStartDate);
   const today = dayjs();
   const oneYearAgo = today.subtract(1, "year");
-  return (
-    lastSubDate.isAfter(oneYearAgo) &&
-    (lastSubDate.isBefore(today, "day") || lastSubDate.isSame(today, "day"))
-  );
+  return lastSubDate.isAfter(oneYearAgo);
 }
 
 export function isLatestSubmissionDateYearPlus(subDate: DateType) {

--- a/utilities/__test__/DateUtilities.test.ts
+++ b/utilities/__test__/DateUtilities.test.ts
@@ -7,6 +7,8 @@ describe("DateUtilities", () => {
   const yesterday = now.subtract(1, "day").toDate();
   const tomorrow = now.add(1, "day").toDate();
   const today = now.toDate();
+  const belowLegalAge = now.subtract(17, "year").toDate();
+  const legalAge = now.subtract(18, "year").toDate();
 
   it("ToLocalDateTime should return date in DD/MM/YYYY HH:mm format", () => {
     expect(DateUtilities.ToLocalDateTime(new Date("2020-04-20 12:42"))).toEqual(
@@ -40,12 +42,12 @@ describe("DateUtilities", () => {
     expect(DateUtilities.IsLegalAge(null)).toEqual(true);
   });
 
-  it("IsLegalAge should return true if age is above 18", () => {
-    expect(DateUtilities.IsLegalAge(new Date("2000-04-20"))).toEqual(true);
+  it("IsLegalAge should return true if age is 18 or above", () => {
+    expect(DateUtilities.IsLegalAge(legalAge)).toEqual(true);
   });
 
   it("IsLegalAge should return false if age is below 18", () => {
-    expect(DateUtilities.IsLegalAge(new Date("2019-04-20"))).toEqual(false);
+    expect(DateUtilities.IsLegalAge(belowLegalAge)).toEqual(false);
   });
 
   it("IsPastDate should return true if date is null", () => {


### PR DESCRIPTION
...where the user submits a form in e.g. Hawaii (UTC -10:00) timezone at say 10pm on 10/01/2024, which BE saves as 8am 11/01/2024 UTC. The result is a latest submitted 'future' form not being displayed in the Action Summary. Easiest fix is to remove the future constraint from the utils function logic (not sure why it was there in the first place tbh).

Also, after carefully considering the 'Doogie Howser, M.D. factor' with my learned colleague, R. Roberts esq. ,make the legalAge text match the D.O.B. validation logic (18+) - which in turn matches the BE validation logic.

NO TICKET