### PR TITLE
feat: Add validation to Form A View #1

### DIFF
--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -477,15 +477,8 @@ export default function FormBuilder({
           </div>
         </>
       )}
-      {/* Render error summary for the entire form */}
       {Object.keys(formErrors).length > 0 && (
-        <ErrorSummary
-          aria-labelledby="errorSummaryTitle"
-          role="alert"
-          tabIndex={-1}
-        >
-          <FormErrors formErrors={formErrors} />
-        </ErrorSummary>
+        <FormErrors formErrors={formErrors} />
       )}
       <nav className="nhsuk-pagination">
         <ul className="nhsuk-list nhsuk-pagination__list">
@@ -568,17 +561,26 @@ interface FormErrorsProps {
   formErrors: Record<string, string>;
 }
 
-function FormErrors({ formErrors }: Readonly<FormErrorsProps>) {
+export function FormErrors({ formErrors }: Readonly<FormErrorsProps>) {
   return (
-    <div className="error-summary" data-cy="errorSummary">
-      <p>
-        <b>Please fix the following errors before proceeding:</b>
-      </p>
-      <ul>
-        {Object.entries(formErrors).map(error => (
-          <li data-cy={`error-txt-${error}`} key={error[0]}>{`${error[1]}`}</li>
-        ))}
-      </ul>
-    </div>
+    <ErrorSummary
+      aria-labelledby="errorSummaryTitle"
+      role="alert"
+      tabIndex={-1}
+    >
+      <div className="error-summary" data-cy="errorSummary">
+        <p>
+          <b>Please fix the following errors before proceeding:</b>
+        </p>
+        <ul>
+          {Object.entries(formErrors).map(error => (
+            <li
+              data-cy={`error-txt-${error}`}
+              key={error[0]}
+            >{`${error[1]}`}</li>
+          ))}
+        </ul>
+      </div>
+    </ErrorSummary>
   );
 }

--- a/components/forms/form-builder/FormViewBuilder.tsx
+++ b/components/forms/form-builder/FormViewBuilder.tsx
@@ -8,12 +8,14 @@ interface FormViewBuilderProps {
   jsonForm: Form;
   formData: FormData;
   canEdit: boolean;
+  formErrors: { [key: string]: string };
 }
 
 const FormViewBuilder: React.FC<FormViewBuilderProps> = ({
   jsonForm,
   formData,
-  canEdit
+  canEdit,
+  formErrors
 }: FormViewBuilderProps) => {
   return (
     <div>
@@ -22,7 +24,7 @@ const FormViewBuilder: React.FC<FormViewBuilderProps> = ({
           <Card feature>
             <Card.Content>
               <Card.Heading>{page.pageName}</Card.Heading>
-              {page.sections.map((section, sectionIndex) => (
+              {page.sections.map((section, _sectionIndex) => (
                 <div key={section.sectionHeader}>
                   {canEdit && (
                     <Button
@@ -36,19 +38,21 @@ const FormViewBuilder: React.FC<FormViewBuilderProps> = ({
                     </Button>
                   )}
                   <SummaryList>
-                    {section.fields.map(field =>
-                      // viewWhenEmpty json field prop is used when we want to to display empty fields as "Not provided"
-                      formData[field.name] || field.viewWhenEmpty ? (
-                        <SummaryList.Row key={field.name}>
-                          <SummaryList.Key data-cy={`${field.name}-label`}>
-                            {field.label}
-                          </SummaryList.Key>
-                          <SummaryList.Value data-cy={`${field.name}-value`}>
-                            {displayListValue(formData[field.name], field.type)}
-                          </SummaryList.Value>
-                        </SummaryList.Row>
-                      ) : null
-                    )}
+                    {section.fields.map(field => (
+                      <SummaryList.Row key={field.name}>
+                        <SummaryList.Key
+                          data-cy={`${field.name}-label`}
+                          className={
+                            formErrors[field.name] ? "nhsuk-error-message" : ""
+                          }
+                        >
+                          {field.label}
+                        </SummaryList.Key>
+                        <SummaryList.Value data-cy={`${field.name}-value`}>
+                          {displayListValue(formData[field.name], field.type)}
+                        </SummaryList.Value>
+                      </SummaryList.Row>
+                    ))}
                   </SummaryList>
                 </div>
               ))}
@@ -62,10 +66,10 @@ const FormViewBuilder: React.FC<FormViewBuilderProps> = ({
 
 export default FormViewBuilder;
 
-function displayListValue(fieldName: string, fieldType: string) {
-  if (!fieldName) return "Not provided";
-  if (fieldType === "date" && fieldName) {
-    return DateUtilities.ToLocalDate(fieldName);
+function displayListValue(fieldVal: string, fieldType: string) {
+  if (!fieldVal) return "Not provided";
+  if (fieldType === "date" && fieldVal) {
+    return DateUtilities.ToLocalDate(fieldVal);
   }
-  return fieldName;
+  return fieldVal;
 }

--- a/components/forms/form-builder/form-r/part-a/formAValidationSchema.ts
+++ b/components/forms/form-builder/form-r/part-a/formAValidationSchema.ts
@@ -9,7 +9,7 @@ import {
 const dateValidationSchema = (fieldName: string) =>
   yup.date().nullable().required(`${fieldName} is required`);
 
-export const formAValidationSchema = yup.object({
+const formAValidationSchemaDefault = {
   forename: StringValidationSchema("Forename"),
   surname: StringValidationSchema("GMC-Registered Surname"),
   gmcNumber: StringValidationSchema("GMC number", 20),
@@ -92,4 +92,14 @@ export const formAValidationSchema = yup.object({
       "Training hours (Full Time Equivalent) needs to be a number less than or equal to 1 and greater than zero (a maximum of 2 decimal places)",
       value => (value ? CHECK_WHOLE_TIME_EQUIVALENT_REGEX.test(value) : false)
     )
+};
+
+export const formAValidationSchema = yup.object(formAValidationSchemaDefault);
+
+export const formAValidationSchemaView = yup.object({
+  ...formAValidationSchemaDefault,
+  cctSpecialty1: yup.string().when("declarationType", {
+    is: "I have been appointed to a programme leading to award of CCT",
+    then: yup.string().required("Specialty 1 for Award of CCT is required")
+  })
 });

--- a/cypress/component/forms/formr-part-a/View.cy.tsx
+++ b/cypress/component/forms/formr-part-a/View.cy.tsx
@@ -115,6 +115,7 @@ describe("View", () => {
       "have.class",
       "nhsuk-error-message"
     );
+    cy.get('[data-cy="BtnSubmit"]').should("be.disabled");
   });
   it("should display no error message when form passes validation", () => {
     const MockedViewNoErrors = () => {
@@ -137,5 +138,6 @@ describe("View", () => {
       </Provider>
     );
     cy.get(".nhsuk-error-summary").should("not.exist");
+    cy.get('[data-cy="BtnSubmit"]').should("not.be.disabled");
   });
 });

--- a/cypress/component/forms/formr-part-a/View.cy.tsx
+++ b/cypress/component/forms/formr-part-a/View.cy.tsx
@@ -66,7 +66,9 @@ describe("View", () => {
   it("should render view component with no save PDF btn/link for unsubmitted form", () => {
     const MockedViewUnsubmitted = () => {
       const dispatch = useAppDispatch();
-      dispatch(updatedFormA(submittedFormRPartAs[1]));
+      dispatch(
+        updatedFormA({ ...submittedFormRPartAs[1], wholeTimeEquivalent: "" })
+      );
       dispatch(updatedCanEdit(true));
       return <FormAView />;
     };
@@ -80,5 +82,60 @@ describe("View", () => {
     cy.get("[data-cy=backLink]").should("not.exist");
     cy.get("[data-cy=savePdfBtn]").should("not.exist");
     cy.get("[data-cy=pdfHelpLink]").should("not.exist");
+  });
+
+  it("should display the error messages for any fields failing validation", () => {
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <FormAView />
+        </Router>
+      </Provider>
+    );
+
+    cy.get(".nhsuk-error-summary").should("exist");
+    cy.get(
+      '[data-cy="error-txt-dateOfBirth,This date is before the minimum date allowed"]'
+    ).should("exist");
+    cy.get(
+      '[data-cy="error-txt-completionDate,Anticipated completion date - please choose a future date"]'
+    ).should("exist");
+    cy.get(
+      '[data-cy="error-txt-wholeTimeEquivalent,Training hours (Full Time Equivalent) needs to be a number less than or equal to 1 and greater than zero (a maximum of 2 decimal places)"]'
+    ).should("exist");
+    cy.get('[data-cy="dateOfBirth-label"]').should(
+      "have.class",
+      "nhsuk-error-message"
+    );
+    cy.get('[data-cy="completionDate-label"]').should(
+      "have.class",
+      "nhsuk-error-message"
+    );
+    cy.get('[data-cy="wholeTimeEquivalent-label"]').should(
+      "have.class",
+      "nhsuk-error-message"
+    );
+  });
+  it("should display no error message when form passes validation", () => {
+    const MockedViewNoErrors = () => {
+      const dispatch = useAppDispatch();
+      dispatch(
+        updatedFormA({
+          ...submittedFormRPartAs[1],
+          dateOfBirth: "01/01/2000",
+          completionDate: "01/01/2030",
+          wholeTimeEquivalent: "0.5"
+        })
+      );
+      return <FormAView />;
+    };
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <MockedViewNoErrors />
+        </Router>
+      </Provider>
+    );
+    cy.get(".nhsuk-error-summary").should("not.exist");
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.87.3",
+  "version": "0.87.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.87.3",
+      "version": "0.87.4",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.87.3",
+  "version": "0.87.4",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",


### PR DESCRIPTION
First iteration...
This commit is in preparation for https://hee-tis.atlassian.net/browse/TIS21-5578 
1. Display error summary box listing field errors
2. Use CSS to indicate individual field error
3. Disable the form submit button until errors are cleared

Had to tweak the visibility of elements displayed in the View component to ensure that all fields with errors are displayed. Next iteration will include better displayListValue logic to put 'N/A' next to a field name rather than 'None provided' where the conditional field logic determines this.

Also, future iterations can look to provide the same validation for Form B View.

NO TICKET