### PR TITLE
Fix  date configuration on text input field date picker

### DIFF
--- a/components/forms/TextInputField.tsx
+++ b/components/forms/TextInputField.tsx
@@ -49,7 +49,7 @@ const TextInputField: FunctionComponent<Props> = props => {
         {...rest}
         readOnly={props.readOnly}
         min="1920-01-01"
-        max="2119-31-12"
+        max="2119-12-31"
         data-cy={props.name}
       />
       <InputFooterLabel label={props.footer || ""} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.87.4",
+  "version": "0.87.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.87.4",
+      "version": "0.87.5",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.87.4",
+  "version": "0.87.5",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",


### PR DESCRIPTION
The year section of the date picker was allowing an excess of numbers due to the layout of the date being yyyy/dd/mm instead of yyyy/mm/dd

When trying to create tests to check if more than 4 digits could be entered into the field, it was found that cypress was unable to enter the values into the date picker in such a way that would allow individual digits to be added. 


TIS21-5645