### PR TITLE
refactor: FormBuilder logic to handle panel arrays (step 1 of about 4)

### DIFF
--- a/components/forms/MobilePhoneInputField.tsx
+++ b/components/forms/MobilePhoneInputField.tsx
@@ -6,32 +6,30 @@ interface IMobilePhoneInputField {
   name: string;
   label?: string;
   hidelabel?: boolean;
-  id?: string;
-  placeholder?: string;
   footer?: any;
-  value?: any;
   disabled?: boolean;
 }
 const MobilePhoneInputField: FunctionComponent<
   IMobilePhoneInputField
 > = props => {
   const [field, { error }, helpers] = useField(props);
+  const { name, label, hidelabel, footer, disabled } = props;
   return (
     <div
       className={`nhsuk-form-group ${error && "nhsuk-form-group--error"} ${
-        props.hidelabel && "hide-label"
+        hidelabel && "hide-label"
       }`}
     >
-      {props.label && (
+      {label && (
         <label htmlFor="mobilePhoneNumber" className="nhsuk-label">
-          {props.label}
+          {label}
         </label>
       )}
       <PhoneInput
         placeholder="Enter mobile number..."
         onBlur={field.onBlur}
-        disabled={props.disabled}
-        name="mobilePhoneNumber"
+        disabled={disabled}
+        name={name}
         defaultCountry="GB"
         onChange={value => {
           helpers.setValue(value);
@@ -45,7 +43,7 @@ const MobilePhoneInputField: FunctionComponent<
         <span className="nhsuk-u-visually-hidden">Error: </span>
         {error}
       </span>
-      <InputFooterLabel label={props.footer || ""} />
+      <InputFooterLabel label={footer || ""} />
     </div>
   );
 };

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -278,9 +278,8 @@ export default function FormBuilder({
                               )
                             : renderFormField(
                                 field,
-                                handleChange,
+                                { handleChange, handleBlur },
                                 fieldWarning,
-                                handleBlur,
                                 options,
                                 formData[field.name],
                                 formErrors[field.name]
@@ -442,15 +441,18 @@ function FormErrorsList({ formErrors }: Readonly<FormErrorsListProps>) {
 
 function renderFormField(
   field: Field,
-  handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void,
+  handlers: {
+    handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    handleBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
+  },
   fieldWarning: FieldWarning | undefined,
-  handleBlur: (event: React.FocusEvent<HTMLInputElement>) => void,
   options: any,
   value: unknown,
   error: any,
-  arrayIndex?: number,
-  arrayName?: string
+  arrayDetails?: { arrayIndex: number; arrayName: string }
 ): React.ReactElement | null {
+  const { handleChange, handleBlur } = handlers;
+  const { arrayIndex, arrayName } = arrayDetails ?? {};
   const { name, type, label, placeholder, optionsKey } = field;
   switch (type) {
     case "text":

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -403,7 +403,11 @@ function FormErrorsList({ formErrors }: Readonly<FormErrorsListProps>) {
         {Object.keys(formErrors).map(key => {
           if (typeof formErrors[key] === "string") {
             return (
-              <div key={key} className="error-spacing_div">
+              <div
+                key={key}
+                className="error-spacing_div"
+                data-cy={`error-txt-${formErrors[key]}`}
+              >
                 {formErrors[key]}
               </div>
             );

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -268,22 +268,28 @@ export default function FormBuilder({
                       <Card.Heading>{section.sectionHeader}</Card.Heading>
                       {visibleFields.map((field: Field) => (
                         <div key={field.name} className="nhsuk-form-group">
-                          {field.type === "array"
-                            ? renderArrayField(
-                                field,
-                                formData,
-                                setFormData,
-                                formErrors,
-                                renderFormField
-                              )
-                            : renderFormField(
-                                field,
-                                { handleChange, handleBlur },
-                                fieldWarning,
-                                options,
-                                formData[field.name],
-                                formErrors[field.name]
-                              )}
+                          {field.type === "array" ? (
+                            <PanelBuilder
+                              field={field}
+                              formData={formData}
+                              setFormData={setFormData}
+                              renderFormField={renderFormField}
+                              handleChange={handleChange}
+                              handleBlur={handleBlur}
+                              panelErrors={formErrors[field.name]}
+                              fieldWarning={fieldWarning}
+                              options={options}
+                            />
+                          ) : (
+                            renderFormField(
+                              field,
+                              formData[field.name],
+                              formErrors[field.name],
+                              fieldWarning,
+                              { handleChange, handleBlur },
+                              options
+                            )
+                          )}
                         </div>
                       ))}
                     </Card.Content>
@@ -307,6 +313,7 @@ export default function FormBuilder({
                     "nhsuk-pagination__link nhsuk-pagination__link--prev"
                   }
                   onClick={() => {
+                    setFormErrors({});
                     setCurrentPage(currentPage - 1);
                   }}
                   data-cy="navPrevious"
@@ -441,19 +448,29 @@ function FormErrorsList({ formErrors }: Readonly<FormErrorsListProps>) {
 
 function renderFormField(
   field: Field,
-  handlers: {
-    handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-    handleBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
-  },
-  fieldWarning: FieldWarning | undefined,
-  options: any,
   value: unknown,
   error: any,
+  fieldWarning: FieldWarning | undefined,
+  handlers: {
+    handleChange: (
+      event: any,
+      selectedOption?: any,
+      index?: number,
+      name?: string
+    ) => void;
+    handleBlur: (
+      event: any,
+      selectedOption?: any,
+      index?: number,
+      name?: string
+    ) => void;
+  },
+  options?: any,
   arrayDetails?: { arrayIndex: number; arrayName: string }
 ): React.ReactElement | null {
+  const { name, type, label, placeholder, optionsKey } = field;
   const { handleChange, handleBlur } = handlers;
   const { arrayIndex, arrayName } = arrayDetails ?? {};
-  const { name, type, label, placeholder, optionsKey } = field;
   switch (type) {
     case "text":
       return (
@@ -462,8 +479,8 @@ function renderFormField(
           label={label}
           handleChange={handleChange}
           fieldError={error ?? ""}
-          placeholder={placeholder}
           fieldWarning={fieldWarning}
+          placeholder={placeholder}
           handleBlur={handleBlur}
           value={value as string}
           arrayIndex={arrayIndex}
@@ -477,6 +494,7 @@ function renderFormField(
           label={label}
           options={filteredOptions(optionsKey, options)}
           handleChange={handleChange}
+          fieldError={error ?? ""}
           value={value as string}
           arrayIndex={arrayIndex}
           arrayName={arrayName}
@@ -517,6 +535,7 @@ function renderFormField(
           name={name}
           label={label}
           handleChange={handleChange}
+          fieldError={error ?? ""}
           value={value as string}
           arrayIndex={arrayIndex}
           arrayName={arrayName}
@@ -525,22 +544,4 @@ function renderFormField(
     default:
       return null;
   }
-}
-
-function renderArrayField(
-  field: Field,
-  formData: any,
-  setFormData: any,
-  formErrors: any,
-  renderFormField: any
-) {
-  return (
-    <PanelBuilder
-      field={field}
-      formData={formData}
-      setFormData={setFormData}
-      renderFormField={renderFormField}
-      panelErrors={formErrors[field.name]}
-    />
-  );
 }

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -12,12 +12,14 @@ import {
 } from "nhsuk-react-components";
 import {
   continueToConfirm,
+  createErrorObject,
+  filteredOptions,
   getEditPageNumber,
+  handleSoftValidationWarningMsgVisibility,
+  handleTextFieldWidth,
   saveDraftForm,
-  setTextFieldWidth,
-  showFieldMatchWarning
+  validateFields
 } from "../../../utilities/FormBuilderUtilities";
-import * as Yup from "yup";
 import { Link } from "react-router-dom";
 import DataSourceMsg from "../../common/DataSourceMsg";
 import { Text } from "./form-fields/Text";
@@ -32,8 +34,9 @@ import { AutosaveNote } from "../AutosaveNote";
 import { useAppSelector } from "../../../redux/hooks/hooks";
 import { StartOverButton } from "../StartOverButton";
 import store from "../../../redux/store/store";
+import PanelBuilder from "./form-array/PanelBuilder";
 
-export interface Field {
+export type Field = {
   name: string;
   label?: string;
   type: string;
@@ -46,39 +49,42 @@ export interface Field {
   canGrow?: boolean;
   viewWhenEmpty?: boolean;
   parent?: string;
-}
-export interface FormData {
+  objectFields?: Field[];
+  value?: unknown;
+};
+export type FormData = {
   [key: string]: any;
-}
-interface Page {
+};
+type Page = {
   pageName: string;
   importantTxtName?: string;
   msgLinkName?: string;
   sections: Section[];
-}
-interface Section {
+};
+type Section = {
   sectionHeader: string;
   fields: Field[];
-}
-export interface Form {
+  objectFields?: Field[];
+};
+export type Form = {
   name: string;
   pages: Page[];
-}
-interface FormBuilderProps {
+};
+type FormBuilderProps = {
   jsonForm: Form;
   fetchedFormData: FormData;
   options: any;
   validationSchema: any;
   history: string[];
-}
-export interface FieldWarning {
+};
+export type FieldWarning = {
   fieldName: string;
   warningMsg: string;
-}
-export interface Warning {
+};
+export type Warning = {
   matcher: string;
   msgText: string;
-}
+};
 
 export default function FormBuilder({
   jsonForm,
@@ -89,479 +95,287 @@ export default function FormBuilder({
 }: Readonly<FormBuilderProps>) {
   const jsonFormName = jsonForm.name;
   const pages = jsonForm.pages;
-  const [fields, setFields] = useState<Field[]>([]);
+  const [visibleFields, setVisibleFields] = useState<Field[]>([]);
   const isFormDirty = useRef(false);
   const isAutosaving =
     useAppSelector(state => state.formA.autosaveStatus) === "saving";
   const lastSavedFormData = store.getState().formA.formAData;
-
   const lastPage = pages.length - 1;
   const initialPageValue = useMemo(
     () => getEditPageNumber(jsonFormName),
     [jsonFormName]
   );
   const [currentPage, setCurrentPage] = useState(initialPageValue);
-  // Get the current field names from the JSON and then get the current fields (which includes their visibility status) for validation purposes
-  const fieldNamesForCurrentPage = pages[currentPage].sections.flatMap(
-    (section: Section) => section.fields.map((field: Field) => field.name)
-  );
-  const fieldNamesForCurrentPageSet = useMemo(
-    () => new Set(fieldNamesForCurrentPage),
-    [fieldNamesForCurrentPage]
-  );
-  const currentFields = useMemo(() => {
-    return fields.filter(field => fieldNamesForCurrentPageSet.has(field.name));
-  }, [fields, fieldNamesForCurrentPageSet]);
-
-  // Custom hook that tracks data changes and autosaves draft form data to db (currently triggered 2s after last dirty change)
-  const { formFields, setFormFields } = useFormAutosave(
+  const { formData, setFormData } = useFormAutosave(
     fetchedFormData,
     jsonFormName,
     isFormDirty
   );
-  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+  const [formErrors, setFormErrors] = useState<any>({});
   const [fieldWarning, setFieldWarning] = useState<FieldWarning | undefined>(
     undefined
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const filteredOptions = (optionsKey: string | undefined, options: any) => {
-    return optionsKey && options[optionsKey]?.length > 0
-      ? options[optionsKey]
-      : [];
-  };
+  const flatFields = useMemo(
+    () =>
+      pages[currentPage].sections.flatMap((section: Section) => section.fields),
+    [currentPage, pages]
+  );
 
-  const renderFormField = (field: Field) => {
-    const {
-      name,
-      type,
-      label,
-      placeholder,
-      visible,
-      visibleIf,
-      parent,
-      optionsKey
-    } = field;
-    const fieldError = formErrors[name];
-    // Note - Need to reference the parent field to ensure dependent fields are visible when they are meant to be shown (they default to hidden and are only shown via handleClick)
-    if (visible || (parent && visibleIf?.includes(formFields[parent]))) {
-      switch (type) {
-        case "text":
-          return (
-            <Text
-              name={name}
-              label={label}
-              formFields={formFields}
-              handleChange={handleChange}
-              fieldError={fieldError}
-              placeholder={placeholder}
-              fieldWarning={fieldWarning}
-              handleBlur={handleBlur}
-            />
-          );
-        case "radio":
-          return (
-            <Radios
-              name={name}
-              label={label}
-              formFields={formFields}
-              options={filteredOptions(optionsKey, options)}
-              handleChange={handleChange}
-            />
-          );
+  // Initialise and track the visible fields (using JSON instructions and current formData state)
+  useEffect(() => {
+    const updatedFields = flatFields.reduce(
+      (visibleFields: Field[], field: Field) => {
+        if (
+          field.visible ||
+          (field.visibleIf &&
+            field.visibleIf.includes(formData[field.parent!!]))
+        ) {
+          visibleFields.push(field);
+        }
+        return visibleFields;
+      },
+      []
+    );
 
-        case "select":
-          return (
-            <Selector
-              name={name}
-              label={label}
-              formFields={formFields}
-              options={filteredOptions(optionsKey, options)}
-              handleChange={handleChange}
-            />
-          );
+    setVisibleFields(updatedFields);
+  }, [formData, flatFields, currentPage]);
 
-        case "date":
-          return (
-            <Dates
-              name={name}
-              label={label}
-              formFields={formFields}
-              handleChange={handleChange}
-              fieldError={fieldError}
-              placeholder={placeholder}
-            />
-          );
-
-        case "phone":
-          return (
-            <Phone
-              name={name}
-              label={label}
-              formFields={formFields}
-              handleChange={handleChange}
-            />
-          );
-      }
-    } else return null;
-  };
+  useEffect(() => {
+    if (isFormDirty.current) {
+      validateFields(visibleFields, formData, validationSchema)
+        .then(() => {
+          setFormErrors({});
+        })
+        .catch((err: { inner: { path: string; message: string }[] }) => {
+          setFormErrors(() => {
+            const newErrors = createErrorObject(err);
+            return newErrors;
+          });
+        });
+    }
+  }, [formData, visibleFields, validationSchema]);
 
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     const { name, value } = event.currentTarget;
-    setFormFields((prev: FormData) => {
+    setFormData((prev: FormData) => {
       return { ...prev, [name]: value.trim() };
-    });
-  };
-
-  const handleTextFieldWidth = (
-    event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
-    currentValue: string,
-    primaryField: Field | undefined
-  ) => {
-    if (
-      primaryField?.type === "text" &&
-      currentValue.length >= 20 &&
-      primaryField?.canGrow
-    ) {
-      const thisFieldWidth = setTextFieldWidth(currentValue?.length);
-      event.currentTarget.className = `nhsuk-input nhsuk-input--width-${thisFieldWidth}`;
-    }
-  };
-
-  const updateFieldVisibility = (
-    field: Field,
-    fieldToShow: string,
-    currentValue: string
-  ) => {
-    if (field.name !== fieldToShow) return field;
-    const shouldShow = field.visibleIf
-      ? field.visibleIf.includes(currentValue)
-      : false;
-    return { ...field, visible: shouldShow };
-  };
-
-  const removeErrorsForInvisibleFields = (
-    updatedFields: Field[],
-    fieldToShow: string
-  ) => {
-    updatedFields.forEach(depField => {
-      if (depField.name === fieldToShow && !depField.visible) {
-        setFormErrors((prev: FormData) => {
-          const { [fieldToShow]: omittedField, ...newErrors } = prev;
-          return newErrors;
-        });
-      }
-    });
-  };
-
-  const handleDependantFieldVisibility = (
-    currentValue: string,
-    primaryField: Field | undefined
-  ) => {
-    if (!primaryField?.dependencies) return;
-
-    primaryField.dependencies.forEach(fieldToShow => {
-      setFields(prevFields => {
-        const updatedFields = prevFields.map(field =>
-          updateFieldVisibility(field, fieldToShow, currentValue)
-        );
-        removeErrorsForInvisibleFields(updatedFields, fieldToShow);
-        return updatedFields;
-      });
-    });
-  };
-
-  const validateCurrentField = (fieldName: string, currentVal: string) => {
-    // validate the current field only if validation is needed on that field
-    if (Object.keys(validationSchema.fields).includes(fieldName)) {
-      validationSchema
-        .validateAt(fieldName, { [fieldName]: currentVal })
-        .then(() => {
-          // remove error for the current field
-          setFormErrors((prev: FormData) => {
-            const { [fieldName]: val, ...newErrors } = prev;
-            return newErrors;
-          });
-        })
-        .catch((err: { message: string }) => {
-          // set error for the current field
-          setFormErrors((prev: FormData) => {
-            return { ...prev, [fieldName]: err.message };
-          });
-        });
-    }
-  };
-
-  const handleSoftValidationWarningMsgVisibility = (
-    inputVal: string | undefined,
-    primaryFormField: Field | undefined,
-    fieldName: string
-  ) => {
-    // show warning if the value of the current field matches the warning criteria
-    if (inputVal?.length && primaryFormField?.warning) {
-      const matcher = new RegExp(primaryFormField.warning.matcher, "i");
-      const msg = primaryFormField.warning.msgText;
-      const warning = showFieldMatchWarning(inputVal, matcher, msg, fieldName);
-      setFieldWarning(warning as FieldWarning);
-    } else setFieldWarning(undefined);
-  };
-
-  const updateCurrentField = (fieldName: string, currVal: string) => {
-    // update the value of the current field
-    setFormFields((prevFormData: FormData) => {
-      return { ...prevFormData, [fieldName]: currVal };
     });
   };
 
   const handleChange = (
     event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
-    selectedOption?: any
+    selectedOption?: any,
+    arrayIndex?: number,
+    arrayName?: string
   ) => {
     const { name, value } = event.currentTarget;
     const currentValue = selectedOption ? selectedOption.value : value;
-    const primaryField = fields.find(field => field.name === name);
-    const inputValue = selectedOption ? selectedOption.value : value;
+
+    // Note this code still only works for non-nested text fields
+    const primaryField = visibleFields.find(field => field.name === name);
     handleTextFieldWidth(event, currentValue, primaryField);
-    handleDependantFieldVisibility(currentValue, primaryField);
-    handleSoftValidationWarningMsgVisibility(inputValue, primaryField, name);
-    updateCurrentField(name, currentValue);
-    validateCurrentField(name, currentValue);
+    handleSoftValidationWarningMsgVisibility(
+      currentValue,
+      primaryField,
+      name,
+      setFieldWarning
+    );
+    //-----------------------------------------------------------
+
+    let updatedFormData: FormData = {};
+    if (typeof arrayIndex === "number" && arrayName) {
+      setFormData((prevFormData: FormData) => {
+        const newArray = [...prevFormData[arrayName]];
+        newArray[arrayIndex] = {
+          ...newArray[arrayIndex],
+          [name]: currentValue
+        };
+        updatedFormData = { ...prevFormData, [arrayName]: newArray };
+        return updatedFormData;
+      });
+    } else {
+      setFormData((prevFormData: FormData) => {
+        updatedFormData = {
+          ...prevFormData,
+          [name]: currentValue
+        };
+        return updatedFormData;
+      });
+    }
     isFormDirty.current = true;
   };
 
-  const validateFields = (fields: Field[], values: FormData) => {
-    let visibleValidationSchema = Yup.object().shape({});
-    visibleValidationSchema = fields.reduce((schema, field) => {
-      if (field.visible) {
-        const fieldSchema = validationSchema.fields[field.name];
-        schema = schema.shape({
-          [field.name]: fieldSchema
-        });
+  const finalFormFields = lastSavedFormData.id
+    ? {
+        ...formData,
+        id: lastSavedFormData.id,
+        lastModifiedDate: lastSavedFormData.lastModifiedDate,
+        lifecycleState: lastSavedFormData.lifecycleState,
+        traineeTisId: lastSavedFormData.traineeTisId
       }
-      return schema;
-    }, visibleValidationSchema);
-
-    return visibleValidationSchema.validate(values, { abortEarly: false });
-  };
-
-  const calculateVisibleFields = (formFields: {
-    [fieldName: string]: string;
-  }) => {
-    const visibleFormData = fields.reduce((formData, field: Field) => {
-      if (
-        field.visible ||
-        (field.parent && field.visibleIf?.includes(formFields[field.parent]))
-      ) {
-        formData[field.name] = formFields[field.name];
-      } else {
-        formData[field.name] = "";
-      }
-      return formData;
-    }, {} as FormData);
-    // Need to add these vals listed below (from last lastSavedFormData) to ensure latest autosave data is included)
-    return lastSavedFormData.id
-      ? {
-          ...visibleFormData,
-          id: lastSavedFormData.id,
-          lastModifiedDate: lastSavedFormData.lastModifiedDate,
-          lifecycleState: lastSavedFormData.lifecycleState,
-          traineeTisId: lastSavedFormData.traineeTisId
-        }
-      : {
-          ...visibleFormData,
-          traineeTisId: lastSavedFormData.traineeTisId
-        };
-  };
-
-  const handleErrorCatching = (e: any) => {
-    if (e) {
-      const errors: Record<string, string> = {};
-      e.inner.forEach((err: { path: string; message: string }) => {
-        errors[err.path] = err.message;
-      });
-      setFormErrors(errors);
-    }
-  };
+    : { ...formData, traineeTisId: lastSavedFormData.traineeTisId };
 
   const handlePageChange = () => {
-    if (currentPage === lastPage) {
-      validateFields(fields, formFields)
-        .then(() => {
-          const visibleFormData = calculateVisibleFields(formFields);
-          continueToConfirm(jsonFormName, visibleFormData, history);
-        })
-        .catch(err => {
-          handleErrorCatching(err);
-        });
-    } else {
-      validateFields(currentFields, formFields)
-        .then(() => {
+    isFormDirty.current = false;
+    validateFields(visibleFields, formData, validationSchema)
+      .then(() => {
+        if (currentPage === lastPage) {
+          continueToConfirm(jsonFormName, finalFormFields, history);
+        } else {
           setCurrentPage(currentPage + 1);
-        })
-        .catch(err => {
-          handleErrorCatching(err);
+        }
+      })
+      .catch((err: { inner: { path: string; message: string }[] }) => {
+        setFormErrors(() => {
+          const newErrors = createErrorObject(err);
+          return newErrors;
         });
-    }
+      });
   };
 
   const handleSaveBtnClick = () => {
     setIsSubmitting(true);
-    saveDraftForm(jsonFormName, formFields, history);
+    saveDraftForm(jsonFormName, formData, history);
     setIsSubmitting(false);
   };
 
-  // Initialise the dependent JSON form fields visibility based on the fetchedFormData state (which is needed if you load a saved draft where dependent fields would default back to hidden).
-  useEffect(() => {
-    const updatedFields = pages
-      .flatMap((page: Page) =>
-        page.sections.flatMap((section: Section) => section.fields)
-      )
-      .map(field => {
-        if (field.visibleIf) {
-          const shouldShow = field.visibleIf.includes(
-            fetchedFormData[field.parent!!]
-          );
-          return {
-            ...field,
-            visible: shouldShow
-          };
-        }
-        return field;
-      });
-
-    setFields(updatedFields);
-  }, [jsonForm, fetchedFormData, pages]);
-
   return (
-    <form onSubmit={handlePageChange} acceptCharset="UTF-8">
-      {pages && (
-        <>
-          <div>
-            {pages[currentPage].importantTxtName && (
-              <ImportantText
-                txtName={pages[currentPage].importantTxtName as string}
-              />
-            )}
-          </div>
-          {pages[currentPage].msgLinkName && <DataSourceMsg />}
-          <div data-cy="progress-header">
-            {pages[currentPage].pageName && (
-              <h3>{`Part ${currentPage + 1} of ${pages.length} - ${
-                pages[currentPage].pageName
-              }`}</h3>
-            )}
-            {pages[currentPage]?.sections.map((section: Section) => (
-              <React.Fragment key={section.sectionHeader}>
-                <AutosaveNote />
-                <Card feature>
-                  <Card.Content>
-                    <Card.Heading>{section.sectionHeader}</Card.Heading>
-                    {section?.fields.map((field: Field) => (
-                      <div key={field.name} className="nhsuk-form-group">
-                        {formFields && renderFormField(field)}
-                        {formErrors[field.name] && (
-                          <div
-                            className="nhsuk-error-message"
-                            data-cy={`${field.name}-inline-error-msg`}
-                          >
-                            {formErrors[field.name]}
-                          </div>
-                        )}
-                      </div>
-                    ))}
-                  </Card.Content>
-                </Card>
-                <AutosaveMessage formName={jsonFormName} />
-              </React.Fragment>
-            ))}
-          </div>
-        </>
-      )}
-      {Object.keys(formErrors).length > 0 && (
-        <FormErrors formErrors={formErrors} />
-      )}
-      <nav className="nhsuk-pagination">
-        <ul className="nhsuk-list nhsuk-pagination__list">
-          <li className="nhsuk-pagination-item--previous">
-            {currentPage > 0 && pages.length > 1 && (
+    formData && (
+      <form onSubmit={handlePageChange} acceptCharset="UTF-8">
+        {pages && (
+          <>
+            <div>
+              {pages[currentPage].importantTxtName && (
+                <ImportantText
+                  txtName={pages[currentPage].importantTxtName as string}
+                />
+              )}
+            </div>
+            {pages[currentPage].msgLinkName && <DataSourceMsg />}
+            <div data-cy="progress-header">
+              {pages[currentPage].pageName && (
+                <h3>{`Part ${currentPage + 1} of ${pages.length} - ${
+                  pages[currentPage].pageName
+                }`}</h3>
+              )}
+              {pages[currentPage]?.sections.map((section: Section) => (
+                <React.Fragment key={section.sectionHeader}>
+                  <AutosaveNote />
+                  <Card feature>
+                    <Card.Content>
+                      <Card.Heading>{section.sectionHeader}</Card.Heading>
+                      {visibleFields.map((field: Field) => (
+                        <div key={field.name} className="nhsuk-form-group">
+                          {field.type === "array"
+                            ? renderArrayField(
+                                field,
+                                formData,
+                                setFormData,
+                                formErrors,
+                                renderFormField
+                              )
+                            : renderFormField(
+                                field,
+                                handleChange,
+                                fieldWarning,
+                                handleBlur,
+                                options,
+                                formData[field.name],
+                                formErrors[field.name]
+                              )}
+                        </div>
+                      ))}
+                    </Card.Content>
+                  </Card>
+                  <AutosaveMessage formName={jsonFormName} />
+                </React.Fragment>
+              ))}
+            </div>
+          </>
+        )}
+        {Object.keys(formErrors).length > 0 && (
+          <FormErrors formErrors={formErrors} />
+        )}
+        <nav className="nhsuk-pagination">
+          <ul className="nhsuk-list nhsuk-pagination__list">
+            <li className="nhsuk-pagination-item--previous">
+              {currentPage > 0 && pages.length > 1 && (
+                <Link
+                  to="#"
+                  className={
+                    "nhsuk-pagination__link nhsuk-pagination__link--prev"
+                  }
+                  onClick={() => {
+                    setCurrentPage(currentPage - 1);
+                  }}
+                  data-cy="navPrevious"
+                >
+                  <span className="nhsuk-pagination__title">{"Previous"}</span>
+                  <span className="nhsuk-u-visually-hidden">:</span>
+                  <span className="nhsuk-pagination__page">
+                    <div>{`${currentPage}. ${
+                      pages[currentPage - 1].pageName
+                    }`}</div>
+                  </span>
+                  <ArrowLeftIcon />
+                </Link>
+              )}
+            </li>
+            <li className="nhsuk-pagination-item--next">
               <Link
                 to="#"
-                className={
-                  "nhsuk-pagination__link nhsuk-pagination__link--prev"
-                }
-                onClick={() => {
-                  setFormErrors({});
-                  setCurrentPage(currentPage - 1);
-                }}
-                data-cy="navPrevious"
+                className={`nhsuk-pagination__link nhsuk-pagination__link--next ${
+                  isSubmitting || Object.keys(formErrors).length > 0
+                    ? "disabled-link"
+                    : ""
+                }`}
+                onClick={handlePageChange}
+                data-cy="navNext"
               >
-                <span className="nhsuk-pagination__title">{"Previous"}</span>
+                <span className="nhsuk-pagination__title">{"Next"}</span>
                 <span className="nhsuk-u-visually-hidden">:</span>
                 <span className="nhsuk-pagination__page">
-                  <div>{`${currentPage}. ${
-                    pages[currentPage - 1].pageName
-                  }`}</div>
+                  {currentPage === lastPage ? (
+                    <>{"Review & submit"}</>
+                  ) : (
+                    <div>{`${currentPage + 2}. ${
+                      pages[currentPage + 1].pageName
+                    }`}</div>
+                  )}
                 </span>
-                <ArrowLeftIcon />
+                <ArrowRightIcon />
               </Link>
-            )}
-          </li>
-          <li className="nhsuk-pagination-item--next">
-            <Link
-              to="#"
-              className={`nhsuk-pagination__link nhsuk-pagination__link--next ${
-                isSubmitting || Object.keys(formErrors).length > 0
-                  ? "disabled-link"
-                  : ""
-              }`}
-              onClick={handlePageChange}
-              data-cy="navNext"
-            >
-              <span className="nhsuk-pagination__title">{"Next"}</span>
-              <span className="nhsuk-u-visually-hidden">:</span>
-              <span className="nhsuk-pagination__page">
-                {currentPage === lastPage ? (
-                  <>{"Review & submit"}</>
-                ) : (
-                  <div>{`${currentPage + 2}. ${
-                    pages[currentPage + 1].pageName
-                  }`}</div>
-                )}
-              </span>
-              <ArrowRightIcon />
-            </Link>
-          </li>
-        </ul>
-      </nav>
-      <Container>
-        <Row>
-          <Col width="one-quarter">
-            <Button
-              secondary
-              onClick={(e: { preventDefault: () => void }) => {
-                e.preventDefault();
-                handleSaveBtnClick();
-              }}
-              disabled={isSubmitting || isAutosaving}
-              data-cy="BtnSaveDraft"
-            >
-              {"Save & exit"}
-            </Button>
-          </Col>
-          <Col width="one-quarter">
-            <StartOverButton />
-          </Col>
-        </Row>
-      </Container>
-    </form>
+            </li>
+          </ul>
+        </nav>
+        <Container>
+          <Row>
+            <Col width="one-quarter">
+              <Button
+                secondary
+                onClick={(e: { preventDefault: () => void }) => {
+                  e.preventDefault();
+                  handleSaveBtnClick();
+                }}
+                disabled={isSubmitting || isAutosaving}
+                data-cy="BtnSaveDraft"
+              >
+                {"Save & exit"}
+              </Button>
+            </Col>
+            <Col width="one-quarter">
+              <StartOverButton />
+            </Col>
+          </Row>
+        </Container>
+      </form>
+    )
   );
 }
 
-interface FormErrorsProps {
-  formErrors: Record<string, string>;
-}
-
-export function FormErrors({ formErrors }: Readonly<FormErrorsProps>) {
+export function FormErrors(formErrors: any) {
   return (
     <ErrorSummary
       aria-labelledby="errorSummaryTitle"
@@ -572,15 +386,155 @@ export function FormErrors({ formErrors }: Readonly<FormErrorsProps>) {
         <p>
           <b>Please fix the following errors before proceeding:</b>
         </p>
-        <ul>
-          {Object.entries(formErrors).map(error => (
-            <li
-              data-cy={`error-txt-${error}`}
-              key={error[0]}
-            >{`${error[1]}`}</li>
-          ))}
-        </ul>
+        <FormErrorsList formErrors={formErrors} />
       </div>
     </ErrorSummary>
+  );
+}
+
+type FormErrorsListProps = {
+  formErrors: any;
+};
+
+function FormErrorsList({ formErrors }: Readonly<FormErrorsListProps>) {
+  const renderErrors = (formErrors: any) => {
+    return (
+      <ul>
+        {Object.keys(formErrors).map(key => {
+          if (typeof formErrors[key] === "string") {
+            return (
+              <div key={key} className="error-spacing_div">
+                {formErrors[key]}
+              </div>
+            );
+          } else if (Array.isArray(formErrors[key])) {
+            return formErrors[key].map((error: any, index: number) => {
+              return (
+                <li
+                  key={`${key}[${index}]`}
+                  className="error-summary_li_nested"
+                >
+                  <span>
+                    <b>{`${key} ${index + 1}`}</b>
+                  </span>
+                  <span>{renderErrors(error)}</span>
+                </li>
+              );
+            });
+          } else {
+            return (
+              <li key={key} className="error-summary_li">
+                {renderErrors(formErrors[key])}
+              </li>
+            );
+          }
+        })}
+      </ul>
+    );
+  };
+
+  return <div>{renderErrors(formErrors)}</div>;
+}
+
+function renderFormField(
+  field: Field,
+  handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void,
+  fieldWarning: FieldWarning | undefined,
+  handleBlur: (event: React.FocusEvent<HTMLInputElement>) => void,
+  options: any,
+  value: unknown,
+  error: any,
+  arrayIndex?: number,
+  arrayName?: string
+): React.ReactElement | null {
+  const { name, type, label, placeholder, optionsKey } = field;
+  switch (type) {
+    case "text":
+      return (
+        <Text
+          name={name}
+          label={label}
+          handleChange={handleChange}
+          fieldError={error ?? ""}
+          placeholder={placeholder}
+          fieldWarning={fieldWarning}
+          handleBlur={handleBlur}
+          value={value as string}
+          arrayIndex={arrayIndex}
+          arrayName={arrayName}
+        />
+      );
+    case "radio":
+      return (
+        <Radios
+          name={name}
+          label={label}
+          options={filteredOptions(optionsKey, options)}
+          handleChange={handleChange}
+          value={value as string}
+          arrayIndex={arrayIndex}
+          arrayName={arrayName}
+        />
+      );
+
+    case "select":
+      return (
+        <Selector
+          name={name}
+          label={label}
+          options={filteredOptions(optionsKey, options)}
+          handleChange={handleChange}
+          fieldError={error ?? ""}
+          value={value as string}
+          arrayIndex={arrayIndex}
+          arrayName={arrayName}
+        />
+      );
+
+    case "date":
+      return (
+        <Dates
+          name={name}
+          label={label}
+          handleChange={handleChange}
+          fieldError={error ?? ""}
+          placeholder={placeholder}
+          value={value as string | Date}
+          arrayIndex={arrayIndex}
+          arrayName={arrayName}
+        />
+      );
+
+    case "phone":
+      return (
+        <Phone
+          name={name}
+          label={label}
+          handleChange={handleChange}
+          value={value as string}
+          arrayIndex={arrayIndex}
+          arrayName={arrayName}
+        />
+      );
+    default:
+      return null;
+  }
+}
+
+function renderArrayField(
+  field: Field,
+  formData: any,
+  setFormData: any,
+  formErrors: any,
+  renderFormField: any
+) {
+  return (
+    <PanelBuilder
+      field={field}
+      formData={formData}
+      setFormData={setFormData}
+      renderFormField={renderFormField}
+      panelErrors={formErrors[field.name]}
+    />
   );
 }

--- a/components/forms/form-builder/FormViewBuilder.tsx
+++ b/components/forms/form-builder/FormViewBuilder.tsx
@@ -1,22 +1,46 @@
-import React from "react";
-import { Form, FormData } from "./FormBuilder";
+import { Field, Form, FormData } from "./FormBuilder";
 import { Button, Card, SummaryList } from "nhsuk-react-components";
 import { handleEditSection } from "../../../utilities/FormBuilderUtilities";
 import { DateUtilities } from "../../../utilities/DateUtilities";
 import history from "../../navigation/history";
-interface FormViewBuilderProps {
+type FormViewBuilder = {
   jsonForm: Form;
   formData: FormData;
   canEdit: boolean;
   formErrors: { [key: string]: string };
-}
+};
 
-const FormViewBuilder: React.FC<FormViewBuilderProps> = ({
+const showVisibleField = (
+  field: Field,
+  formData: FormData,
+  formErrors: { [key: string]: string }
+) => {
+  if (
+    field.visible ||
+    (field.visibleIf && field.visibleIf.includes(formData[field.parent!!]))
+  ) {
+    return (
+      <SummaryList.Row key={field.name}>
+        <SummaryList.Key
+          data-cy={`${field.name}-label`}
+          className={formErrors[field.name] ? "nhsuk-error-message" : ""}
+        >
+          {field.label}
+        </SummaryList.Key>
+        <SummaryList.Value data-cy={`${field.name}-value`}>
+          {displayListValue(formData[field.name], field.type)}
+        </SummaryList.Value>
+      </SummaryList.Row>
+    );
+  }
+};
+
+export default function FormViewBuilder({
   jsonForm,
   formData,
   canEdit,
   formErrors
-}: FormViewBuilderProps) => {
+}: FormViewBuilder) {
   return (
     <div>
       {jsonForm.pages.map((page, pageIndex) => (
@@ -38,21 +62,9 @@ const FormViewBuilder: React.FC<FormViewBuilderProps> = ({
                     </Button>
                   )}
                   <SummaryList>
-                    {section.fields.map(field => (
-                      <SummaryList.Row key={field.name}>
-                        <SummaryList.Key
-                          data-cy={`${field.name}-label`}
-                          className={
-                            formErrors[field.name] ? "nhsuk-error-message" : ""
-                          }
-                        >
-                          {field.label}
-                        </SummaryList.Key>
-                        <SummaryList.Value data-cy={`${field.name}-value`}>
-                          {displayListValue(formData[field.name], field.type)}
-                        </SummaryList.Value>
-                      </SummaryList.Row>
-                    ))}
+                    {section.fields.map(field =>
+                      showVisibleField(field, formData, formErrors)
+                    )}
                   </SummaryList>
                 </div>
               ))}
@@ -62,9 +74,7 @@ const FormViewBuilder: React.FC<FormViewBuilderProps> = ({
       ))}
     </div>
   );
-};
-
-export default FormViewBuilder;
+}
 
 function displayListValue(fieldVal: string, fieldType: string) {
   if (!fieldVal) return "Not provided";

--- a/components/forms/form-builder/FormViewBuilder.tsx
+++ b/components/forms/form-builder/FormViewBuilder.tsx
@@ -3,18 +3,18 @@ import { Button, Card, SummaryList } from "nhsuk-react-components";
 import { handleEditSection } from "../../../utilities/FormBuilderUtilities";
 import { DateUtilities } from "../../../utilities/DateUtilities";
 import history from "../../navigation/history";
-type FormViewBuilder = {
-  jsonForm: Form;
+
+type VisibleFieldProps = {
+  field: Field;
   formData: FormData;
-  canEdit: boolean;
   formErrors: { [key: string]: string };
 };
 
-const showVisibleField = (
-  field: Field,
-  formData: FormData,
-  formErrors: { [key: string]: string }
-) => {
+function VisibleField({
+  field,
+  formData,
+  formErrors
+}: Readonly<VisibleFieldProps>) {
   if (
     field.visible ||
     (field.visibleIf && field.visibleIf.includes(formData[field.parent!!]))
@@ -33,6 +33,14 @@ const showVisibleField = (
       </SummaryList.Row>
     );
   }
+  return null;
+}
+
+type FormViewBuilder = {
+  jsonForm: Form;
+  formData: FormData;
+  canEdit: boolean;
+  formErrors: { [key: string]: string };
 };
 
 export default function FormViewBuilder({
@@ -62,9 +70,14 @@ export default function FormViewBuilder({
                     </Button>
                   )}
                   <SummaryList>
-                    {section.fields.map(field =>
-                      showVisibleField(field, formData, formErrors)
-                    )}
+                    {section.fields.map(field => (
+                      <VisibleField
+                        key={field.name}
+                        field={field}
+                        formData={formData}
+                        formErrors={formErrors}
+                      />
+                    ))}
                   </SummaryList>
                 </div>
               ))}

--- a/components/forms/form-builder/FormViewBuilder.tsx
+++ b/components/forms/form-builder/FormViewBuilder.tsx
@@ -40,7 +40,7 @@ export default function FormViewBuilder({
   formData,
   canEdit,
   formErrors
-}: FormViewBuilder) {
+}: Readonly<FormViewBuilder>) {
   return (
     <div>
       {jsonForm.pages.map((page, pageIndex) => (

--- a/components/forms/form-builder/form-array/PanelBuilder.tsx
+++ b/components/forms/form-builder/form-array/PanelBuilder.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { Field } from "../FormBuilder";
+import { Card } from "nhsuk-react-components";
+
+type PanelBuilder = {
+  field: Field;
+  formData: any;
+  setFormData: React.Dispatch<any>;
+  renderFormField: (
+    field: Field,
+    value: unknown,
+    error: any,
+    arrayIndex?: number,
+    arrayName?: string
+  ) => JSX.Element | null;
+  panelErrors: any;
+};
+
+export default function PanelBuilder({
+  field,
+  formData,
+  setFormData,
+  renderFormField,
+  panelErrors
+}: Readonly<PanelBuilder>) {
+  const newPanel = () => {
+    const arrPanel = field.objectFields?.reduce((panel, objField) => {
+      panel[objField.name] = "";
+      return panel;
+    }, {} as { [key: string]: string });
+    return arrPanel;
+  };
+
+  const addPanel = () => {
+    const newPanelsArray = [...formData[field.name], newPanel()];
+    setFormData({ ...formData, [field.name]: newPanelsArray });
+  };
+
+  const removePanel = (index: number) => {
+    const newPanelsArray = formData[field.name].filter(
+      (_arrObj: any, i: number) => i !== index
+    );
+    setFormData({ ...formData, [field.name]: newPanelsArray });
+  };
+
+  return (
+    <>
+      {formData[field.name].map((_arrObj: any, index: number) => (
+        <Card key={index}>
+          <Card.Content>
+            <p>
+              <b>{`${field.name} ${index + 1}`}</b>
+            </p>
+            {field.objectFields?.map((objField: Field) => (
+              <div key={objField.name} className="nhsuk-form-group">
+                {renderFormField(
+                  objField,
+                  formData[field.name][index][objField.name] ?? "",
+                  panelErrors?.[index]?.[objField.name] ?? "",
+                  index,
+                  field.name
+                )}
+              </div>
+            ))}
+            <button
+              onClick={e => {
+                e.preventDefault();
+                removePanel(index);
+              }}
+            >
+              Remove Panel
+            </button>
+          </Card.Content>
+        </Card>
+      ))}
+      <button
+        onClick={e => {
+          e.preventDefault();
+          addPanel();
+        }}
+      >
+        Add Panel
+      </button>
+    </>
+  );
+}

--- a/components/forms/form-builder/form-array/PanelBuilder.tsx
+++ b/components/forms/form-builder/form-array/PanelBuilder.tsx
@@ -8,11 +8,10 @@ type PanelBuilder = {
   setFormData: React.Dispatch<any>;
   renderFormField: (
     field: Field,
-    value: unknown,
-    error: any,
-    arrayIndex?: number,
-    arrayName?: string
-  ) => JSX.Element | null;
+    value: any,
+    error: string,
+    arrayDetails: { index: number; parent: string }
+  ) => JSX.Element;
   panelErrors: any;
 };
 
@@ -57,8 +56,7 @@ export default function PanelBuilder({
                   objField,
                   formData[field.name][index][objField.name] ?? "",
                   panelErrors?.[index]?.[objField.name] ?? "",
-                  index,
-                  field.name
+                  { index, parent: field.name }
                 )}
               </div>
             ))}

--- a/components/forms/form-builder/form-array/PanelBuilder.tsx
+++ b/components/forms/form-builder/form-array/PanelBuilder.tsx
@@ -1,18 +1,28 @@
 import React from "react";
-import { Field } from "../FormBuilder";
+import { Field, FieldWarning } from "../FormBuilder";
 import { Card } from "nhsuk-react-components";
 
 type PanelBuilder = {
+  fieldWarning: FieldWarning | undefined;
   field: Field;
   formData: any;
   setFormData: React.Dispatch<any>;
   renderFormField: (
     field: Field,
-    value: any,
+    value: unknown,
     error: string,
-    arrayDetails: { index: number; parent: string }
-  ) => JSX.Element;
+    FieldWarning: FieldWarning | undefined,
+    handlers: {
+      handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+      handleBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
+    },
+    options?: any,
+    arrayDetails?: { arrayIndex: number; arrayName: string }
+  ) => JSX.Element | null;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
   panelErrors: any;
+  options?: any;
 };
 
 export default function PanelBuilder({
@@ -20,7 +30,11 @@ export default function PanelBuilder({
   formData,
   setFormData,
   renderFormField,
-  panelErrors
+  handleChange,
+  handleBlur,
+  panelErrors,
+  fieldWarning,
+  options
 }: Readonly<PanelBuilder>) {
   const newPanel = () => {
     const arrPanel = field.objectFields?.reduce((panel, objField) => {
@@ -56,7 +70,10 @@ export default function PanelBuilder({
                   objField,
                   formData[field.name][index][objField.name] ?? "",
                   panelErrors?.[index]?.[objField.name] ?? "",
-                  { index, parent: field.name }
+                  fieldWarning,
+                  { handleChange, handleBlur },
+                  options,
+                  { arrayIndex: index, arrayName: field.name }
                 )}
               </div>
             ))}

--- a/components/forms/form-builder/form-fields/Dates.tsx
+++ b/components/forms/form-builder/form-fields/Dates.tsx
@@ -1,20 +1,31 @@
 import { handleKeyDown } from "../../../../utilities/FormBuilderUtilities";
+import FieldErrorInline from "./FieldErrorInline";
+
 type DatesProps = {
   name: string;
   label: string | undefined;
-  formFields: Record<string, string>;
-  handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleChange: (
+    event: any,
+    selectedOption?: any,
+    arrayIndex?: number,
+    arrayName?: string
+  ) => void;
   fieldError: string;
   placeholder?: string;
+  value: string | Date;
+  arrayIndex?: number;
+  arrayName?: string;
 };
 
 export const Dates = ({
   name,
   label,
-  formFields,
   handleChange,
   fieldError,
-  placeholder
+  placeholder,
+  value,
+  arrayIndex,
+  arrayName
 }: DatesProps) => {
   return (
     <div data-cy={name}>
@@ -26,9 +37,9 @@ export const Dates = ({
         type="date"
         data-cy={`${name}-input`}
         name={name}
-        value={formFields[name]}
+        value={value as string}
         onChange={event => {
-          handleChange(event);
+          handleChange(event, undefined, arrayIndex, arrayName);
         }}
         className={`nhsuk-input nhsuk-input--width-20 ${
           fieldError ? "nhsuk-input--error" : ""
@@ -37,6 +48,9 @@ export const Dates = ({
         min="1920-01-01"
         max="2119-12-31"
       />
+      {fieldError && (
+        <FieldErrorInline fieldError={fieldError} fieldName={name} />
+      )}
     </div>
   );
 };

--- a/components/forms/form-builder/form-fields/FieldErrorInline.tsx
+++ b/components/forms/form-builder/form-fields/FieldErrorInline.tsx
@@ -1,0 +1,18 @@
+type FieldErrorInlineProps = {
+  fieldError: string;
+  fieldName: string;
+};
+
+export default function FieldErrorInline({
+  fieldError,
+  fieldName
+}: Readonly<FieldErrorInlineProps>) {
+  return (
+    <div
+      className="nhsuk-error-message"
+      data-cy={`${fieldName}-inline-error-msg`}
+    >
+      {fieldError}
+    </div>
+  );
+}

--- a/components/forms/form-builder/form-fields/Phone.tsx
+++ b/components/forms/form-builder/form-fields/Phone.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { handleKeyDown } from "../../../../utilities/FormBuilderUtilities";
 import PhoneInput from "react-phone-number-input";
+import FieldErrorInline from "./FieldErrorInline";
 
 type PhoneProps = {
   name: string;
@@ -11,6 +12,7 @@ type PhoneProps = {
     arrayIndex?: number,
     arrayName?: string
   ) => void;
+  fieldError: string;
   value: string;
   arrayIndex?: number;
   arrayName?: string;
@@ -20,6 +22,7 @@ export const Phone = ({
   name,
   label,
   handleChange,
+  fieldError,
   value,
   arrayIndex,
   arrayName
@@ -46,6 +49,9 @@ export const Phone = ({
         value={value}
         initialValueFormat="national"
       />
+      {fieldError && (
+        <FieldErrorInline fieldError={fieldError} fieldName={name} />
+      )}
     </div>
   );
 };

--- a/components/forms/form-builder/form-fields/Phone.tsx
+++ b/components/forms/form-builder/form-fields/Phone.tsx
@@ -5,15 +5,24 @@ import PhoneInput from "react-phone-number-input";
 type PhoneProps = {
   name: string;
   label: string | undefined;
-  formFields: Record<string, string>;
-  handleChange: (event: any, selectedOption?: any) => void;
+  handleChange: (
+    event: any,
+    selectedOption?: any,
+    arrayIndex?: number,
+    arrayName?: string
+  ) => void;
+  value: string;
+  arrayIndex?: number;
+  arrayName?: string;
 };
 
 export const Phone = ({
   name,
   label,
-  formFields,
-  handleChange
+  handleChange,
+  value,
+  arrayIndex,
+  arrayName
 }: PhoneProps) => {
   return (
     <div data-cy={name}>
@@ -27,9 +36,14 @@ export const Phone = ({
         name={name}
         defaultCountry="GB"
         onChange={value => {
-          handleChange({ currentTarget: { name, value } });
+          handleChange(
+            { currentTarget: { name, value } },
+            undefined,
+            arrayIndex,
+            arrayName
+          );
         }}
-        value={formFields[name]}
+        value={value}
         initialValueFormat="national"
       />
     </div>

--- a/components/forms/form-builder/form-fields/Radios.tsx
+++ b/components/forms/form-builder/form-fields/Radios.tsx
@@ -5,16 +5,25 @@ type RadiosProps = {
   name: string;
   label: string | undefined;
   options: any;
-  formFields: Record<string, string>;
-  handleChange: (event: any, selectedOption?: any) => void;
+  handleChange: (
+    event: any,
+    selectedOption?: any,
+    arrayIndex?: number,
+    arrayName?: string
+  ) => void;
+  value: string;
+  arrayIndex?: number;
+  arrayName?: string;
 };
 
 export const Radios: React.FC<RadiosProps> = ({
   name,
   label,
   options,
-  formFields,
-  handleChange
+  handleChange,
+  value,
+  arrayIndex,
+  arrayName
 }: RadiosProps) => {
   return (
     <div className="nhsuk-radios">
@@ -31,8 +40,10 @@ export const Radios: React.FC<RadiosProps> = ({
             type="radio"
             name={name}
             value={option.value}
-            checked={formFields[name] === option.value}
-            onChange={handleChange}
+            checked={value === option.value}
+            onChange={event =>
+              handleChange(event, undefined, arrayIndex, arrayName)
+            }
             placeholder={option.value}
             aria-labelledby={`${option.value}--label`}
           />

--- a/components/forms/form-builder/form-fields/Radios.tsx
+++ b/components/forms/form-builder/form-fields/Radios.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { handleKeyDown } from "../../../../utilities/FormBuilderUtilities";
+import FieldErrorInline from "./FieldErrorInline";
 
 type RadiosProps = {
   name: string;
@@ -11,6 +12,7 @@ type RadiosProps = {
     arrayIndex?: number,
     arrayName?: string
   ) => void;
+  fieldError: string;
   value: string;
   arrayIndex?: number;
   arrayName?: string;
@@ -21,6 +23,7 @@ export const Radios: React.FC<RadiosProps> = ({
   label,
   options,
   handleChange,
+  fieldError,
   value,
   arrayIndex,
   arrayName
@@ -52,6 +55,9 @@ export const Radios: React.FC<RadiosProps> = ({
           </label>
         </div>
       ))}
+      {fieldError && (
+        <FieldErrorInline fieldError={fieldError} fieldName={name} />
+      )}
     </div>
   );
 };

--- a/components/forms/form-builder/form-fields/Selector.tsx
+++ b/components/forms/form-builder/form-fields/Selector.tsx
@@ -4,21 +4,33 @@ import {
   colourStyles,
   handleKeyDown
 } from "../../../../utilities/FormBuilderUtilities";
+import FieldErrorInline from "./FieldErrorInline";
 
 type SelectorProps = {
   name: string;
   label: string | undefined;
   options: any;
-  formFields: Record<string, string>;
-  handleChange: (event: any, selectedOption?: any) => void;
+  handleChange: (
+    event: any,
+    selectedOption?: any,
+    arrayIndex?: number,
+    arrayName?: string
+  ) => void;
+  fieldError: string;
+  value: string;
+  arrayIndex?: number;
+  arrayName?: string;
 };
 
 export const Selector = ({
   name,
   label,
   options,
-  formFields,
-  handleChange
+  handleChange,
+  fieldError,
+  value,
+  arrayIndex,
+  arrayName
 }: SelectorProps) => {
   return (
     <div data-cy={name}>
@@ -36,7 +48,9 @@ export const Selector = ({
                 value: selectedOption ?? ""
               }
             },
-            selectedOption
+            selectedOption,
+            arrayIndex,
+            arrayName
           )
         }
         className="autocomplete-select"
@@ -46,11 +60,12 @@ export const Selector = ({
           borderRadius: 0
         })}
         styles={colourStyles}
-        value={options?.filter(
-          (option: any) => option.value === formFields[name]
-        )}
+        value={options?.filter((option: any) => option.value === value)}
         isClearable={true}
       />
+      {fieldError && (
+        <FieldErrorInline fieldError={fieldError} fieldName={name} />
+      )}
     </div>
   );
 };

--- a/components/forms/form-builder/form-fields/Text.tsx
+++ b/components/forms/form-builder/form-fields/Text.tsx
@@ -2,27 +2,37 @@ import React from "react";
 import { handleKeyDown } from "../../../../utilities/FormBuilderUtilities";
 import FieldWarningMsg from "../../FieldWarningMsg";
 import { FieldWarning } from "../FormBuilder";
+import FieldErrorInline from "./FieldErrorInline";
 
 type TextProps = {
   name: string;
   label: string | undefined;
-  formFields: Record<string, string>;
-  handleChange: (event: any, selectedOption?: any) => void;
-  fieldError?: string;
+  handleChange: (
+    event: any,
+    selectedOption?: any,
+    index?: number | undefined,
+    name?: string | undefined
+  ) => void;
+  fieldError: string;
   placeholder?: string;
   fieldWarning?: FieldWarning;
   handleBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
+  value?: string;
+  arrayIndex?: number;
+  arrayName?: string;
 };
 
 export const Text: React.FC<TextProps> = ({
   name,
   label,
-  formFields,
   handleChange,
   fieldError,
   placeholder,
   fieldWarning,
-  handleBlur
+  handleBlur,
+  value,
+  arrayIndex,
+  arrayName
 }: TextProps) => {
   return (
     <>
@@ -34,8 +44,11 @@ export const Text: React.FC<TextProps> = ({
         onKeyDown={handleKeyDown}
         type="text"
         name={name}
-        value={formFields[name]}
-        onChange={handleChange}
+        value={value}
+        onChange={
+          ((event: any) =>
+            handleChange(event, undefined, arrayIndex, arrayName)) as any
+        }
         className={`nhsuk-input nhsuk-input--width-20 ${
           fieldError ? "nhsuk-input--error" : ""
         }`}
@@ -43,6 +56,9 @@ export const Text: React.FC<TextProps> = ({
         aria-labelledby={`${name}--label`}
         onBlur={handleBlur}
       />
+      {fieldError && (
+        <FieldErrorInline fieldError={fieldError} fieldName={name} />
+      )}
       {fieldWarning?.fieldName === name ? (
         <FieldWarningMsg warningMsg={fieldWarning?.warningMsg} />
       ) : null}

--- a/components/forms/form-builder/form-r/part-a/FormAView.tsx
+++ b/components/forms/form-builder/form-r/part-a/FormAView.tsx
@@ -30,9 +30,10 @@ import { formAValidationSchemaView } from "./formAValidationSchema";
 import { ValidationError } from "yup";
 import { FormErrors } from "../../FormBuilder";
 
+//NOTE TO FUTURE SELF - make this comp more generic
 const FormAView = () => {
   const confirm = useConfirm();
-  const formName: string = "formA";
+  const formName = formAJson.name;
   const canEdit = useAppSelector(selectCanEditStatus);
   const formAData = useAppSelector(selectSavedFormA);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -64,7 +65,7 @@ const FormAView = () => {
     confirm({
       description: dialogBoxWarnings.formSubMsg
     })
-      .then(() => submitForm(formName, formData, history))
+      .then(() => submitForm(formAJson, formData, history))
       .catch(() => {
         console.log("form a submit cancelled");
       });

--- a/components/forms/form-builder/form-r/part-a/formAValidationSchema.ts
+++ b/components/forms/form-builder/form-r/part-a/formAValidationSchema.ts
@@ -23,7 +23,7 @@ const formAValidationSchemaDefault = {
     )
     .test(
       "dateOfBirth",
-      "This date is before the minimum date allowed",
+      "Date of Birth is before the minimum date allowed",
       value => DateUtilities.IsMoreThanMinDate(value)
     ),
   gender: StringValidationSchema("Gender"),
@@ -37,7 +37,7 @@ const formAValidationSchemaDefault = {
     )
     .test(
       "dateAttained",
-      "This date is before the minimum date allowed",
+      "Date awarded is before the minimum date allowed",
       value => DateUtilities.IsMoreThanMinDate(value)
     ),
   medicalSchool: StringValidationSchema(

--- a/components/forms/formr-part-b/sections/Declarations.tsx
+++ b/components/forms/formr-part-b/sections/Declarations.tsx
@@ -19,7 +19,7 @@ import FormRPartBPagination from "../FormRPartBPagination";
 import store from "../../../../redux/store/store";
 import { IProgSection } from "../../../../models/IProgressSection";
 import { useConfirm } from "material-ui-confirm";
-import { submitForm } from "../../../../utilities/FormBuilderUtilities";
+import { tempSubFormB } from "../../../../utilities/FormBuilderUtilities";
 interface IDeclarations {
   prevSectionLabel: string;
   history: any;
@@ -39,7 +39,7 @@ const Declarations = ({
   const handleFormBSubmit = async (formVals: FormRPartB) => {
     if (!saveBtnActive) {
       dispatch(updatesaveBtnActive());
-      await submitForm("formB", formVals, history);
+      await tempSubFormB("formB", formVals, history);
       const formBStatus = store.getState().formB.status;
       if (formBStatus === "succeeded") {
         history.push("/formr-b");

--- a/components/home/actionSummary/ActionSummary.tsx
+++ b/components/home/actionSummary/ActionSummary.tsx
@@ -103,76 +103,78 @@ export default function ActionSummary() {
                   <Card.Heading data-cy="formRSubsHeading">
                     Form R submissions
                   </Card.Heading>
-                  {/* **** Form A - LABEL ****/}
-                  <Label
-                    size="l"
-                    style={{ color: "#005EB8" }}
-                    data-cy="formASubHeader"
-                  >
-                    Form R (Part A)
-                  </Label>
-                  {/* **** Form A - NO SUB ****/}
-                  {noSubFormRA && (
-                    <FormMessage formType="A" message="infoNoFormEver" />
-                  )}
-                  {/* **** Form A - SUBMITTED ****/}
-                  {/* **** Form A - LATEST SUB DATE WITHIN LAST YEAR ****/}
-                  {infoActionsA.latestSubDateForm &&
-                    infoActionsA.isForInfoWithinYearSubForm && (
-                      <FormMessage
-                        formType="A"
-                        message="infoLatestSubFormRWithinYear"
-                        latestSubFormDate={DateUtilities.ToLocalDate(
-                          infoActionsA.latestSubDateForm
-                        )}
-                      />
+                  <ul className="no-bullet">
+                    {/* **** Form A - LABEL ****/}
+                    <Label
+                      size="l"
+                      style={{ color: "#005EB8" }}
+                      data-cy="formASubHeader"
+                    >
+                      Form R (Part A)
+                    </Label>
+                    {/* **** Form A - NO SUB ****/}
+                    {noSubFormRA && (
+                      <FormMessage formType="A" message="infoNoFormEver" />
                     )}
-                  {/* **** Form A - LATEST SUB DATE YEAR PLUS ****/}
-                  {infoActionsA.latestSubDateForm &&
-                    infoActionsA.isForInfoYearPlusSubForm && (
-                      <FormMessage
-                        formType="A"
-                        message="infoLatestSubFormRYearPlus"
-                        latestSubFormDate={DateUtilities.ToLocalDate(
-                          infoActionsA.latestSubDateForm
-                        )}
-                      />
+                    {/* **** Form A - SUBMITTED ****/}
+                    {/* **** Form A - LATEST SUB DATE WITHIN LAST YEAR ****/}
+                    {infoActionsA.latestSubDateForm &&
+                      infoActionsA.isForInfoWithinYearSubForm && (
+                        <FormMessage
+                          formType="A"
+                          message="infoLatestSubFormRWithinYear"
+                          latestSubFormDate={DateUtilities.ToLocalDate(
+                            infoActionsA.latestSubDateForm
+                          )}
+                        />
+                      )}
+                    {/* **** Form A - LATEST SUB DATE YEAR PLUS ****/}
+                    {infoActionsA.latestSubDateForm &&
+                      infoActionsA.isForInfoYearPlusSubForm && (
+                        <FormMessage
+                          formType="A"
+                          message="infoLatestSubFormRYearPlus"
+                          latestSubFormDate={DateUtilities.ToLocalDate(
+                            infoActionsA.latestSubDateForm
+                          )}
+                        />
+                      )}
+                    {/* **** Form B - LABEL ****/}
+                    <Label
+                      size="l"
+                      style={{ color: "#005EB8" }}
+                      data-cy="formASubHeader"
+                    >
+                      Form R (Part B)
+                    </Label>
+                    {/* **** Form B - NO SUB ****/}
+                    {noSubFormRB && (
+                      <FormMessage formType="B" message="infoNoFormEver" />
                     )}
-                  {/* **** Form B - LABEL ****/}
-                  <Label
-                    size="l"
-                    style={{ color: "#005EB8" }}
-                    data-cy="formASubHeader"
-                  >
-                    Form R (Part B)
-                  </Label>
-                  {/* **** Form B - NO SUB ****/}
-                  {noSubFormRB && (
-                    <FormMessage formType="B" message="infoNoFormEver" />
-                  )}
-                  {/* **** Form B - SUBMITTED ****/}
-                  {/* **** Form B - LATEST SUB DATE WITHIN LAST YEAR ****/}
-                  {infoActionsB.latestSubDateForm &&
-                    infoActionsB.isForInfoWithinYearSubForm && (
-                      <FormMessage
-                        formType="B"
-                        message="infoLatestSubFormRWithinYear"
-                        latestSubFormDate={DateUtilities.ToLocalDate(
-                          infoActionsB.latestSubDateForm
-                        )}
-                      />
-                    )}
-                  {/* **** Form B - LATEST SUB DATE YEAR PLUS ****/}
-                  {infoActionsB.latestSubDateForm &&
-                    infoActionsB.isForInfoYearPlusSubForm && (
-                      <FormMessage
-                        formType="B"
-                        message="infoLatestSubFormRYearPlus"
-                        latestSubFormDate={DateUtilities.ToLocalDate(
-                          infoActionsB.latestSubDateForm
-                        )}
-                      />
-                    )}
+                    {/* **** Form B - SUBMITTED ****/}
+                    {/* **** Form B - LATEST SUB DATE WITHIN LAST YEAR ****/}
+                    {infoActionsB.latestSubDateForm &&
+                      infoActionsB.isForInfoWithinYearSubForm && (
+                        <FormMessage
+                          formType="B"
+                          message="infoLatestSubFormRWithinYear"
+                          latestSubFormDate={DateUtilities.ToLocalDate(
+                            infoActionsB.latestSubDateForm
+                          )}
+                        />
+                      )}
+                    {/* **** Form B - LATEST SUB DATE YEAR PLUS ****/}
+                    {infoActionsB.latestSubDateForm &&
+                      infoActionsB.isForInfoYearPlusSubForm && (
+                        <FormMessage
+                          formType="B"
+                          message="infoLatestSubFormRYearPlus"
+                          latestSubFormDate={DateUtilities.ToLocalDate(
+                            infoActionsB.latestSubDateForm
+                          )}
+                        />
+                      )}
+                  </ul>
                 </Card.Content>
               </Card>
               {/* ----------------- In progress ---------------------- */}

--- a/cypress/component/forms/formr-part-a/FormA.cy.tsx
+++ b/cypress/component/forms/formr-part-a/FormA.cy.tsx
@@ -120,27 +120,34 @@ describe("FormA (form creation)", () => {
       .click();
     cy.get(".react-select__value-container").contains("British");
 
-    cy.get('[data-cy="dateAttained-input"]').should("exist").type("2023-05-01");
-    cy.get('[data-cy="medicalSchool-input"]').clear();
-    cy.get('[data-cy="medicalSchool-inline-error-msg"]')
+    cy.get('[data-cy="dateOfBirth-input"]').should("exist").type("1000-05-01");
+    cy.get('[data-cy="dateOfBirth-inline-error-msg"]')
       .should("exist")
       .should(
         "include.text",
-        "Medical School Awarding Primary Qualification is required"
+        "Date of Birth is before the minimum date allowed"
       );
-    cy.get(".nhsuk-error-summary").should("exist");
-    cy.get(
-      '[data-cy="error-txt-medicalSchool,Medical School Awarding Primary Qualification is required"]'
-    ).should("exist");
+    cy.get('[data-cy="email-inline-error-msg"]').should("exist");
 
+    cy.get('[data-cy="errorSummary"] > p')
+      .should("exist")
+      .should(
+        "include.text",
+        "Please fix the following errors before proceeding:"
+      );
     cy.get(
-      '[data-cy="error-txt-dateOfBirth,This date is before the minimum date allowed"]'
+      '[data-cy="error-txt-Date of Birth is before the minimum date allowed"]'
+    ).should("exist");
+    cy.get('[data-cy="error-txt-Email address is required"]').should("exist");
+
+    cy.get('[data-cy="dateOfBirth-input"]').type("2000-05-01");
+    cy.get('[data-cy="email-input"]').type("a@a.a");
+
+    cy.get('[data-cy="errorSummary"] > p').should("not.exist");
+    cy.get(
+      '[data-cy="error-txt-Date of Birth is before the minimum date allowed"]'
     ).should("not.exist");
     cy.get('[data-cy="dateOfBirth-inline-error-msg"]').should("not.exist");
-
-    cy.get('[data-cy="medicalSchool-input"]').type("best medical school");
-    cy.get(".nhsuk-error-summary").should("not.exist");
-    cy.get('[data-cy="medicalSchool-inline-error-msg"]').should("not.exist");
 
     // test soft validation
     cy.get('[data-cy="postCode-input"]').should("exist").clear().type("123456");
@@ -152,24 +159,18 @@ describe("FormA (form creation)", () => {
       );
     cy.get('[data-cy="postCode-inline-error-msg"]').should("not.exist");
 
-    cy.get('[data-cy="navNext"]').click();
+    cy.get('[data-cy="email-input"]').clear().type("x@x");
+    cy.get('[data-cy="navNext"]').click({ force: true });
+    cy.get('[data-cy="navNext"]').should(
+      "have.class",
+      "nhsuk-pagination__link nhsuk-pagination__link--next disabled-link"
+    );
     cy.get(".nhsuk-error-summary").should("exist");
-    cy.get(
-      '[data-cy="error-txt-dateOfBirth,This date is before the minimum date allowed"]'
-    ).should("exist");
-    cy.get('[data-cy="dateOfBirth-inline-error-msg"]').should("exist");
-    cy.get('[data-cy="email-inline-error-msg"]').should("exist");
-    cy.get('[data-cy="error-txt-email,Email address is required"]').should(
-      "exist"
-    );
-    cy.get('[data-cy="dateOfBirth-input"]').type("2003-05-01");
-    cy.get('[data-cy="email-input"]').type("a@a.a");
+    cy.get('[data-cy="error-txt-Email address is invalid"]').should("exist");
+
+    cy.get('[data-cy="email-input"]').clear().type("in@refinement.coma");
+
     cy.get(".nhsuk-error-summary").should("not.exist");
-    cy.get('[data-cy="dateOfBirth-inline-error-msg"]').should("not.exist");
-    cy.get('[data-cy="email-inline-error-msg"]').should("not.exist");
-    cy.get('[data-cy="error-txt-email,Email address is required"]').should(
-      "not.exist"
-    );
     cy.get('[data-cy="BtnSaveDraft"]').should("exist");
     cy.get('[data-cy="navNext"]').click();
 
@@ -231,13 +232,11 @@ describe("FormA (form creation)", () => {
     cy.get(
       '[data-cy="cctSpecialty1"] > .autocomplete-select > .react-select__control > .react-select__value-container > .react-select__input-container'
     ).should("not.exist");
-    cy.get(".nhsuk-error-summary").should("not.exist");
+    cy.get('[data-cy="cctSpecialty1-inline-error-msg"]').should("not.exist");
 
-    // catch any errors not ttriggered completing the form section
-    cy.get('[data-cy="navNext"]').click();
     cy.get(".nhsuk-error-summary").should("exist");
     cy.get(
-      '[data-cy="error-txt-completionDate,Anticipated completion date - please choose a future date"]'
+      '[data-cy="error-txt-Anticipated completion date - please choose a future date"]'
     ).should("exist");
     cy.get('[data-cy="completionDate-inline-error-msg"]').should("exist");
 
@@ -299,11 +298,11 @@ describe("FormA (form creation)", () => {
       "Please fix the following errors before proceeding:"
     );
     cy.get(
-      '[data-cy="error-txt-wholeTimeEquivalent,Training hours (Full Time Equivalent) needs to be a number less than or equal to 1 and greater than zero (a maximum of 2 decimal places)"]'
+      '[data-cy="error-txt-Training hours (Full Time Equivalent) needs to be a number less than or equal to 1 and greater than zero (a maximum of 2 decimal places)"]'
     ).should("exist");
     cy.get('[data-cy="wholeTimeEquivalent-input"]').type("1.1");
     cy.get(
-      '[data-cy="error-txt-wholeTimeEquivalent,Training hours (Full Time Equivalent) needs to be a number less than or equal to 1 and greater than zero (a maximum of 2 decimal places)"]'
+      '[data-cy="error-txt-Training hours (Full Time Equivalent) needs to be a number less than or equal to 1 and greater than zero (a maximum of 2 decimal places)"]'
     ).should("exist");
     cy.get('[data-cy="wholeTimeEquivalent-input"]').clear().type("0.5");
     cy.get(

--- a/cypress/component/forms/formr-part-a/View.cy.tsx
+++ b/cypress/component/forms/formr-part-a/View.cy.tsx
@@ -95,13 +95,13 @@ describe("View", () => {
 
     cy.get(".nhsuk-error-summary").should("exist");
     cy.get(
-      '[data-cy="error-txt-dateOfBirth,This date is before the minimum date allowed"]'
+      '[data-cy="error-txt-Date of Birth is before the minimum date allowed"]'
     ).should("exist");
     cy.get(
-      '[data-cy="error-txt-completionDate,Anticipated completion date - please choose a future date"]'
+      '[data-cy="error-txt-Anticipated completion date - please choose a future date"]'
     ).should("exist");
     cy.get(
-      '[data-cy="error-txt-wholeTimeEquivalent,Training hours (Full Time Equivalent) needs to be a number less than or equal to 1 and greater than zero (a maximum of 2 decimal places)"]'
+      '[data-cy="error-txt-Training hours (Full Time Equivalent) needs to be a number less than or equal to 1 and greater than zero (a maximum of 2 decimal places)"]'
     ).should("exist");
     cy.get('[data-cy="dateOfBirth-label"]').should(
       "have.class",

--- a/cypress/e2e/formr-a/FormRA.spec.ts
+++ b/cypress/e2e/formr-a/FormRA.spec.ts
@@ -103,7 +103,7 @@ describe("Form R Part A - Basic Form completion and submission", () => {
         cy.log("################ Error msg when no email ###################");
         cy.get('[data-cy="navNext"]').click();
         cy.get(".nhsuk-error-summary").should("exist");
-        cy.get('[data-cy="error-txt-email,Email address is required"]').should(
+        cy.get('[data-cy="error-txt-Email address is required"]').should(
           "exist"
         );
         cy.get('[data-cy="email-input"]')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.87.8",
+  "version": "0.88.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.87.8",
+      "version": "0.88.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.87.8",
+  "version": "0.88.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -614,3 +614,23 @@ ol[type="a"] {
   outline: none;
   border: none;
 }
+// error summary
+.error-summary_li {
+  list-style-type: none;
+  margin-left: -2em;
+}
+
+@media (max-width: 640px) {
+  .error-summary_li {
+    list-style-type: none;
+    margin-left: -2.5em;
+  }
+}
+
+.error-summary_li_nested {
+  list-style-type: none;
+}
+
+.error-spacing_div {
+  padding-top: 0.5em;
+}

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -459,7 +459,7 @@ export function validateFields(
 }
 
 export function filteredOptions(optionsKey: string | undefined, options: any) {
-  return optionsKey && options[optionsKey]?.length > 0
+  return optionsKey && options?.[optionsKey]?.length > 0
     ? options[optionsKey]
     : [];
 }

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -283,7 +283,9 @@ export function setTextFieldWidth(width: number) {
 }
 
 export function handleTextFieldWidth(
-  event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLDivElement>,
+  event: React.ChangeEvent<
+    HTMLInputElement | HTMLSelectElement | HTMLDivElement
+  >,
   currentValue: string,
   primaryField: Field | undefined
 ) {
@@ -297,7 +299,11 @@ export function handleTextFieldWidth(
   }
 }
 
-export function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+export function handleKeyDown(
+  e: React.KeyboardEvent<
+    HTMLInputElement | HTMLTextAreaElement | HTMLDivElement
+  >
+) {
   if (e.key === "Enter") {
     e.preventDefault();
   }

--- a/utilities/ProfileUtilities.ts
+++ b/utilities/ProfileUtilities.ts
@@ -102,7 +102,7 @@ export class ProfileUtilities {
     return trimmedWork;
   }
 
-  public static groupPlacementsByDate = (
+  public static readonly groupPlacementsByDate = (
     placements: Placement[]
   ): PlacementGroup => {
     const groupedPlacements: PlacementGroup = {

--- a/utilities/hooks/useFormAutosave.ts
+++ b/utilities/hooks/useFormAutosave.ts
@@ -2,24 +2,24 @@ import { MutableRefObject, useEffect, useState } from "react";
 import { autosaveFormR } from "../FormBuilderUtilities";
 
 const useFormAutosave = (
-  formData: any,
+  fetchedFormData: any,
   formName: string,
   isFormDirty: MutableRefObject<boolean>
 ) => {
-  const [formFields, setFormFields] = useState(formData);
+  const [formData, setFormData] = useState(fetchedFormData);
 
   useEffect(() => {
     if (isFormDirty.current) {
       const timeoutId = setTimeout(() => {
-        autosaveFormR(formName, formFields);
+        autosaveFormR(formName, formData);
       }, 2000);
       return () => {
         clearTimeout(timeoutId);
       };
     }
-  }, [formFields]);
+  }, [formData]);
 
-  return { formFields, setFormFields };
+  return { formData, setFormData };
 };
 
 export default useFormAutosave;


### PR DESCRIPTION
**The main objective of this commit** 
1. Make sure Form R (Part A) still works while adding the necessary logic to the FormBuilder to accommodate dynamic arrays of objects (e.g. used in Form R Part B section 2). 

**This commit includes the following:**
1. Refactor of the FormBuilder component to allow arrays 
3. Create a PanelBuilder component to allow the us to render a dynamic array of panels, the ability to add and remove panels, and the validation of nested panel fields.
4. Rework the FormErrors error summary component to allow us to display nested array object field errors under the parent name/number.
3. Following discussion, trigger and display Inline errors in any form built via the FormBuilder as per the current Form R B implementation i.e. any field errors for the section appear via a field onChange event. (This implementation leads to simplified validation logic via a useEffect in the FormBuilder. The JSON field visibility logic is also also simplified with some being moved to the FormViewBuilder component).
5. Move some FormBuilder functions out of the FormBuilder component to utils file to make it more readable/more easily maintained.
6. Fix some styling issues - mainly around displaying nested error ul/li across devices.
7. Move more of the form submission/ filtering for visible fields logic into the utils file and refactor the form R sub function so it can be used by any FormBuilder form.

**TODO:**
Refactor the FormBuilder Text component to allow number-only input and a read-only total field.
Refactor the Form View component to display nested object fields and a nested error summary

**Note:**
As far as testing is concerned, the goal for this commit is to not break the current Form R (A) tests so there are no new tests added so far. 
When we use the array logic when building Form R Part B (which has panel arrays and TOOT number/totals fields) we can add any new tests then.