### PR TITLE
Add submission declarations checklist to FormBuilder 

### DIFF
--- a/components/forms/form-builder/Declarations.tsx
+++ b/components/forms/form-builder/Declarations.tsx
@@ -1,0 +1,53 @@
+import { Checkboxes } from "nhsuk-react-components";
+import { Form } from "./FormBuilder";
+import { useEffect, useMemo, useState } from "react";
+
+type DeclarationsProps = {
+  setCanSubmit: (canSubmit: boolean) => void;
+  canEdit: boolean;
+  formJson: Form;
+};
+
+export default function Declarations({
+  setCanSubmit,
+  canEdit,
+  formJson
+}: Readonly<DeclarationsProps>) {
+  const initialDecValues = useMemo(() => {
+    return formJson.declarations.reduce((values, declaration) => {
+      values[declaration.name] = false;
+      return values;
+    }, {} as Record<string, boolean>);
+  }, [formJson.declarations]);
+
+  const [decValues, setDecValues] =
+    useState<Record<string, boolean>>(initialDecValues);
+  const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, checked } = event.target;
+    setDecValues({
+      ...decValues,
+      [name]: checked
+    });
+  };
+
+  useEffect(() => {
+    setCanSubmit(Object.values(decValues).every(v => v));
+  }, [decValues, setCanSubmit]);
+
+  return (
+    <Checkboxes>
+      {formJson.declarations.map(declaration => (
+        <Checkboxes.Box
+          key={declaration.name}
+          data-cy={declaration.name}
+          name={declaration.name}
+          checked={canEdit ? decValues[declaration.name] : true}
+          onChange={handleCheckboxChange}
+          readOnly={!canEdit}
+        >
+          {declaration.label}
+        </Checkboxes.Box>
+      ))}
+    </Checkboxes>
+  );
+}

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -77,6 +77,7 @@ type Section = {
 export type Form = {
   name: string;
   pages: Page[];
+  declarations: { name: string; label: string }[];
 };
 type FormBuilderProps = {
   jsonForm: Form;

--- a/components/forms/form-builder/form-r/part-a/FormAView.tsx
+++ b/components/forms/form-builder/form-r/part-a/FormAView.tsx
@@ -82,9 +82,9 @@ const FormAView = () => {
             Confirmation
           </WarningCallout.Label>
           <p>
-            Please check the information entered below is correct, agree to the
+            {`Please check the information entered below is correct, agree to the
             Declarations at the bottom of the page, and then click 'Submit
-            Form'.
+            Form'.`}
           </p>
         </WarningCallout>
       )}

--- a/components/forms/form-builder/form-r/part-a/FormAView.tsx
+++ b/components/forms/form-builder/form-r/part-a/FormAView.tsx
@@ -29,8 +29,8 @@ import { StartOverButton } from "../../../StartOverButton";
 import { formAValidationSchemaView } from "./formAValidationSchema";
 import { ValidationError } from "yup";
 import { FormErrors } from "../../FormBuilder";
+import Declarations from "../../Declarations";
 
-//NOTE TO FUTURE SELF - make this comp more generic
 const FormAView = () => {
   const confirm = useConfirm();
   const formName = formAJson.name;
@@ -38,6 +38,7 @@ const FormAView = () => {
   const formAData = useAppSelector(selectSavedFormA);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState({});
+  const [canSubmit, setCanSubmit] = useState(false);
 
   useEffect(() => {
     if (canEdit) {
@@ -81,8 +82,9 @@ const FormAView = () => {
             Confirmation
           </WarningCallout.Label>
           <p>
-            Check the information entered below is correct and click Submit at
-            the bottom of the page.
+            Please check the information entered below is correct, agree to the
+            Declarations at the bottom of the page, and then click 'Submit
+            Form'.
           </p>
         </WarningCallout>
       )}
@@ -98,34 +100,36 @@ const FormAView = () => {
         formErrors={errors}
       />
       {Object.keys(errors).length > 0 && <FormErrors formErrors={errors} />}
-      {canEdit && (
-        <WarningCallout data-cy="warningSubmit">
-          <WarningCallout.Label visuallyHiddenText={false}>
-            Important
-          </WarningCallout.Label>
-          <p>
-            By submitting this form, I confirm that the information above is
-            correct and I will keep my Designated Body and the GMC informed as
-            soon as possible of any change to my contact details.
-          </p>
-        </WarningCallout>
-      )}
+
+      <WarningCallout>
+        <WarningCallout.Label>Declarations</WarningCallout.Label>
+        <form onSubmit={() => setIsSubmitting(true)}>
+          <Declarations
+            setCanSubmit={setCanSubmit}
+            canEdit={canEdit}
+            formJson={formAJson}
+          />
+          {canEdit && (
+            <Button
+              onClick={(e: { preventDefault: () => void }) => {
+                e.preventDefault();
+                setIsSubmitting(true);
+                handleSubClick(formAData);
+              }}
+              disabled={
+                !canSubmit || isSubmitting || Object.keys(errors).length > 0
+              }
+              data-cy="BtnSubmit"
+            >
+              Submit Form
+            </Button>
+          )}
+        </form>
+      </WarningCallout>
+
       {canEdit && (
         <Container>
           <Row>
-            <Col width="one-quarter">
-              <Button
-                onClick={(e: { preventDefault: () => void }) => {
-                  e.preventDefault();
-                  setIsSubmitting(true);
-                  handleSubClick(formAData);
-                }}
-                disabled={isSubmitting || Object.keys(errors).length > 0}
-                data-cy="BtnSubmit"
-              >
-                Submit Form
-              </Button>
-            </Col>
             <Col width="one-quarter">
               <Button
                 secondary

--- a/components/forms/form-builder/form-r/part-a/formA.json
+++ b/components/forms/form-builder/form-r/part-a/formA.json
@@ -250,5 +250,15 @@
         }
       ]
     }
+  ],
+  "declarations": [
+    {
+      "name": "isCorrect",
+      "label": "I confirm that the above information is correct."
+    },
+    {
+      "name": "willKeepInformed",
+      "label": "I will keep my Designated Body and the GMC informed as soon as possible of any change to my contact details."
+    }
   ]
 }

--- a/cypress/component/forms/formr-part-a/View.cy.tsx
+++ b/cypress/component/forms/formr-part-a/View.cy.tsx
@@ -138,6 +138,9 @@ describe("View", () => {
       </Provider>
     );
     cy.get(".nhsuk-error-summary").should("not.exist");
+    cy.get('[data-cy="BtnSubmit"]').should("be.disabled");
+    cy.get('[data-cy="isCorrect"]').should("exist").click();
+    cy.get('[data-cy="willKeepInformed"]').should("exist").click();
     cy.get('[data-cy="BtnSubmit"]').should("not.be.disabled");
   });
 });

--- a/cypress/e2e/formr-a/FormRA.spec.ts
+++ b/cypress/e2e/formr-a/FormRA.spec.ts
@@ -207,7 +207,13 @@ describe("Form R Part A - Basic Form completion and submission", () => {
         cy.get('[data-cy="edit-Personal Details"]').should("exist");
 
         // Submit form
-        cy.get("[data-cy=BtnSubmit]").scrollIntoView().should("exist").click();
+        cy.get("[data-cy=BtnSubmit]")
+          .scrollIntoView()
+          .should("exist")
+          .should("be.disabled");
+        cy.get('[data-cy="isCorrect"]').should("exist").click();
+        cy.get('[data-cy="willKeepInformed"]').should("exist").click();
+        cy.get('[data-cy="BtnSubmit"]').should("not.be.disabled").click();
         cy.get(".MuiDialog-container")
           .should("exist")
           .should("include.text", "Please think carefully before submitting");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.91.0",
+  "version": "0.93.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.91.0",
+      "version": "0.93.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",
@@ -16241,9 +16241,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
       "peer": true
     },
     "node_modules/is-arguments": {
@@ -37422,9 +37422,9 @@
       }
     },
     "ip": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
       "peer": true
     },
     "is-arguments": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.92.4",
+  "version": "0.93.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",


### PR DESCRIPTION
**Problem**
There is currently no consistency with Form R submission declarations.
Form A currently has a warning callout with a "by submitting this form..." declaration, with no mention of any agreements on the submitted form View page, while Form B does have checkboxes to tick as part of the main form.

**Solution** 
1. Standardise the submission checklist so the checklist fields and text can be passed in via the JSON file to a self-contained Declarations component.
2. Simplify the checkbox validation logic i.e. ‘Submit Form’ button is disabled unless all checkboxes have been checked (with no need for additional form validation).

Note: Some of the submit logic added to `FormAView.tsx` has been copied from the existing logic in `formr-part-b/sections/Declarations.tsx` .

TO DO:
There's still scope to refactor this code further but the main priority is to have something that can be used for a form built via the FormBuilder.
A lot of the other Warning text can be moved to the JSON file and passed into the form in a similar way to the Declarations.

TIS21-5754

