### PR TITLE
Add in-app notifications (welcome pt1)

### DIFF
--- a/components/common/ErrorPage.tsx
+++ b/components/common/ErrorPage.tsx
@@ -1,0 +1,28 @@
+type ErrorPageProps = {
+  message: string;
+  header?: string;
+};
+
+export default function ErrorPage({
+  message,
+  header = "Oops! Something went wrong"
+}: Readonly<ErrorPageProps>) {
+  return (
+    <div
+      className="nhsuk-error-summary"
+      aria-labelledby="error-summary-title"
+      role="alert"
+    >
+      <h2
+        className="nhsuk-error-summary__title"
+        id="error-summary-title"
+        data-cy="error-header-text"
+      >
+        {header}
+      </h2>
+      <div className="nhsuk-error-summary__body" data-cy="error-message-text">
+        {message}
+      </div>
+    </div>
+  );
+}

--- a/components/main/Main.tsx
+++ b/components/main/Main.tsx
@@ -30,6 +30,7 @@ import packageJson from "../../package.json";
 import { loadFormAList } from "../../redux/slices/formASlice";
 import { loadFormBList } from "../../redux/slices/formBSlice";
 import { fetchTraineeActionsData } from "../../redux/slices/traineeActionsSlice";
+import { Notifications } from "../notifications/Notifications";
 
 const appVersion = packageJson.version;
 
@@ -137,6 +138,7 @@ export const Main = () => {
             <Route path="/formr-b" component={FormRPartB} />
             <Route exact path="/support" component={Support} />
             <Route path="/mfa" component={MFA} />
+            <Route path="/notifications" component={Notifications} />
             <Redirect exact path="/" to="/home" />
             <Redirect
               exact

--- a/components/navigation/TSSHeader.tsx
+++ b/components/navigation/TSSHeader.tsx
@@ -3,8 +3,21 @@ import { NavLink } from "react-router-dom";
 import { SignOutBtn } from "../common/SignOutBtn";
 import { NHSEnglandLogoWhite } from "../../public/NHSEnglandLogoWhite";
 import store from "../../redux/store/store";
+import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
+import { useEffect } from "react";
+import { getNotifications } from "../../redux/slices/notificationsSlice";
 
 const TSSHeader = () => {
+  const dispatch = useAppDispatch();
+  const notificationsStatus = useAppSelector(
+    state => state.notifications.status
+  );
+  useEffect(() => {
+    if (notificationsStatus === "idle") {
+      dispatch(getNotifications());
+    }
+  }, [notificationsStatus, dispatch]);
+
   return (
     <Header>
       <Header.Container>

--- a/components/navigation/TSSHeader.tsx
+++ b/components/navigation/TSSHeader.tsx
@@ -6,9 +6,13 @@ import store from "../../redux/store/store";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
 import { useEffect } from "react";
 import { getNotifications } from "../../redux/slices/notificationsSlice";
+import { NotificationsBtn } from "../notifications/NotificationsBtn";
 
 const TSSHeader = () => {
   const dispatch = useAppDispatch();
+  const unreadNotificationCount = useAppSelector(
+    state => state.notifications.unreadNotificationCount
+  );
   const notificationsStatus = useAppSelector(
     state => state.notifications.status
   );
@@ -31,23 +35,35 @@ const TSSHeader = () => {
           </a>
         </div>
         <Header.Content>
-          <Header.MenuToggle data-cy="menuToggleBtn" />
+          <div className="mobile-header">
+            <NotificationsBtn
+              unreadNotificationCount={unreadNotificationCount}
+              data-cy="notificationBtnHDR"
+            />
+            <Header.MenuToggle data-cy="menuToggleBtn" />
+          </div>
           <div className="top-nav-container">
-            <NavLink
-              className="nhsuk-header__navigation-link"
-              data-cy="topNavSupport"
-              to="/support"
-            >
-              Support
-            </NavLink>
-            <NavLink
-              className="nhsuk-header__navigation-link"
-              data-cy="topNavMfaSetup"
-              to="/mfa"
-            >
-              MFA set-up
-            </NavLink>
-            <SignOutBtn />
+            <NotificationsBtn
+              unreadNotificationCount={unreadNotificationCount}
+              data-cy="notificationBtnHDR"
+            />
+            <div className="top-nav-container">
+              <NavLink
+                className="nhsuk-header__navigation-link"
+                data-cy="topNavSupport"
+                to="/support"
+              >
+                Support
+              </NavLink>
+              <NavLink
+                className="nhsuk-header__navigation-link"
+                data-cy="topNavMfaSetup"
+                to="/mfa"
+              >
+                MFA set-up
+              </NavLink>
+              <SignOutBtn />
+            </div>
           </div>
         </Header.Content>
       </Header.Container>

--- a/components/notifications/AllUnreadCheckbox.tsx
+++ b/components/notifications/AllUnreadCheckbox.tsx
@@ -1,0 +1,29 @@
+import { Header } from "@tanstack/react-table";
+import { NotificationType } from "../../redux/slices/notificationsSlice";
+
+type AllUnreadCheckboxProps = {
+  header: Header<NotificationType, unknown>;
+};
+
+export function AllUnreadCheckbox({
+  header
+}: Readonly<AllUnreadCheckboxProps>) {
+  return (
+    <div>
+      <label htmlFor="unreadCheck" className="nhsuk-u-font-size-14">
+        Unread
+      </label>
+      <input
+        type="checkbox"
+        id="unreadCheck"
+        value={(header.column.getFilterValue() as string) || "read"}
+        defaultChecked={false}
+        onChange={e =>
+          header.column.setFilterValue(
+            e.target.value === "read" ? "unread" : "read"
+          )
+        }
+      ></input>
+    </div>
+  );
+}

--- a/components/notifications/DebouncedInput.tsx
+++ b/components/notifications/DebouncedInput.tsx
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+
+export function DebouncedInput({
+  value: initialValue,
+  onChange,
+  debounce = 500,
+  ...props
+}: {
+  value: string | number;
+  onChange: (value: string | number) => void;
+  debounce?: number;
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange">) {
+  const [value, setValue] = useState(initialValue);
+
+  useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      onChange(value);
+    }, debounce);
+
+    return () => clearTimeout(timeout);
+  }, [value, onChange, debounce]); // TODO check these dependencies
+
+  return (
+    <input {...props} value={value} onChange={e => setValue(e.target.value)} />
+  );
+}

--- a/components/notifications/NotificationMessage.tsx
+++ b/components/notifications/NotificationMessage.tsx
@@ -1,0 +1,74 @@
+import { useParams } from "react-router-dom";
+import { useAppSelector } from "../../redux/hooks/hooks";
+import ErrorPage from "../common/ErrorPage";
+import { BackLink, Col, Container, Label, Row } from "nhsuk-react-components";
+import history from "../navigation/history";
+import { DateUtilities } from "../../utilities/DateUtilities";
+import { useEffect } from "react";
+import store from "../../redux/store/store";
+import { getNotificationMessage } from "../../redux/slices/notificationsSlice";
+import { NotificationMessageText } from "./NotificationMessageText";
+
+export const NotificationMessage = () => {
+  const { id } = useParams<{ id: string }>();
+  //active notification (from previous page row click)
+  const activeNotification = useAppSelector(
+    state => state.notifications.activeNotification
+  );
+  const notificationMessage = useAppSelector(
+    state => state.notifications.notificationMsg
+  );
+  const notificationMessageStatus = useAppSelector(
+    state => state.notifications.msgStatus
+  );
+
+  useEffect(() => {
+    store.dispatch(getNotificationMessage(id));
+  }, [id]);
+
+  return (
+    <div>
+      <Row>
+        <Col width="three-quarters">
+          <BackLink
+            data-testid="backLink-to-notifications"
+            className="back-link"
+            data-cy="backLink"
+            onClick={() => history.push("/notifications")}
+          >
+            Back to list
+          </BackLink>
+        </Col>
+      </Row>
+      {id && id === activeNotification?.id ? (
+        <Container className="nhsuk-u-margin-bottom-5 nhsuk-u-padding-3 container">
+          <Row>
+            <Col width="three-quarters">
+              <Label size="m">
+                <b>{activeNotification?.subjectText}</b>
+              </Label>
+            </Col>
+            <Col width="one-quarter">
+              <Label>
+                {DateUtilities.ToLocalDateTime(activeNotification?.sentAt)}
+              </Label>
+              <span>{activeNotification?.subject}</span>
+            </Col>
+          </Row>
+          <Row>
+            <Col width="full">
+              <NotificationMessageText
+                notificationMessageStatus={notificationMessageStatus}
+                notificationMessageText={notificationMessage}
+              />
+            </Col>
+          </Row>
+        </Container>
+      ) : (
+        <ErrorPage message="This message could not be loaded." />
+      )}
+    </div>
+  );
+};
+
+export default NotificationMessage;

--- a/components/notifications/NotificationMessage.tsx
+++ b/components/notifications/NotificationMessage.tsx
@@ -8,6 +8,7 @@ import { useEffect } from "react";
 import store from "../../redux/store/store";
 import { getNotificationMessage } from "../../redux/slices/notificationsSlice";
 import { NotificationMessageText } from "./NotificationMessageText";
+import { toastErrText } from "../../utilities/Constants";
 
 export const NotificationMessage = () => {
   const { id } = useParams<{ id: string }>();
@@ -65,7 +66,7 @@ export const NotificationMessage = () => {
           </Row>
         </Container>
       ) : (
-        <ErrorPage message="This message could not be loaded." />
+        <ErrorPage message={toastErrText.fetchNotificationMessage} />
       )}
     </div>
   );

--- a/components/notifications/NotificationMessageText.tsx
+++ b/components/notifications/NotificationMessageText.tsx
@@ -1,3 +1,4 @@
+import { toastErrText } from "../../utilities/Constants";
 import ErrorPage from "../common/ErrorPage";
 
 type NotificationMessageTextType = {
@@ -12,7 +13,7 @@ export function NotificationMessageText({
   if (notificationMessageStatus === "loading") {
     return <p>Loading...</p>;
   } else if (notificationMessageStatus === "failed") {
-    return <ErrorPage message="Failed to load this message." />;
+    return <ErrorPage message={toastErrText.fetchNotificationMessage} />;
   }
   return (
     <div className="nhsuk-u-margin-top-2">

--- a/components/notifications/NotificationMessageText.tsx
+++ b/components/notifications/NotificationMessageText.tsx
@@ -1,0 +1,22 @@
+import ErrorPage from "../common/ErrorPage";
+
+type NotificationMessageTextType = {
+  notificationMessageStatus: string;
+  notificationMessageText: string;
+};
+
+export function NotificationMessageText({
+  notificationMessageStatus,
+  notificationMessageText
+}: Readonly<NotificationMessageTextType>) {
+  if (notificationMessageStatus === "loading") {
+    return <p>Loading...</p>;
+  } else if (notificationMessageStatus === "failed") {
+    return <ErrorPage message="Failed to load this message." />;
+  }
+  return (
+    <div className="nhsuk-u-margin-top-2">
+      <p className="nhsuk-body"> {notificationMessageText}</p>
+    </div>
+  );
+}

--- a/components/notifications/Notifications.tsx
+++ b/components/notifications/Notifications.tsx
@@ -1,0 +1,39 @@
+import { Redirect, Route, Switch } from "react-router-dom";
+import ScrollTo from "../forms/ScrollTo";
+import PageTitle from "../common/PageTitle";
+import { Fieldset } from "nhsuk-react-components";
+import { useAppSelector } from "../../redux/hooks/hooks";
+import PageNotFound from "../common/PageNotFound";
+import { NotificationsTable } from "./NotificationsTable";
+import { NotificationMessage } from "./NotificationMessage";
+
+export const Notifications = () => {
+  const preferredMfa = useAppSelector(state => state.user.preferredMfa);
+  if (preferredMfa === "NOMFA") {
+    return <Redirect to="/mfa" />;
+  }
+  return (
+    <>
+      <PageTitle title="Notifications" />
+      <ScrollTo />
+      <Fieldset>
+        <Fieldset.Legend
+          isPageHeading
+          className="fieldset-legend__header"
+          data-cy="notificationsHeading"
+        >
+          Notifications
+        </Fieldset.Legend>
+      </Fieldset>
+      <Switch>
+        <Route
+          exact
+          path="/notifications/:id"
+          component={NotificationMessage}
+        />
+        <Route exact path="/notifications" component={NotificationsTable} />
+        <Route path="/notifications/*" component={PageNotFound} />
+      </Switch>
+    </>
+  );
+};

--- a/components/notifications/NotificationsBtn.tsx
+++ b/components/notifications/NotificationsBtn.tsx
@@ -2,30 +2,30 @@ import { Button } from "nhsuk-react-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBell } from "@fortawesome/free-solid-svg-icons";
 import { Tooltip } from "react-tooltip";
-
+import history from "../navigation/history";
 type NotificationsBtnType = {
   unreadNotificationCount: number;
 };
-
 export const NotificationsBtn = ({
   unreadNotificationCount
 }: NotificationsBtnType) => {
+  const handleBtnClick = () => {
+    history.push("/notifications");
+  };
   return (
     <Button
       type="button"
       className="notification-btn"
       data-cy="signOutBtn"
-      data-tooltip-id="Notifications"
+      data-tooltip-id="NotificationsCount"
+      onClick={handleBtnClick}
     >
       <span>
         <FontAwesomeIcon icon={faBell} size="xs" color="white" />
-        <Tooltip
-          className="tooltip tooltip-row"
-          id="Notifications"
-          place="top"
-          content="Notifications"
-        />
-        {<span className="notification-badge">{unreadNotificationCount}</span>}
+        <Tooltip id="NotificationsCount" content="Read your notifications" />
+        {unreadNotificationCount > 0 && (
+          <span className="notification-badge">{unreadNotificationCount}</span>
+        )}
       </span>
     </Button>
   );

--- a/components/notifications/NotificationsBtn.tsx
+++ b/components/notifications/NotificationsBtn.tsx
@@ -1,0 +1,32 @@
+import { Button } from "nhsuk-react-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faBell } from "@fortawesome/free-solid-svg-icons";
+import { Tooltip } from "react-tooltip";
+
+type NotificationsBtnType = {
+  unreadNotificationCount: number;
+};
+
+export const NotificationsBtn = ({
+  unreadNotificationCount
+}: NotificationsBtnType) => {
+  return (
+    <Button
+      type="button"
+      className="notification-btn"
+      data-cy="signOutBtn"
+      data-tooltip-id="Notifications"
+    >
+      <span>
+        <FontAwesomeIcon icon={faBell} size="xs" color="white" />
+        <Tooltip
+          className="tooltip tooltip-row"
+          id="Notifications"
+          place="top"
+          content="Notifications"
+        />
+        {<span className="notification-badge">{unreadNotificationCount}</span>}
+      </span>
+    </Button>
+  );
+};

--- a/components/notifications/NotificationsTable.tsx
+++ b/components/notifications/NotificationsTable.tsx
@@ -1,0 +1,137 @@
+import React, { useMemo, useState } from "react";
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  flexRender,
+  SortingState,
+  ColumnFiltersState,
+  PaginationState
+} from "@tanstack/react-table";
+import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
+import { updateNotificationStatus } from "../../utilities/NotificationsUtilities";
+import { DebouncedInput } from "./DebouncedInput";
+import { TablePagination } from "./TablePagination";
+import { AllUnreadCheckbox } from "./AllUnreadCheckbox";
+import { columns } from "./columns";
+import { updatedNotificationUpdateInProgress } from "../../redux/slices/notificationsSlice";
+
+export const NotificationsTable: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const inProgressUpdate = useAppSelector(
+    state => state.notifications.notificationUpdateInProgress
+  );
+  const notificationsData = useAppSelector(
+    state => state.notifications.notificationsList
+  );
+  const memoData = useMemo(() => notificationsData, [notificationsData]);
+
+  const [globalFilter, setGlobalFilter] = useState<string>("");
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "sentAt", desc: true }
+  ]);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 5
+  });
+
+  const table = useReactTable({
+    data: memoData,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    state: {
+      columnFilters,
+      sorting,
+      globalFilter,
+      pagination
+    },
+    onColumnFiltersChange: setColumnFilters,
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    onPaginationChange: setPagination,
+    autoResetPageIndex: false
+  });
+
+  return (
+    <>
+      <DebouncedInput
+        value={globalFilter}
+        onChange={value => setGlobalFilter(String(value))}
+        placeholder="Search notifications..."
+        className="nhsuk-input nhsuk-input--width-20 table-search-input"
+        data-cy="NotificationsSearchInput"
+      />
+      <div className="table-wrapper">
+        <table data-cy="notificationsTable">
+          <thead>
+            {table.getHeaderGroups().map(headerGroup => {
+              return (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map(header => {
+                    return (
+                      <th
+                        key={header.id}
+                        className="nhsuk-u-padding-left-3"
+                        data-cy={`notificationsTable-${header.id}`}
+                      >
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                        {header.column.columnDef.id === "status" && (
+                          <AllUnreadCheckbox header={header} />
+                        )}
+                      </th>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map(row => {
+              const statusClass =
+                row.original.status === "READ"
+                  ? "table-row row-read"
+                  : "table-row row-unread";
+              return (
+                <tr
+                  onClick={async e => {
+                    if (inProgressUpdate) return;
+                    dispatch(updatedNotificationUpdateInProgress(true));
+                    e.stopPropagation();
+                    await updateNotificationStatus(row.original, "READ");
+                    dispatch(updatedNotificationUpdateInProgress(false));
+                  }}
+                  key={row.id}
+                  className={`${statusClass}`}
+                  data-cy={`notificationsTableRow-${row.id}`}
+                >
+                  {row.getVisibleCells().map(cell => (
+                    <td
+                      key={cell.id}
+                      className="nhsuk-u-padding-left-3 table-data"
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <TablePagination table={table} />
+      <hr />
+    </>
+  );
+};

--- a/components/notifications/NotificationsTable.tsx
+++ b/components/notifications/NotificationsTable.tsx
@@ -17,6 +17,7 @@ import { TablePagination } from "./TablePagination";
 import { AllUnreadCheckbox } from "./AllUnreadCheckbox";
 import { columns } from "./columns";
 import { updatedNotificationUpdateInProgress } from "../../redux/slices/notificationsSlice";
+import { Label } from "nhsuk-react-components";
 
 export const NotificationsTable: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -58,7 +59,7 @@ export const NotificationsTable: React.FC = () => {
     autoResetPageIndex: false
   });
 
-  return (
+  return notificationsData.length > 0 ? (
     <>
       <DebouncedInput
         value={globalFilter}
@@ -133,5 +134,7 @@ export const NotificationsTable: React.FC = () => {
       <TablePagination table={table} />
       <hr />
     </>
+  ) : (
+    <Label>{`You currently don't have any notifications to read.`}</Label>
   );
 };

--- a/components/notifications/NotificationsTable.tsx
+++ b/components/notifications/NotificationsTable.tsx
@@ -10,20 +10,15 @@ import {
   ColumnFiltersState,
   PaginationState
 } from "@tanstack/react-table";
-import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
+import { useAppSelector } from "../../redux/hooks/hooks";
 import { updateNotificationStatus } from "../../utilities/NotificationsUtilities";
 import { DebouncedInput } from "./DebouncedInput";
 import { TablePagination } from "./TablePagination";
 import { AllUnreadCheckbox } from "./AllUnreadCheckbox";
 import { columns } from "./columns";
-import { updatedNotificationUpdateInProgress } from "../../redux/slices/notificationsSlice";
 import { Label } from "nhsuk-react-components";
 
 export const NotificationsTable: React.FC = () => {
-  const dispatch = useAppDispatch();
-  const inProgressUpdate = useAppSelector(
-    state => state.notifications.notificationUpdateInProgress
-  );
   const notificationsData = useAppSelector(
     state => state.notifications.notificationsList
   );
@@ -104,15 +99,13 @@ export const NotificationsTable: React.FC = () => {
               return (
                 <tr
                   onClick={async e => {
-                    if (inProgressUpdate) return;
-                    dispatch(updatedNotificationUpdateInProgress(true));
                     e.stopPropagation();
-                    await updateNotificationStatus(row.original, "READ");
-                    dispatch(updatedNotificationUpdateInProgress(false));
+                    updateNotificationStatus(row.original, "READ");
                   }}
                   key={row.id}
                   className={`${statusClass}`}
                   data-cy={`notificationsTableRow-${row.id}`}
+                  data-testid={`notificationsTableRow-${row.original.id}`}
                 >
                   {row.getVisibleCells().map(cell => (
                     <td

--- a/components/notifications/NotificationsTable.tsx
+++ b/components/notifications/NotificationsTable.tsx
@@ -135,6 +135,6 @@ export const NotificationsTable: React.FC = () => {
       <hr />
     </>
   ) : (
-    <Label>{`You currently don't have any notifications to read.`}</Label>
+    <Label data-cy="notificationsTableNoNotifs">{`You currently don't have any notifications to read.`}</Label>
   );
 };

--- a/components/notifications/RowActions.tsx
+++ b/components/notifications/RowActions.tsx
@@ -1,0 +1,38 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
+import {
+  NotificationType,
+  updatedNotificationUpdateInProgress
+} from "../../redux/slices/notificationsSlice";
+import { updateNotificationStatus } from "../../utilities/NotificationsUtilities";
+import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
+
+type RowActionsProps = {
+  row: NotificationType;
+};
+
+export function RowActions({ row }: Readonly<RowActionsProps>) {
+  const dispatch = useAppDispatch();
+  const inProgressUpdate = useAppSelector(
+    state => state.notifications.notificationUpdateInProgress
+  );
+
+  if (row.status === "READ") {
+    return (
+      <button
+        type="button"
+        className="unread-btn"
+        onClick={async e => {
+          dispatch(updatedNotificationUpdateInProgress(true));
+          e.stopPropagation();
+          await updateNotificationStatus(row, "UNREAD");
+          dispatch(updatedNotificationUpdateInProgress(false));
+        }}
+        disabled={inProgressUpdate}
+      >
+        <FontAwesomeIcon icon={faEnvelope} size="sm" className="unread-icon" />
+        <span>Mark as unread</span>
+      </button>
+    );
+  } else return null;
+}

--- a/components/notifications/RowActions.tsx
+++ b/components/notifications/RowActions.tsx
@@ -1,18 +1,14 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
-import {
-  NotificationType,
-  updatedNotificationUpdateInProgress
-} from "../../redux/slices/notificationsSlice";
+import { NotificationType } from "../../redux/slices/notificationsSlice";
 import { updateNotificationStatus } from "../../utilities/NotificationsUtilities";
-import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
+import { useAppSelector } from "../../redux/hooks/hooks";
 
 type RowActionsProps = {
   row: NotificationType;
 };
 
 export function RowActions({ row }: Readonly<RowActionsProps>) {
-  const dispatch = useAppDispatch();
   const inProgressUpdate = useAppSelector(
     state => state.notifications.notificationUpdateInProgress
   );
@@ -23,10 +19,8 @@ export function RowActions({ row }: Readonly<RowActionsProps>) {
         type="button"
         className="unread-btn"
         onClick={async e => {
-          dispatch(updatedNotificationUpdateInProgress(true));
           e.stopPropagation();
-          await updateNotificationStatus(row, "UNREAD");
-          dispatch(updatedNotificationUpdateInProgress(false));
+          updateNotificationStatus(row, "UNREAD");
         }}
         disabled={inProgressUpdate}
       >

--- a/components/notifications/TableColumnHeader.tsx
+++ b/components/notifications/TableColumnHeader.tsx
@@ -1,0 +1,50 @@
+import { Column } from "@tanstack/react-table";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faSort,
+  faSortDown,
+  faSortUp
+} from "@fortawesome/free-solid-svg-icons";
+
+type TableColumnHeaderProps<TData, TValue> = {
+  column: Column<TData, TValue>;
+  title: string;
+};
+
+export function TableColumnHeader<TData, TValue>({
+  column,
+  title
+}: Readonly<TableColumnHeaderProps<TData, TValue>>) {
+  const renderSortIcon = () => {
+    const sort = column.getIsSorted();
+    if (!sort) return <FontAwesomeIcon icon={faSort} size="sm" />;
+    return sort === "asc" ? (
+      <FontAwesomeIcon
+        icon={faSortUp}
+        size="sm"
+        data-cy={`${title}-fa-sort-up`}
+      />
+    ) : (
+      <FontAwesomeIcon
+        icon={faSortDown}
+        size="sm"
+        data-cy={`${title}-fa-sort-down`}
+      />
+    );
+  };
+  if (!column.getCanSort()) return <div>{title}</div>;
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={column.getToggleSortingHandler()}
+        className="table-header-btn"
+      >
+        <span>{title}</span>
+        <span className="nhsuk-u-padding-left-2 table-header-btn-icon">
+          {renderSortIcon()}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/components/notifications/TablePagination.tsx
+++ b/components/notifications/TablePagination.tsx
@@ -17,59 +17,63 @@ export function TablePagination({ table }: Readonly<TablePaginationType>) {
   return (
     <Container>
       <Row>
-        <Col width="two-thirds">
-          <button
-            type="button"
-            className="nhsuk-u-margin-right-2 pagination-btn"
-            onClick={() => table.firstPage()}
-            disabled={!table.getCanPreviousPage()}
-            data-cy="NotificationsTableFirstPageBtn"
-          >
-            <FontAwesomeIcon icon={faAngleDoubleLeft} />
-          </button>
-          <button
-            type="button"
-            className="nhsuk-u-margin-right-1 pagination-btn"
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-            data-cy="NotificationsTablePreviousPageBtn"
-          >
-            <FontAwesomeIcon icon={faAngleLeft} />
-          </button>
-          <button
-            type="button"
-            className="nhsuk-u-margin-right-2 pagination-btn"
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
-            data-cy="NotificationsTableNextPageBtn"
-          >
-            <FontAwesomeIcon icon={faAngleRight} />
-          </button>
-          <button
-            type="button"
-            className="nhsuk-u-margin-right-2 pagination-btn"
-            onClick={() => table.lastPage()}
-            disabled={!table.getCanNextPage()}
-            data-cy="NotificationsTableLastPageBtn"
-          >
-            <FontAwesomeIcon icon={faAngleDoubleRight} />
-          </button>
-          <select
-            className="nhsuk-select nhsuk-u-margin-left-1"
-            value={table.getState().pagination.pageSize}
-            onChange={e => {
-              table.setPageSize(Number(e.target.value));
-            }}
-            data-cy="NotificationsTablePageSizeSelect"
-          >
-            {[5, 10, 20, 30].map(pageSize => (
-              <option key={pageSize} value={pageSize}>
-                {`Show ${pageSize} rows`}
-              </option>
-            ))}
-          </select>
+        <Col width="two-thirds" className="nhsuk-mobile-pagination-col">
+          <Row className="nhsuk-mobile-pagination-row">
+            <button
+              type="button"
+              className="nhsuk-u-margin-right-2 pagination-btn"
+              onClick={() => table.firstPage()}
+              disabled={!table.getCanPreviousPage()}
+              data-cy="NotificationsTableFirstPageBtn"
+            >
+              <FontAwesomeIcon icon={faAngleDoubleLeft} />
+            </button>
+            <button
+              type="button"
+              className="nhsuk-u-margin-right-1 pagination-btn"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+              data-cy="NotificationsTablePreviousPageBtn"
+            >
+              <FontAwesomeIcon icon={faAngleLeft} />
+            </button>
+            <button
+              type="button"
+              className="nhsuk-u-margin-right-2 pagination-btn"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+              data-cy="NotificationsTableNextPageBtn"
+            >
+              <FontAwesomeIcon icon={faAngleRight} />
+            </button>
+            <button
+              type="button"
+              className="nhsuk-u-margin-right-2 pagination-btn"
+              onClick={() => table.lastPage()}
+              disabled={!table.getCanNextPage()}
+              data-cy="NotificationsTableLastPageBtn"
+            >
+              <FontAwesomeIcon icon={faAngleDoubleRight} />
+            </button>
+          </Row>
+          <Row className="nhsuk-mobile-pagination-row">
+            <select
+              className="nhsuk-select nhsuk-u-margin-left-1"
+              value={table.getState().pagination.pageSize}
+              onChange={e => {
+                table.setPageSize(Number(e.target.value));
+              }}
+              data-cy="NotificationsTablePageSizeSelect"
+            >
+              {[5, 10, 20, 30].map(pageSize => (
+                <option key={pageSize} value={pageSize}>
+                  {`Show ${pageSize} rows`}
+                </option>
+              ))}
+            </select>
+          </Row>
         </Col>
-        <Col width="one-third">
+        <Col width="one-third" className="nhsuk-mobile-pagination-col">
           {table.getPageCount() >= 2 && (
             <span className="nhsuk-u-font-size-19">
               {`Go to page: `}

--- a/components/notifications/TablePagination.tsx
+++ b/components/notifications/TablePagination.tsx
@@ -1,0 +1,104 @@
+import { Table } from "@tanstack/react-table";
+import { NotificationType } from "../../redux/slices/notificationsSlice";
+import { Col, Container, Row } from "nhsuk-react-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faAngleDoubleLeft,
+  faAngleDoubleRight,
+  faAngleLeft,
+  faAngleRight
+} from "@fortawesome/free-solid-svg-icons";
+
+type TablePaginationType = {
+  table: Table<NotificationType>;
+};
+
+export function TablePagination({ table }: Readonly<TablePaginationType>) {
+  return (
+    <Container>
+      <Row>
+        <Col width="two-thirds">
+          <button
+            type="button"
+            className="nhsuk-u-margin-right-2 pagination-btn"
+            onClick={() => table.firstPage()}
+            disabled={!table.getCanPreviousPage()}
+            data-cy="NotificationsTableFirstPageBtn"
+          >
+            <FontAwesomeIcon icon={faAngleDoubleLeft} />
+          </button>
+          <button
+            type="button"
+            className="nhsuk-u-margin-right-1 pagination-btn"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+            data-cy="NotificationsTablePreviousPageBtn"
+          >
+            <FontAwesomeIcon icon={faAngleLeft} />
+          </button>
+          <button
+            type="button"
+            className="nhsuk-u-margin-right-2 pagination-btn"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+            data-cy="NotificationsTableNextPageBtn"
+          >
+            <FontAwesomeIcon icon={faAngleRight} />
+          </button>
+          <button
+            type="button"
+            className="nhsuk-u-margin-right-2 pagination-btn"
+            onClick={() => table.lastPage()}
+            disabled={!table.getCanNextPage()}
+            data-cy="NotificationsTableLastPageBtn"
+          >
+            <FontAwesomeIcon icon={faAngleDoubleRight} />
+          </button>
+          <select
+            className="nhsuk-select nhsuk-u-margin-left-1"
+            value={table.getState().pagination.pageSize}
+            onChange={e => {
+              table.setPageSize(Number(e.target.value));
+            }}
+            data-cy="NotificationsTablePageSizeSelect"
+          >
+            {[5, 10, 20, 30].map(pageSize => (
+              <option key={pageSize} value={pageSize}>
+                {`Show ${pageSize} rows`}
+              </option>
+            ))}
+          </select>
+        </Col>
+        <Col width="one-third">
+          {table.getPageCount() >= 2 && (
+            <span className="nhsuk-u-font-size-19">
+              {`Go to page: `}
+              <input
+                type="number"
+                defaultValue={table.getState().pagination.pageIndex + 1}
+                onChange={e => {
+                  const target = e.target as HTMLInputElement;
+                  const page = target.value ? Number(target.value) - 1 : 0;
+                  table.setPageIndex(page);
+                }}
+                onInput={e => {
+                  const target = e.target as HTMLInputElement;
+                  const enteredPage = Number(target.value);
+                  if (enteredPage > table.getPageCount()) {
+                    target.value = table.getPageCount().toString();
+                  }
+                }}
+                onFocus={e => {
+                  e.target.value = "";
+                }}
+                className="nhsuk-input nhsuk-input--width-2"
+                data-cy="NotificationsTablePageInput"
+              />
+              {` of ${table.getPageCount()}`}
+            </span>
+          )}
+        </Col>
+      </Row>
+    </Container>
+  );
+}

--- a/components/notifications/__test__/NotificationsTable.test.tsx
+++ b/components/notifications/__test__/NotificationsTable.test.tsx
@@ -1,0 +1,41 @@
+import { render, fireEvent } from "@testing-library/react";
+import { NotificationsTable } from "../NotificationsTable";
+import { notificationsData } from "../../../mock-data/notifications";
+import store from "../../../redux/store/store";
+import { Router } from "react-router-dom";
+import { Provider } from "react-redux";
+import history from "../../../components/navigation/history";
+import { updateNotificationStatus } from "../../../utilities/NotificationsUtilities";
+import { useAppDispatch } from "../../../redux/hooks/hooks";
+import { loadedNotificationsList } from "../../../redux/slices/notificationsSlice";
+
+jest.mock("../../../utilities/NotificationsUtilities", () => ({
+  ...jest.requireActual("../../../utilities/NotificationsUtilities"),
+  updateNotificationStatus: jest.fn()
+}));
+
+test("NotificationsTable", () => {
+  const MockedNotificationsTable = () => {
+    const dispatch = useAppDispatch();
+    dispatch(loadedNotificationsList([notificationsData[1]]));
+    return <NotificationsTable />;
+  };
+
+  const renderMockedNotificationTable = () =>
+    render(
+      <Provider store={store}>
+        <Router history={history}>
+          <MockedNotificationsTable />
+        </Router>
+      </Provider>
+    );
+  const { getByTestId } = renderMockedNotificationTable();
+  const tableRow = getByTestId(
+    `notificationsTableRow-${notificationsData[1].id}`
+  );
+  fireEvent.click(tableRow);
+  expect(updateNotificationStatus).toHaveBeenCalledWith(
+    notificationsData[1],
+    "READ"
+  );
+});

--- a/components/notifications/__test__/RowActions.test.tsx
+++ b/components/notifications/__test__/RowActions.test.tsx
@@ -1,0 +1,27 @@
+import { render, fireEvent } from "@testing-library/react";
+import { RowActions } from "../RowActions";
+import { notificationsData } from "../../../mock-data/notifications";
+import store from "../../../redux/store/store";
+import { Router } from "react-router-dom";
+import { Provider } from "react-redux";
+import history from "../../../components/navigation/history";
+import { updateNotificationStatus } from "../../../utilities/NotificationsUtilities";
+
+jest.mock("../../../utilities/NotificationsUtilities", () => ({
+  ...jest.requireActual("../../../utilities/NotificationsUtilities"),
+  updateNotificationStatus: jest.fn()
+}));
+
+test("RowActions", () => {
+  const row = notificationsData[1];
+  const { getByRole } = render(
+    <Provider store={store}>
+      <Router history={history}>
+        <RowActions row={row} />
+      </Router>
+    </Provider>
+  );
+  const button = getByRole("button", { name: /Mark as unread/i });
+  fireEvent.click(button);
+  expect(updateNotificationStatus).toHaveBeenCalledWith(row, "UNREAD");
+});

--- a/components/notifications/columns.tsx
+++ b/components/notifications/columns.tsx
@@ -27,8 +27,8 @@ export const columns = [
       );
     }
   }),
-  columnHelper.accessor("subject", {
-    id: "subject",
+  columnHelper.accessor("subjectText", {
+    id: "subjectText",
     header: ({ column }) => <TableColumnHeader column={column} title="Title" />,
     cell: props => (
       <span>
@@ -38,8 +38,8 @@ export const columns = [
     enableColumnFilter: false
   }),
 
-  columnHelper.accessor("type", {
-    id: "type",
+  columnHelper.accessor("subject", {
+    id: "subject",
     header: ({ column }) => <TableColumnHeader column={column} title="Type" />,
     cell: props => <span>{props.renderValue()}</span>,
     enableColumnFilter: false

--- a/components/notifications/columns.tsx
+++ b/components/notifications/columns.tsx
@@ -1,0 +1,60 @@
+import { createColumnHelper } from "@tanstack/react-table";
+import { NotificationType } from "../../redux/slices/notificationsSlice";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEnvelope, faEnvelopeOpen } from "@fortawesome/free-solid-svg-icons";
+import { TableColumnHeader } from "./TableColumnHeader";
+import { StringUtilities } from "../../utilities/StringUtilities";
+import { DateUtilities } from "../../utilities/DateUtilities";
+import { RowActions } from "./RowActions";
+
+const columnHelper = createColumnHelper<NotificationType>();
+
+export const columns = [
+  columnHelper.accessor("status", {
+    id: "status",
+    header: "",
+    cell: props => {
+      const statusClass =
+        props.row.original.status === "READ" ? "status-read" : "status-unread";
+      return (
+        <span className={`${statusClass} nhsuk-margin-left-1`}>
+          {props.row.original.status === "READ" ? (
+            <FontAwesomeIcon icon={faEnvelopeOpen} size="lg" />
+          ) : (
+            <FontAwesomeIcon icon={faEnvelope} size="lg" />
+          )}
+        </span>
+      );
+    }
+  }),
+  columnHelper.accessor("subject", {
+    id: "subject",
+    header: ({ column }) => <TableColumnHeader column={column} title="Title" />,
+    cell: props => (
+      <span>
+        {StringUtilities.truncateString(props.renderValue() as string, 40)}
+      </span>
+    ),
+    enableColumnFilter: false
+  }),
+
+  columnHelper.accessor("type", {
+    id: "type",
+    header: ({ column }) => <TableColumnHeader column={column} title="Type" />,
+    cell: props => <span>{props.renderValue()}</span>,
+    enableColumnFilter: false
+  }),
+
+  columnHelper.accessor("sentAt", {
+    id: "sentAt",
+    header: ({ column }) => <TableColumnHeader column={column} title="Date" />,
+    cell: info => DateUtilities.ToLocalDate(info.renderValue()),
+    sortingFn: "datetime",
+    sortDescFirst: false,
+    enableColumnFilter: false
+  }),
+  columnHelper.display({
+    id: "moreActions",
+    cell: props => <RowActions row={props.row.original} />
+  })
+];

--- a/cypress/component/notifications/NotificationMessage.cy.tsx
+++ b/cypress/component/notifications/NotificationMessage.cy.tsx
@@ -1,0 +1,34 @@
+import { mount } from "cypress/react18";
+import { Router } from "react-router-dom";
+import { Provider } from "react-redux";
+import history from "../../../components/navigation/history";
+import { NotificationMessage } from "../../../components/notifications/NotificationMessage";
+import store from "../../../redux/store/store";
+
+describe("NotificationMessage", () => {
+  beforeEach(() => {
+    cy.viewport("macbook-15");
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <NotificationMessage />
+        </Router>
+      </Provider>
+    );
+  });
+
+  it("should display the error page when no matched active notification to display", () => {
+    cy.get('[data-cy="backLink"]')
+      .should("exist")
+      .should("include.text", "Back to list");
+    cy.url().should("include", "/notifications");
+    cy.get('[data-cy="error-header-text"]')
+      .should("exist")
+      .contains("Oops! Something went wrong");
+    cy.get('[data-cy="error-message-text"]')
+      .should("exist")
+      .contains(
+        "Couldn't load this message. Please check your internet connection and try again."
+      );
+  });
+});

--- a/cypress/component/notifications/NotificationMessageText.cy.tsx
+++ b/cypress/component/notifications/NotificationMessageText.cy.tsx
@@ -1,0 +1,42 @@
+import { mount } from "cypress/react18";
+import { NotificationMessageText } from "../../../components/notifications/NotificationMessageText";
+
+describe("NotificationMessageText", () => {
+  it("displays loading state", () => {
+    mount(
+      <NotificationMessageText
+        notificationMessageStatus="loading"
+        notificationMessageText=""
+      />
+    );
+    cy.contains("p", "Loading...");
+  });
+
+  it("displays error state", () => {
+    mount(
+      <NotificationMessageText
+        notificationMessageStatus="failed"
+        notificationMessageText=""
+      />
+    );
+    cy.get('[data-cy="error-header-text"]')
+      .should("exist")
+      .contains("Oops! Something went wrong");
+    cy.get('[data-cy="error-message-text"]')
+      .should("exist")
+      .contains(
+        "Couldn't load this message. Please check your internet connection and try again."
+      );
+  });
+
+  it("displays notification message", () => {
+    const message = "This is a test notification message";
+    mount(
+      <NotificationMessageText
+        notificationMessageStatus="success"
+        notificationMessageText={message}
+      />
+    );
+    cy.contains("p", message);
+  });
+});

--- a/cypress/component/notifications/Notifications.cy.tsx
+++ b/cypress/component/notifications/Notifications.cy.tsx
@@ -1,0 +1,49 @@
+import { mount } from "cypress/react18";
+import { Router } from "react-router-dom";
+import history from "../../../components/navigation/history";
+import { Authenticator } from "@aws-amplify/ui-react";
+import { NotificationsBtn } from "../../../components/notifications/NotificationsBtn";
+
+const comp = (unreadNotificationCount: number) => (
+  <Authenticator.Provider>
+    <Router history={history}>
+      <NotificationsBtn unreadNotificationCount={unreadNotificationCount} />
+    </Router>
+  </Authenticator.Provider>
+);
+
+describe("Notification Icon and Badge display", () => {
+  beforeEach(() => {
+    cy.viewport(1024, 768);
+  });
+
+  it("should contain notification Icon & badge not exist", () => {
+    mount(comp(0));
+    cy.get(".notification-btn").should("be.visible");
+    cy.get(".notification-badge").should("not.exist");
+  });
+
+  it("should contain notification Icon and badge displaying value of 12", () => {
+    mount(comp(12));
+    cy.get(".notification-btn").should("be.visible");
+    cy.get(".notification-badge").should("exist").should("contain", "12");
+  });
+});
+
+describe("Notification display in mobile view", () => {
+  beforeEach(() => {
+    cy.viewport(900, 768);
+  });
+
+  it("should contain notification Icon & badge not exist", () => {
+    mount(comp(0));
+    cy.get(".notification-btn").should("be.visible");
+    cy.get(".notification-badge").should("not.exist");
+  });
+
+  it("should contain notification Icon and badge displaying value of 12", () => {
+    mount(comp(12));
+    cy.get(".notification-btn").should("be.visible");
+    cy.get(".notification-badge").should("exist").should("contain", "12");
+  });
+});

--- a/cypress/component/notifications/Notifications.cy.tsx
+++ b/cypress/component/notifications/Notifications.cy.tsx
@@ -17,13 +17,13 @@ describe("Notification Icon and Badge display", () => {
     cy.viewport(1024, 768);
   });
 
-  it("should contain notification Icon & badge not exist", () => {
+  it("should contain notification Icon & badge not exist when zero unread notifications", () => {
     mount(comp(0));
     cy.get(".notification-btn").should("be.visible");
     cy.get(".notification-badge").should("not.exist");
   });
 
-  it("should contain notification Icon and badge displaying value of 12", () => {
+  it("should contain notification Icon and badge when unread notifications", () => {
     mount(comp(12));
     cy.get(".notification-btn").should("be.visible");
     cy.get(".notification-badge").should("exist").should("contain", "12");
@@ -35,13 +35,13 @@ describe("Notification display in mobile view", () => {
     cy.viewport(900, 768);
   });
 
-  it("should contain notification Icon & badge not exist", () => {
+  it("should contain notification Icon & badge not exist when zero unread notifications", () => {
     mount(comp(0));
     cy.get(".notification-btn").should("be.visible");
     cy.get(".notification-badge").should("not.exist");
   });
 
-  it("should contain notification Icon and badge displaying value of 12", () => {
+  it("should contain notification Icon and badge when unread notifications", () => {
     mount(comp(12));
     cy.get(".notification-btn").should("be.visible");
     cy.get(".notification-badge").should("exist").should("contain", "12");

--- a/cypress/component/notifications/NotificationsTable.cy.tsx
+++ b/cypress/component/notifications/NotificationsTable.cy.tsx
@@ -1,0 +1,112 @@
+import { mount } from "cypress/react18";
+import { Router } from "react-router-dom";
+import { Provider } from "react-redux";
+import history from "../../../components/navigation/history";
+import { NotificationsTable } from "../../../components/notifications/NotificationsTable";
+import { useAppDispatch } from "../../../redux/hooks/hooks";
+import { loadedNotificationsList } from "../../../redux/slices/notificationsSlice";
+import { notificationsData } from "../../../mock-data/notifications";
+import store from "../../../redux/store/store";
+
+describe("NotificationsTable with no notifications data", () => {
+  it("should render the 'no notifications' message if no notifications", () => {
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <NotificationsTable />
+        </Router>
+      </Provider>
+    );
+    cy.get(`[data-cy=notificationsTable]`).should("not.exist");
+    cy.get('[data-cy="notificationsTableNoNotifs"]')
+      .should("exist")
+      .contains("You currently don't have any notifications to read.");
+  });
+});
+
+describe("NotificationsTable with notifications data", () => {
+  beforeEach(() => {
+    cy.viewport("macbook-15");
+    const MockedNotificationsTable = () => {
+      const dispatch = useAppDispatch();
+      dispatch(loadedNotificationsList(notificationsData));
+      return <NotificationsTable />;
+    };
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <MockedNotificationsTable />
+        </Router>
+      </Provider>
+    );
+  });
+
+  it("should render the table and find notifications with the global search text", () => {
+    cy.get(`[data-cy=notificationsTable]`).should("exist");
+    cy.get('[data-cy="NotificationsSearchInput"]').should("exist").type("some");
+    cy.get("tr.table-row.row-unread").should("have.length", 2);
+    cy.get('[data-cy="notificationsTableRow-6"]').should("exist");
+    cy.get('[data-cy="notificationsTableRow-9"]').should("exist");
+  });
+
+  it("should show only the unread notifications when the unread checkbox is checked", () => {
+    cy.get("#unreadCheck").should("exist").check();
+    cy.get("tr.table-row.row-unread").should("have.length", 5);
+    cy.get("tr.table-row.row-read").should("have.length", 0);
+    cy.get('[data-cy="NotificationsTablePageSizeSelect"]')
+      .should("exist")
+      .select("10");
+    cy.get("tr.table-row.row-unread").should("have.length", 6);
+    // page input doesn't exist when all rows are shown
+    cy.get('[data-cy="NotificationsTablePageInput"]').should("not.exist");
+  });
+
+  it("should go to the correct page when the page input is changed", () => {
+    cy.get('[data-cy="NotificationsTablePageInput"]').should("exist").type("2");
+    cy.get('[data-cy="notificationsTableRow-6"] > :nth-child(4)')
+      .should("exist")
+      .contains("01/03/2024");
+    // Enter number > page count
+    cy.get('[data-cy="NotificationsTablePageInput"]').type("3");
+    cy.get('[data-cy="NotificationsTablePageInput"]').should("have.value", "2");
+  });
+
+  it("should navigate to the correct page via the navigation buttons", () => {
+    cy.get('[data-cy="NotificationsTableLastPageBtn"]').should("exist").click();
+    cy.get("tr.table-row").should("have.length", 5);
+
+    cy.get('[data-cy="notificationsTableRow-6"] > :nth-child(4)').contains(
+      "01/03/2024"
+    );
+    cy.get('[data-cy="NotificationsTableNextPageBtn"]').should("be.disabled");
+    cy.get('[data-cy="NotificationsTableLastPageBtn"]').should("be.disabled");
+    cy.get('[data-cy="NotificationsTableFirstPageBtn"]').should(
+      "not.be.disabled"
+    );
+    cy.get('[data-cy="NotificationsTablePreviousPageBtn"]')
+      .should("not.be.disabled")
+      .click();
+    cy.get('[data-cy="NotificationsTableNextPageBtn"]').should(
+      "not.be.disabled"
+    );
+    cy.get('[data-cy="NotificationsTableLastPageBtn"]').should(
+      "not.be.disabled"
+    );
+    cy.get("tr.table-row").should("have.length", 5);
+  });
+
+  it("should sort the table columns when the header is clicked", () => {
+    // date defaults to sort desc
+    cy.get('[data-cy="Date-fa-sort-down"]').should("be.visible");
+    cy.get('[data-cy="Date-fa-sort-up"]').should("not.exist");
+    cy.get('[data-cy="notificationsTable-subject"] > div > .table-header-btn')
+      .should("exist")
+      .click();
+    cy.get('[data-cy="notificationsTableRow-0"] > :nth-child(4)').contains(
+      "01/03/2024"
+    );
+    cy.get("tr.table-row.row-unread").should("have.length", 3);
+    cy.get('[data-cy="Type-fa-sort-up"]').should("exist");
+    cy.get('[data-cy="Type-fa-sort-down"]').should("not.exist");
+  });
+});

--- a/cypress/e2e/notifications/Notifications.spec.ts
+++ b/cypress/e2e/notifications/Notifications.spec.ts
@@ -1,0 +1,14 @@
+/// <reference types="cypress" />
+/// <reference path="../../support/index.d.ts" />
+
+describe("Notifications", () => {
+  beforeEach(() => {
+    cy.signInToTss(30000, "/notifications");
+  });
+
+  it("should load the notifications page", () => {
+    cy.get('[data-cy="notificationsHeading"]')
+      .should("exist")
+      .should("contain.text", "Notifications");
+  });
+});

--- a/mock-data/notifications.ts
+++ b/mock-data/notifications.ts
@@ -1,0 +1,124 @@
+import { NotificationType } from "../redux/slices/notificationsSlice";
+
+export const notificationsData: NotificationType[] = [
+  {
+    id: "65f1d6bd3f7898e099514187",
+    tisReference: null,
+    type: "IN_APP",
+    subject: "WELCOME",
+    subjectText: "Welcome to TIS Self-Service",
+    contact: null,
+    sentAt: new Date("2024-03-01T15:21:02.939Z"),
+    readAt: new Date("2024-03-19T13:41:14.750Z"),
+    status: "UNREAD",
+    statusDetail: null
+  },
+  {
+    id: "65f1d6bd3f7898e099514188",
+    tisReference: null,
+    type: "IN_APP",
+    subject: "WELCOME",
+    subjectText: "Welcome to TIS Self-Service",
+    contact: null,
+    sentAt: new Date("2024-03-01T15:21:02.939Z"),
+    readAt: new Date("2024-03-19T13:41:14.750Z"),
+    status: "READ",
+    statusDetail: null
+  },
+  {
+    id: "65f1d6bd3f7898e099514189",
+    tisReference: null,
+    type: "IN_APP",
+    subject: "WELCOME",
+    subjectText: "Welcome to TIS Self-Service",
+    contact: null,
+    sentAt: new Date("2024-03-01T15:21:02.939Z"),
+    readAt: new Date("2024-03-19T13:41:14.750Z"),
+    status: "UNREAD",
+    statusDetail: null
+  },
+  {
+    id: "65f1d6bd3f7898e099514190",
+    tisReference: null,
+    type: "IN_APP",
+    subject: "WELCOME",
+    subjectText: "Welcome to TIS Self-Service",
+    contact: null,
+    sentAt: new Date("2024-03-01T15:21:02.939Z"),
+    readAt: new Date("2024-03-19T13:41:14.750Z"),
+    status: "READ",
+    statusDetail: null
+  },
+  {
+    id: "65f1d6bd3f7898e099514191",
+    tisReference: null,
+    type: "IN_APP",
+    subject: "WELCOME",
+    subjectText: "Welcome to TIS Self-Service",
+    contact: null,
+    sentAt: new Date("2024-03-01T15:21:02.939Z"),
+    readAt: new Date("2024-03-19T13:41:14.750Z"),
+    status: "UNREAD",
+    statusDetail: null
+  },
+  {
+    id: "65f1d6bd3f7898e099514192",
+    tisReference: null,
+    type: "IN_APP",
+    subject: "WELCOME",
+    subjectText: "Welcome to TIS Self-Service",
+    contact: null,
+    sentAt: new Date("2024-03-01T15:21:02.939Z"),
+    readAt: new Date("2024-03-19T13:41:14.750Z"),
+    status: "READ",
+    statusDetail: null
+  },
+  {
+    id: "65f1d6bd3f7898e099514193",
+    tisReference: null,
+    type: "IN_APP",
+    subject: "WELCOME",
+    subjectText: "SOME TIMES ONLY TIS Self-Service will do",
+    contact: null,
+    sentAt: new Date("2024-03-01T15:21:02.939Z"),
+    readAt: new Date("2024-03-19T13:41:14.750Z"),
+    status: "UNREAD",
+    statusDetail: null
+  },
+  {
+    id: "65f1d6bd3f7898e099514194",
+    tisReference: null,
+    type: "IN_APP",
+    subject: "WELCOME",
+    subjectText: "Welcome to TIS Self-Service",
+    contact: null,
+    sentAt: new Date("2024-03-01T15:21:02.939Z"),
+    readAt: new Date("2024-03-19T13:41:14.750Z"),
+    status: "READ",
+    statusDetail: null
+  },
+  {
+    id: "65f1d6bd3f7898e099514195",
+    tisReference: null,
+    type: "IN_APP",
+    subject: "WELCOME",
+    subjectText: "Welcome to TIS Self-Service",
+    contact: null,
+    sentAt: new Date("2024-03-01T15:21:02.939Z"),
+    readAt: new Date("2024-03-19T13:41:14.750Z"),
+    status: "UNREAD",
+    statusDetail: null
+  },
+  {
+    id: "65f1d6bd3f7898e099514196",
+    tisReference: null,
+    type: "IN_APP",
+    subject: "WELCOME",
+    subjectText: "Something else to test the filter",
+    contact: null,
+    sentAt: new Date("2024-03-02T15:21:02.939Z"),
+    readAt: new Date("2024-03-18T13:41:14.750Z"),
+    status: "UNREAD",
+    statusDetail: null
+  }
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.93.1",
+  "version": "0.94.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.93.1",
+      "version": "0.94.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",
@@ -17,6 +17,7 @@
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@reduxjs/toolkit": "^1.9.5",
         "@sentry/browser": "^7.69.0",
+        "@tanstack/react-table": "^8.13.2",
         "@testing-library/dom": "^9.0.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
@@ -79,6 +80,7 @@
         "react-select-event": "^5.5.1",
         "react-test-renderer": "^18.2.0",
         "react-toastify": "^9.1.3",
+        "react-tooltip": "^5.26.3",
         "redux": "^4.2.1",
         "redux-thunk": "^2.4.2",
         "sass": "^1.57.1",
@@ -8205,6 +8207,11 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz",
@@ -10760,6 +10767,37 @@
       "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.14.0.tgz",
+      "integrity": "sha512-l9iwO99oz/azy5RT5VkVRsHHuy7o//fiXgLxzl3fad8qf7Bj+9ihsfmE6Q+BNjH4wHbxZkahwxtb3ngGq9FQxA==",
+      "dependencies": {
+        "@tanstack/table-core": "8.14.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.14.0.tgz",
+      "integrity": "sha512-wDhpKJahGHWhmRt4RxtV3pES63CoeadljGWS/xeS9OJr1HBl2NB+OO44ht3sxDH5j5TRDAbQzC0NvSlsUfn7lQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -21805,6 +21843,36 @@
         "react-dom": ">=16"
       }
     },
+    "node_modules/react-tooltip": {
+      "version": "5.26.3",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.26.3.tgz",
+      "integrity": "sha512-MpYAws8CEHUd/RC4GaDCdoceph/T4KHM5vS5Dbk8FOmLMvvIht2ymP2htWdrke7K6lqPO8rz8+bnwWUIXeDlzg==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
+    },
+    "node_modules/react-tooltip/node_modules/@floating-ui/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/react-tooltip/node_modules/@floating-ui/dom": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -31359,6 +31427,11 @@
         "use-isomorphic-layout-effect": "^1.1.1"
       }
     },
+    "@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
     "@fortawesome/fontawesome-common-types": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz",
@@ -33239,6 +33312,19 @@
       "requires": {
         "tslib": "^2.4.0"
       }
+    },
+    "@tanstack/react-table": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.14.0.tgz",
+      "integrity": "sha512-l9iwO99oz/azy5RT5VkVRsHHuy7o//fiXgLxzl3fad8qf7Bj+9ihsfmE6Q+BNjH4wHbxZkahwxtb3ngGq9FQxA==",
+      "requires": {
+        "@tanstack/table-core": "8.14.0"
+      }
+    },
+    "@tanstack/table-core": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.14.0.tgz",
+      "integrity": "sha512-wDhpKJahGHWhmRt4RxtV3pES63CoeadljGWS/xeS9OJr1HBl2NB+OO44ht3sxDH5j5TRDAbQzC0NvSlsUfn7lQ=="
     },
     "@testing-library/dom": {
       "version": "9.0.1",
@@ -41572,6 +41658,34 @@
       "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
       "requires": {
         "clsx": "^1.1.1"
+      }
+    },
+    "react-tooltip": {
+      "version": "5.26.3",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.26.3.tgz",
+      "integrity": "sha512-MpYAws8CEHUd/RC4GaDCdoceph/T4KHM5vS5Dbk8FOmLMvvIht2ymP2htWdrke7K6lqPO8rz8+bnwWUIXeDlzg==",
+      "requires": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "dependencies": {
+        "@floating-ui/core": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+          "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+          "requires": {
+            "@floating-ui/utils": "^0.2.1"
+          }
+        },
+        "@floating-ui/dom": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+          "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+          "requires": {
+            "@floating-ui/core": "^1.0.0",
+            "@floating-ui/utils": "^0.2.0"
+          }
+        }
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.93.1",
+  "version": "0.94.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",
@@ -12,6 +12,7 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@reduxjs/toolkit": "^1.9.5",
     "@sentry/browser": "^7.69.0",
+    "@tanstack/react-table": "^8.13.2",
     "@testing-library/dom": "^9.0.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
@@ -74,6 +75,7 @@
     "react-select-event": "^5.5.1",
     "react-test-renderer": "^18.2.0",
     "react-toastify": "^9.1.3",
+    "react-tooltip": "^5.26.3",
     "redux": "^4.2.1",
     "redux-thunk": "^2.4.2",
     "sass": "^1.57.1",

--- a/redux/slices/index.ts
+++ b/redux/slices/index.ts
@@ -9,6 +9,7 @@ import featureFlagsReducer from "./featureFlagsSlice";
 import userReducer from "./userSlice";
 import dspReducer from "./dspSlice";
 import tssUpdatesReducer from "./tssUpdatesSlice";
+import notificationsReducer from "./notificationsSlice";
 
 const rootReducer = combineReducers({
   traineeProfile: traineeProfileReducer,
@@ -20,7 +21,8 @@ const rootReducer = combineReducers({
   featureFlags: featureFlagsReducer,
   user: userReducer,
   dsp: dspReducer,
-  tssUpdates: tssUpdatesReducer
+  tssUpdates: tssUpdatesReducer,
+  notifications: notificationsReducer
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/redux/slices/notificationsSlice.ts
+++ b/redux/slices/notificationsSlice.ts
@@ -1,0 +1,224 @@
+import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
+import { toastErrText } from "../../utilities/Constants";
+import { ToastType, showToast } from "../../components/common/ToastMessage";
+import { TraineeNotificationsService } from "../../services/TraineeNotificationsService";
+
+export type NotificationStatus =
+  | "READ"
+  | "UNREAD"
+  | "FAILED"
+  | "SENT"
+  | "ARCHIVED";
+
+export type NotificationMsgType = "IN_APP";
+
+export type NotificationType = {
+  id: string;
+  tisReference: string | null;
+  type: NotificationMsgType;
+  subject: string;
+  subjectText: string;
+  contact: string | null;
+  status: NotificationStatus;
+  sentAt: Date;
+  statusDetail: string | null;
+  readAt?: Date;
+};
+
+export type NotificationsState = {
+  notificationsList: NotificationType[];
+  status: string;
+  notificationUpdateStatus: string;
+  notificationMsg: string;
+  msgStatus: string;
+  error: any;
+  activeNotification: NotificationType | null;
+  unreadNotificationCount: number;
+  notificationUpdateInProgress: boolean; // to prevent multiple row/button clicks
+};
+
+export const initialState: NotificationsState = {
+  notificationsList: [],
+  status: "idle",
+  notificationUpdateStatus: "idle",
+  notificationMsg: "",
+  msgStatus: "idle",
+  error: "",
+  activeNotification: null,
+  unreadNotificationCount: 0,
+  notificationUpdateInProgress: false
+};
+
+export const getNotifications = createAsyncThunk(
+  "notifications/getNotifications",
+  async () => {
+    const notificationService = new TraineeNotificationsService();
+    const response = await notificationService.getAllNotifications();
+    return response.data;
+  }
+);
+
+export const markNotificationAsRead = createAsyncThunk(
+  "notifications/markNotificationAsRead",
+  async (notificationId: string) => {
+    const notificationService = new TraineeNotificationsService();
+    return (await notificationService.markNotificationAsRead(notificationId))
+      .data;
+  }
+);
+
+export const markNotificationAsUnread = createAsyncThunk(
+  "notifications/markNotificationAsUnread",
+  async (notificationId: string) => {
+    const notificationService = new TraineeNotificationsService();
+    return await notificationService.markNotificationAsUnread(notificationId);
+  }
+);
+
+export const archiveNotification = createAsyncThunk(
+  "notifications/archiveNotification",
+  async (notificationId: string) => {
+    const notificationService = new TraineeNotificationsService();
+    return await notificationService.archiveNotification(notificationId);
+  }
+);
+
+export const getNotificationMessage = createAsyncThunk(
+  "notifications/getNotificationMessage",
+  async (notificationId: string) => {
+    const notificationService = new TraineeNotificationsService();
+    return (await notificationService.getNotificationMessage(notificationId))
+      .data;
+  }
+);
+
+const notificationsSlice = createSlice({
+  name: "notifications",
+  initialState,
+  reducers: {
+    updatedActiveNotification(state, action: PayloadAction<NotificationType>) {
+      return { ...state, activeNotification: action.payload };
+    },
+    updatedNotificationsList(state, action: PayloadAction<NotificationType>) {
+      const updatedNotification = action.payload;
+      const updatedNotificationsList = state.notificationsList.map(
+        notification =>
+          notification.id === updatedNotification.id
+            ? updatedNotification
+            : notification
+      );
+      return { ...state, notificationsList: updatedNotificationsList };
+    },
+    resetNotificationsStatus(state) {
+      return { ...state, status: "idle" };
+    },
+    loadedNotificationsList(state, action: PayloadAction<NotificationType[]>) {
+      return { ...state, notificationsList: action.payload };
+    },
+    updatedNotificationUpdateInProgress(state, action: PayloadAction<boolean>) {
+      return { ...state, notificationUpdateInProgress: action.payload };
+    }
+  },
+  extraReducers(builder): void {
+    builder
+      .addCase(getNotifications.pending, (state, _action) => {
+        state.status = "loading";
+      })
+      .addCase(getNotifications.fulfilled, (state, action) => {
+        state.status = "succeeded";
+        state.notificationsList = action.payload;
+        state.unreadNotificationCount = unreadNotificationsCount(
+          action.payload ?? 0
+        );
+      })
+      .addCase(getNotifications.rejected, (state, { error }) => {
+        state.status = "failed";
+        state.error = error.message;
+        showToast(
+          toastErrText.fetchAllNotifications,
+          ToastType.ERROR,
+          `${error.code}-${error.message}`
+        );
+      })
+      .addCase(markNotificationAsRead.pending, (state, _action) => {
+        state.notificationUpdateStatus = "loading";
+      })
+      .addCase(markNotificationAsRead.fulfilled, (state, action) => {
+        state.notificationUpdateStatus = "succeeded";
+        state.activeNotification = action.payload;
+      })
+      .addCase(markNotificationAsRead.rejected, (state, { error }) => {
+        state.notificationUpdateStatus = "failed";
+        state.error = error.message;
+        showToast(
+          toastErrText.markNotificationAsRead,
+          ToastType.ERROR,
+          `${error.code}-${error.message}`
+        );
+      })
+      .addCase(markNotificationAsUnread.pending, (state, _action) => {
+        state.notificationUpdateStatus = "loading";
+      })
+      .addCase(markNotificationAsUnread.fulfilled, (state, _action) => {
+        state.notificationUpdateStatus = "succeeded";
+      })
+      .addCase(markNotificationAsUnread.rejected, (state, { error }) => {
+        state.notificationUpdateStatus = "failed";
+        state.error = error.message;
+        showToast(
+          toastErrText.markNotificationAsUnread,
+          ToastType.ERROR,
+          `${error.code}-${error.message}`
+        );
+      })
+      .addCase(archiveNotification.pending, (state, _action) => {
+        state.notificationUpdateStatus = "loading";
+      })
+      .addCase(archiveNotification.fulfilled, (state, _action) => {
+        state.notificationUpdateStatus = "succeeded";
+      })
+      .addCase(archiveNotification.rejected, (state, { error }) => {
+        state.notificationUpdateStatus = "failed";
+        state.error = error.message;
+        showToast(
+          toastErrText.archiveNotification,
+          ToastType.ERROR,
+          `${error.code}-${error.message}`
+        );
+      })
+      .addCase(getNotificationMessage.pending, (state, _action) => {
+        state.msgStatus = "loading";
+      })
+      .addCase(getNotificationMessage.fulfilled, (state, action) => {
+        state.msgStatus = "succeeded";
+        state.notificationMsg = action.payload;
+      })
+      .addCase(getNotificationMessage.rejected, (state, { error }) => {
+        state.msgStatus = "failed";
+        state.error = error.message;
+        showToast(
+          toastErrText.fetchNotificationMessage,
+          ToastType.ERROR,
+          `${error.code}-${error.message}`
+        );
+      });
+  }
+});
+
+export default notificationsSlice.reducer;
+
+export const {
+  updatedActiveNotification,
+  updatedNotificationsList,
+  resetNotificationsStatus,
+  loadedNotificationsList,
+  updatedNotificationUpdateInProgress
+} = notificationsSlice.actions;
+
+export function unreadNotificationsCount(notificationsData: any[]) {
+  if (!Array.isArray(notificationsData)) return 0;
+  const unreadNotifications = notificationsData.filter(
+    notification => notification.status === "UNREAD"
+  );
+  return unreadNotifications.length;
+}

--- a/services/TraineeNotificationsService.ts
+++ b/services/TraineeNotificationsService.ts
@@ -1,0 +1,36 @@
+import { AxiosResponse } from "axios";
+import ApiService from "./apiService";
+
+export class TraineeNotificationsService extends ApiService {
+  constructor() {
+    super("/api");
+  }
+
+  async getAllNotifications(): Promise<AxiosResponse<any[]>> {
+    return this.get<any[]>(`/notifications`);
+  }
+
+  async markNotificationAsRead(
+    notificationId: string
+  ): Promise<AxiosResponse<any>> {
+    return this.put<any>(`/notifications/${notificationId}/mark-read`);
+  }
+
+  async markNotificationAsUnread(
+    notificationId: string
+  ): Promise<AxiosResponse<any>> {
+    return this.put<any>(`/notifications/${notificationId}/mark-unread`);
+  }
+
+  async archiveNotification(
+    notificationId: string
+  ): Promise<AxiosResponse<any>> {
+    return this.put<any>(`/notifications/${notificationId}/archive`);
+  }
+
+  async getNotificationMessage(
+    notificationId: string
+  ): Promise<AxiosResponse<any>> {
+    return this.get<any>(`/notifications/${notificationId}/message`);
+  }
+}

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -44,7 +44,7 @@ export class ApiService {
     return this.axiosInstance.post(endpoint, formData, params);
   }
 
-  put<T = any>(endpoint: string, formData: T): Promise<AxiosResponse<T>> {
+  put<T = any>(endpoint: string, formData?: T): Promise<AxiosResponse<T>> {
     return this.axiosInstance.put(endpoint, formData);
   }
   delete(endpoint: string): Promise<AxiosResponse> {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -638,7 +638,7 @@ ol[type="a"] {
 // ---- Notifications Icon ----
 
 .notification-btn {
-  margin: 0 0 0 1rem;
+  margin: 0.3rem 0 0 1rem;
   position: "relative";
   padding: 0 1rem;
   box-shadow: 0 1px 0 transparent;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -662,7 +662,7 @@ ol[type="a"] {
   min-height: 30%;
   min-width: 30%;
   border-radius: 16px;
-  padding: 1% 10%;
+  padding: 2% 10%;
   font-size: 10px;
   display: flex;
   align-items: center;
@@ -670,6 +670,18 @@ ol[type="a"] {
 }
 
 // mobile notifications
+
+@media (max-width: 989px) {
+  .notification-btn {
+    margin: 0.3rem 1rem 0 1rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .notification-badge {
+    padding: 1% 16%;
+  }
+}
 
 .mobile-header {
   display: flex;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -635,6 +635,54 @@ ol[type="a"] {
   padding-top: 0.5em;
 }
 
+// ---- Notifications Icon ----
+
+.notification-btn {
+  margin: 0 0 0 1rem;
+  position: "relative";
+  padding: 0 1rem;
+  box-shadow: 0 1px 0 transparent;
+  background-color: transparent;
+  &:hover,
+  &:focus {
+    background-color: darken(#005eb8, 7%) !important;
+  }
+}
+
+.notification-btn:hover .notification-badge {
+  background-color: darken(#ed8b00, 7%);
+}
+
+.notification-badge {
+  position: absolute;
+  bottom: 45%;
+  left: 50%;
+  background-color: #ed8b00;
+  color: white;
+  min-height: 30%;
+  min-width: 30%;
+  border-radius: 16px;
+  padding: 1% 10%;
+  font-size: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+// mobile notifications
+
+.mobile-header {
+  display: flex;
+  align-items: center;
+  justify-content: right;
+}
+
+@media (min-width: 989px) {
+  .mobile-header {
+    display: none;
+  }
+}
+
 // ---- Notifications table ----
 .table-wrapper {
   overflow-x: auto;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -700,6 +700,27 @@ ol[type="a"] {
   overflow-x: auto;
 }
 
+// ---- Notifications table pagination ----
+
+.nhsuk-mobile-pagination-col {
+  display: flex;
+  align-items: center;
+  justify-content: left;
+  flex-wrap: wrap;
+  @include nhsuk-responsive-padding(3);
+  @include nhsuk-responsive-padding(0, "bottom");
+}
+
+.nhsuk-mobile-pagination-row {
+  @include nhsuk-responsive-padding(6, "right");
+  @media (max-width: 440px) {
+    @include nhsuk-responsive-padding(2, "top");
+  }
+  @media (max-width: 345px) {
+    @include nhsuk-responsive-padding(3, "top");
+    @include nhsuk-responsive-padding(0, "left");
+  }
+}
 // Global search
 .table-search-input {
   margin: 1rem 0;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -634,3 +634,114 @@ ol[type="a"] {
 .error-spacing_div {
   padding-top: 0.5em;
 }
+
+// ---- Notifications table ----
+.table-wrapper {
+  overflow-x: auto;
+}
+
+// Global search
+.table-search-input {
+  margin: 1rem 0;
+}
+
+// Header
+.table-header-btn {
+  color: #425563;
+  padding: 0;
+  border: none;
+  &:hover {
+    cursor: pointer;
+    color: #005eb8;
+  }
+}
+
+.table-header-btn-icon {
+  color: #425563;
+  &:hover {
+    color: #005eb8;
+  }
+}
+
+// Row
+.table-row {
+  transition: background-color 0.3s ease;
+  cursor: pointer;
+  &:hover {
+    background-color: #cbe0d9;
+  }
+}
+.row-read {
+  font-weight: normal;
+  background-color: #d8dde0;
+}
+
+.row-unread {
+  font-weight: bold;
+  background-color: white;
+}
+
+.table-data {
+  border-top: solid 1px #bfc3c6;
+}
+
+.status-read {
+  color: #006400;
+}
+
+.status-unread {
+  color: #005eb8;
+}
+
+.back-link {
+  cursor: pointer;
+}
+
+.container {
+  color: #425563;
+  background-color: whitesmoke;
+  border: solid 2px white;
+  box-shadow: 0px 0px 4px 2px rgba(0, 0, 0, 0.1);
+}
+
+// pagination
+.pagination-btn {
+  background-color: #005eb8;
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  margin: 0 4px;
+  border-radius: 4px;
+  &:hover {
+    background-color: #002f5c;
+    transform: scale(1.1);
+  }
+}
+
+.unread-btn {
+  min-width: 190px;
+  max-width: 190px;
+  margin-right: 16px;
+  border: 1px solid white;
+  box-shadow: 0 1px 0 #4c6272;
+  border-radius: 4px;
+  background-color: #f0f4f5;
+  color: #425563;
+  transition: all 0.3s ease;
+  &:hover {
+    border: 1px solid darken(whitesmoke, 5%);
+    transform: scale(1.1);
+    cursor: pointer;
+    color: #212b32;
+    background-color: whitesmoke;
+  }
+  &:active {
+    background-color: #003f6d;
+    color: whitesmoke;
+  }
+}
+
+.unread-icon {
+  color: #425563;
+  margin-right: 0.5em;
+}

--- a/utilities/Constants.ts
+++ b/utilities/Constants.ts
@@ -174,6 +174,8 @@ export const PANEL_KEYS: any = {
   conditionsOfJoining: "Conditions of Joining"
 };
 
+const dodgyConnection = "Please check your internet connection and try again.";
+
 export const toastErrText = {
   deleteFormA: "Couldn't delete your draft Form R (Part A).",
   deleteFormB: "Couldn't delete your draft Form R (Part B).",
@@ -203,7 +205,12 @@ export const toastErrText = {
     "Couldn't verify your identification with that Authentication code.",
   signCoj: "Couldn't sign your Conditions of Joining.",
   fetchTraineeActionsData: "Couldn't load your task checklist (to-do actions).",
-  completeTraineeAction: "Couldn't update trainee actions."
+  completeTraineeAction: "Couldn't update trainee actions.",
+  fetchAllNotifications: "Couldn't load your notifications.",
+  markNotificationAsRead: `Couldn't open this message and mark as read. ${dodgyConnection}`,
+  markNotificationAsUnread: `Couldn't mark this message as unread. ${dodgyConnection}`,
+  archiveNotification: `Couldn't archive this message. ${dodgyConnection}`,
+  fetchNotificationMessage: `Couldn't load this message. ${dodgyConnection}`
 };
 
 export const toastSuccessText = {

--- a/utilities/NotificationsUtilities.ts
+++ b/utilities/NotificationsUtilities.ts
@@ -1,0 +1,42 @@
+import {
+  NotificationStatus,
+  NotificationType,
+  markNotificationAsRead,
+  markNotificationAsUnread,
+  resetNotificationsStatus,
+  updatedNotificationsList
+} from "../redux/slices/notificationsSlice";
+import store from "../redux/store/store";
+import history from "../components/navigation/history";
+
+export async function updateNotificationStatus(
+  row: NotificationType,
+  newStatus: NotificationStatus
+) {
+  // FE updates
+  const activeNotification: NotificationType = {
+    ...row,
+    status: newStatus
+  };
+  store.dispatch(updatedNotificationsList(activeNotification));
+
+  // BE updates
+  const action =
+    newStatus === "READ" ? markNotificationAsRead : markNotificationAsUnread;
+  await store.dispatch(action(row.id));
+
+  if (store.getState().notifications.notificationUpdateStatus === "succeeded") {
+    store.dispatch(resetNotificationsStatus());
+    if (newStatus === "READ") {
+      history.push(`/notifications/${row.id}`);
+    }
+  } else if (
+    store.getState().notifications.notificationUpdateStatus === "failed"
+  ) {
+    const reversedNotification: NotificationType = {
+      ...row,
+      status: newStatus === "READ" ? "UNREAD" : "READ"
+    };
+    store.dispatch(updatedNotificationsList(reversedNotification));
+  }
+}

--- a/utilities/NotificationsUtilities.ts
+++ b/utilities/NotificationsUtilities.ts
@@ -4,39 +4,59 @@ import {
   markNotificationAsRead,
   markNotificationAsUnread,
   resetNotificationsStatus,
+  updatedNotificationUpdateInProgress,
   updatedNotificationsList
 } from "../redux/slices/notificationsSlice";
 import store from "../redux/store/store";
 import history from "../components/navigation/history";
 
-export async function updateNotificationStatus(
+export function updateNotificationStatusFE(
   row: NotificationType,
   newStatus: NotificationStatus
 ) {
-  // FE updates
   const activeNotification: NotificationType = {
     ...row,
     status: newStatus
   };
   store.dispatch(updatedNotificationsList(activeNotification));
+}
 
-  // BE updates
+export async function updateNotificationStatusBE(
+  row: NotificationType,
+  newStatus: NotificationStatus
+) {
   const action =
     newStatus === "READ" ? markNotificationAsRead : markNotificationAsUnread;
   await store.dispatch(action(row.id));
 
+  // success, navigate to notification msg
   if (store.getState().notifications.notificationUpdateStatus === "succeeded") {
+    // trigger fetch to update notifications list/ icon badge
     store.dispatch(resetNotificationsStatus());
+    // navigate to notification msg if row click (i.e. new status is READ)
     if (newStatus === "READ") {
       history.push(`/notifications/${row.id}`);
     }
+    // failed to update, revert previous FE change
   } else if (
     store.getState().notifications.notificationUpdateStatus === "failed"
   ) {
-    const reversedNotification: NotificationType = {
-      ...row,
-      status: newStatus === "READ" ? "UNREAD" : "READ"
-    };
-    store.dispatch(updatedNotificationsList(reversedNotification));
+    const newStatus = row.status === "READ" ? "UNREAD" : "READ";
+    updateNotificationStatusFE(row, newStatus);
   }
+}
+
+export async function updateNotificationStatus(
+  row: NotificationType,
+  newStatus: NotificationStatus
+) {
+  const inProgressUpdate =
+    store.getState().notifications.notificationUpdateInProgress;
+  if (inProgressUpdate) return;
+  store.dispatch(updatedNotificationUpdateInProgress(true));
+  // update FE first to see immediate change
+  updateNotificationStatusFE(row, newStatus);
+  // then make BE call
+  await updateNotificationStatusBE(row, newStatus);
+  store.dispatch(updatedNotificationUpdateInProgress(false));
 }

--- a/utilities/StringUtilities.ts
+++ b/utilities/StringUtilities.ts
@@ -24,4 +24,8 @@ export class StringUtilities {
 
     return sortedValues.join(", ");
   }
+
+  public static truncateString(str: string, length: number) {
+    return str.length > length ? `${str.substring(0, length)}...` : str;
+  }
 }


### PR DESCRIPTION

Add Notifications list, message page, icon

@ReubenRobertsHEE AKA last-man-standing...

I've copied these notes I made on the second commit which might be useful to find your way around the chnages:

1. Notifications.tsx - routing entry point for notifications page
2. NotificationsTable.tsx - /notifications to list the notifications. This component houses some child components: DebouncedInput, AllUnreadCheckbox, TablePagination. It also has the click event logic to mark a row as read/navigate to open the message (line 105). The autoResetPageIndex prop is set to false so when a paginated row is clicked the table doesn't reset.
3. columns.tsx is where the table columns are defined. It houses the TableColumnHeader and RowActions components.
4. RowActions.tsx - deals with the 'mark as unread' btn click event logic.
5. NotificatiosUtilities.ts - This has a updateNotificationStatus function that is called from the NotificationsTable (row click) and RowActions (mark as unread btn click). Still a bit of a WIP. Current implementation is to update the notification status optimistically and then call the API to update the status. If the API call fails, the status is reverted back to the original status (you can see this best with slow internet!).
6. NotificationMessage.tsx - houses the NotificationMessageText component and dispatches the action to get the message from the backend on page load using the id in the url. There's a bit of error handling (using the ErrorPage component) if the message is not found etc.
7. TablePgination.tsx - page sizes are hardcoded for now. Mobile view needs fixing (Ed is looking at this - could be a follow-up commit?).
8. StringUtilities.ts - added a function to truncate subject text of your choosing. Wasn't sure on size but we can play around with it.

Tested as much as I can of the table interactions etc. but couldn't test the complete journey from e.g. marking a notification as unread -> optimistic update -> fail -> revert optimistic changes using Cypress Component. Got a bit further with RTL but would involve a lot more mocking with diminishing utility. Maybe e2e is the way to go with this? Speaking of which, there's just a really basic notifications e2e given the fragile nature of our test data 💥.  

Please feel free to change any of the logic etc. if you spot a better solution. I found the react-table docs https://tanstack.com/table/latest pretty useful.

TIS21-5682

