### PR TITLE
fix: improve in-app notification formatting

### DIFF
--- a/components/notifications/NotificationMessageText.tsx
+++ b/components/notifications/NotificationMessageText.tsx
@@ -1,4 +1,5 @@
 import { toastErrText } from "../../utilities/Constants";
+import DOMPurify from "dompurify";
 import ErrorPage from "../common/ErrorPage";
 
 type NotificationMessageTextType = {
@@ -16,8 +17,11 @@ export function NotificationMessageText({
     return <ErrorPage message={toastErrText.fetchNotificationMessage} />;
   }
   return (
-    <div className="nhsuk-u-margin-top-2">
-      <p className="nhsuk-body"> {notificationMessageText}</p>
-    </div>
+    <div
+      className="nhsuk-u-margin-top-2"
+      dangerouslySetInnerHTML={{
+        __html: DOMPurify.sanitize(notificationMessageText)
+      }}
+    />
   );
 }

--- a/cypress/component/notifications/NotificationMessageText.cy.tsx
+++ b/cypress/component/notifications/NotificationMessageText.cy.tsx
@@ -2,7 +2,7 @@ import { mount } from "cypress/react18";
 import { NotificationMessageText } from "../../../components/notifications/NotificationMessageText";
 
 describe("NotificationMessageText", () => {
-  it("displays loading state", () => {
+  it("should display loading state", () => {
     mount(
       <NotificationMessageText
         notificationMessageStatus="loading"
@@ -12,7 +12,7 @@ describe("NotificationMessageText", () => {
     cy.contains("p", "Loading...");
   });
 
-  it("displays error state", () => {
+  it("should display error state", () => {
     mount(
       <NotificationMessageText
         notificationMessageStatus="failed"
@@ -29,14 +29,24 @@ describe("NotificationMessageText", () => {
       );
   });
 
-  it("displays notification message", () => {
+  it("should display notification message", () => {
     const message = "This is a test notification message";
     mount(
       <NotificationMessageText
         notificationMessageStatus="success"
-        notificationMessageText={message}
+        notificationMessageText={`<p>${message}</p>`}
       />
     );
     cy.contains("p", message);
+  });
+
+  it("should sanitize notification message", () => {
+    mount(
+      <NotificationMessageText
+        notificationMessageStatus="success"
+        notificationMessageText="Test:<script>alert(1);</script>"
+      />
+    );
+    cy.contains("div", "Test:");
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.94.2",
+  "version": "0.94.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -45,6 +45,7 @@
         "cypress-mochawesome-reporter": "^3.3.0",
         "cypress-otp": "^1.0.3",
         "dayjs": "^1.11.9",
+        "dompurify": "^3.1.0",
         "eslint": "^8.50.0",
         "eslint-config-next": "13.0.7",
         "eslint-config-prettier": "^8.5.0",
@@ -88,6 +89,9 @@
         "stylelint-prettier": "^2.0.0",
         "typescript": "^4.9.4",
         "yup": "^0.32.11"
+      },
+      "devDependencies": {
+        "@types/dompurify": "^3.0.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -11074,6 +11078,15 @@
         "cypress": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.4.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
@@ -11364,6 +11377,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -14056,6 +14075,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.0.tgz",
+      "integrity": "sha512-yoU4rhgPKCo+p5UrWWWNKiIq+ToGqmVVhk0PmMYBK4kRsR3/qhemNFL8f6CFmBd4gMwm3F4T7HBoydP5uY07fA=="
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -33549,6 +33573,15 @@
         "cypress": "*"
       }
     },
+    "@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "*"
+      }
+    },
     "@types/eslint": {
       "version": "8.4.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
@@ -33838,6 +33871,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
+    },
+    "@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true
     },
     "@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -35879,6 +35918,11 @@
           "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
         }
       }
+    },
+    "dompurify": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.0.tgz",
+      "integrity": "sha512-yoU4rhgPKCo+p5UrWWWNKiIq+ToGqmVVhk0PmMYBK4kRsR3/qhemNFL8f6CFmBd4gMwm3F4T7HBoydP5uY07fA=="
     },
     "dot-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.94.2",
+  "version": "0.94.3",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",
@@ -19,6 +19,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/aria-query": "^5.0.1",
     "@types/cypress__code-coverage": "^3.10.0",
+    "@types/dompurify": "^3.0.5",
     "@types/jest": "^29.5.5",
     "@types/node": "^18.11.17",
     "@types/qrcode.react": "^1.0.3",
@@ -40,6 +41,7 @@
     "cypress-mochawesome-reporter": "^3.3.0",
     "cypress-otp": "^1.0.3",
     "dayjs": "^1.11.9",
+    "dompurify": "^3.1.0",
     "eslint": "^8.50.0",
     "eslint-config-next": "13.0.7",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
The in-app notification message contents is rendered as plain text, making them difficult to read.

The notification message will be modified to return as a HTML fragment, so the notification message component should be modified to use the fragment as inner html.

Add DOMPurify as a dependency and use it to sanitize the fragment before inserting it in to the DOM.

TIS21-5898
TIS21-5900