### PR TITLE
chore: Add 30s request and response timeouts

### DIFF
--- a/cypress/e2e/notifications/Notifications.spec.ts
+++ b/cypress/e2e/notifications/Notifications.spec.ts
@@ -15,17 +15,19 @@ describe("Notifications", () => {
         body: notificationsMixedTypeData
       }
     ).as("getNotifications");
+    cy.wait("@getNotifications", {
+      requestTimeout: 30000,
+      responseTimeout: 30000
+    });
   });
 
   it("should load the notifications page", () => {
-    cy.wait("@getNotifications");
     cy.get('[data-cy="notificationsHeading"]')
       .should("exist")
       .should("contain.text", "Notifications");
   });
 
   it("should filter the recived list of notifications so that only IN_APP are visiable", () => {
-    cy.wait("@getNotifications");
     cy.get('[data-cy="NotificationsTablePageSizeSelect"]').select(
       "Show 30 rows"
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.98.1",
+  "version": "0.98.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.98.1",
+      "version": "0.98.2",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.98.1",
+  "version": "0.98.2",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",


### PR DESCRIPTION
to the notifications tests

If this doesn't work then I 🔥 it to the ground.

NO TICKET