### PR TITLE
fix: unable to record one day locum

### DIFF
--- a/components/forms/form-builder/form-r/part-b/formBValidationSchema.ts
+++ b/components/forms/form-builder/form-r/part-b/formBValidationSchema.ts
@@ -76,11 +76,11 @@ const WorkValidationSchema = yup.object().shape({
     .required("End date is required")
     .test(
       "end-is-greater",
-      "End date must be later than Start date",
+      "End date must be later than or equal to Start date",
       function (endDate) {
         const { startDate } = this.parent;
         if (startDate && endDate) {
-          return new Date(startDate).getTime() < new Date(endDate).getTime();
+          return new Date(startDate).getTime() <= new Date(endDate).getTime();
         }
         return false;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.98.2",
+  "version": "0.98.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.98.2",
+      "version": "0.98.3",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.98.2",
+  "version": "0.98.3",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",


### PR DESCRIPTION
A single day locum shift will start and end on the same day, currently that fails the Form R validation rules.

Update the validation to allow the start date and end date to be the same, it should still fail if the end date is before the start date.

TIS21-6084