### PR TITLE
chore: fix sonar analysis

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,6 +149,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Analyse quality
         uses: SonarSource/sonarcloud-github-action@v2.1.1
         env:


### PR DESCRIPTION
Sonar analysis is failing as the repo is not checked out. Perform a checkout with deep clone before attempting to run sonar.

NO-TICKET