### PR TITLE
feat: polish the CCT MVP(1)

### DIFF
--- a/components/common/ExpanderMsg.tsx
+++ b/components/common/ExpanderMsg.tsx
@@ -128,13 +128,13 @@ export const ExpanderMsg = ({
             <b> Q. What WTE percentage(s) are you considering?</b>
           </p>
           <p>
-            Please note that the WTE percentage(s) you select are subject to
-            availability and agreement with your TPD.
+            The WTE percentage(s) you select are subject to availability and
+            agreement with your TPD.
           </p>
           <p>
-            The percentages in the dropdown list are the most common. You can
-            add your own WTE percentage by typing and then selecting it but this
-            does not indicate a choice will be possible.
+            {`The dropdown lists the standard WTE percentages. You can add your
+            own by typing and clicking 'Create' but this bespoke value might not
+            be possible.`}
           </p>
           <p>
             Returning to full time (100% WTE) requires a full time vacancy to
@@ -145,17 +145,15 @@ export const ExpanderMsg = ({
             <b>Q. When should the WTE change begin?</b>
           </p>
           <p>
-            The calculator defaults to 16 weeks hence as this is the normal
-            minimum notice period required. Shorter notice periods may be
-            possible but need to be agreed.
+            The required notice period is normally 16 weeks. Shorter notice
+            periods may be possible but will need to be agreed.
           </p>
           <p>
             <b>Q. When should the WTE change end?</b>
           </p>
           <p>
-            The calculator defaults to the current programme end date but you
-            can choose an earlier end date if you are looking at ending the
-            change in WTE sooner than this.
+            The default is the current programme end date but you can choose to
+            end the change in WTE earlier.
           </p>
         </>
       )

--- a/components/common/PanelsCreator.tsx
+++ b/components/common/PanelsCreator.tsx
@@ -69,6 +69,7 @@ export function PanelsCreator({
                   <CctBtn
                     progName={panel.programmeName}
                     endDate={panel.endDate}
+                    startDate={panel.startDate}
                   />
                 )}
                 <SummaryList>

--- a/components/forms/cct/CalcForm.tsx
+++ b/components/forms/cct/CalcForm.tsx
@@ -5,20 +5,24 @@ import { Button, CloseIcon } from "nhsuk-react-components";
 import { AutocompleteSelect } from "../../common/AutocompleteSelect";
 import TextInputField from "../TextInputField";
 import FieldWarningMsg from "../FieldWarningMsg";
-import { FtePercentsTypes, handleClose } from "../../../utilities/CctUtilities";
+import {
+  FtePercentsTypes,
+  NewEndDatesTypes,
+  handleClose
+} from "../../../utilities/CctUtilities";
 
 type CalcFormProps = {
-  currentProgEndDate: Date | string;
-  propStartDate: Date | string;
+  currentProgEndDate: string;
+  propStartDate: string;
   onCalculate: (values: CalcFormValues) => void;
-  newEndDates?: string[];
+  newEndDates: NewEndDatesTypes[];
   handlePrint: () => void;
 };
 
 export type CalcFormValues = {
   ftePercents: FtePercentsTypes[];
-  propStartDate: Date | string;
-  propEndDate: Date | string;
+  propStartDate: string;
+  propEndDate: string;
   currentFtePercent: string;
 };
 

--- a/components/forms/cct/Cct.tsx
+++ b/components/forms/cct/Cct.tsx
@@ -96,10 +96,13 @@ const CctChild = forwardRef(
           >{`CCT Calculator`}</Fieldset.Legend>
           <p id="cct-disclaimer-text" data-cy="cct-disclaimer">
             <b>
-              Please note, this calculator is only intended to provide a quick
-              rough estimate. It does not factor in Time out of Training,
-              statutory leave or a period of OOP. Your actual CCT date will be
-              confirmed at your next ARCP.
+              This calculator is intended to provide a quick rough estimate
+              only.
+              <br />
+              It does not factor in Time out of Training, statutory leave or a
+              period of OOP.
+              <br />
+              Your actual CCT date will be confirmed at your next ARCP.
             </b>
           </p>
           <ExpanderMsg expanderName="cctInfo" />
@@ -156,6 +159,7 @@ const CctChild = forwardRef(
             position={position}
             onStop={handleDrag as DraggableEventHandler}
             cancel=".not-draggable"
+            bounds="parent"
           >
             {dialogContent}
           </Draggable>

--- a/components/programmes/CctBtn.tsx
+++ b/components/programmes/CctBtn.tsx
@@ -4,23 +4,33 @@ import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
 import {
   openCctModal,
   setCurrentProgEndDate,
-  setProgName
+  setProgName,
+  setPropStartDate
 } from "../../redux/slices/cctCalcSlice";
 import { Button, Card, Label } from "nhsuk-react-components";
+import { calcDefaultPropStartDate } from "../../utilities/CctUtilities";
 
 type CctBtnProps = {
   progName: string;
-  endDate: Date | string;
+  endDate: string;
+  startDate: string;
 };
 
-export function CctBtn({ progName, endDate }: Readonly<CctBtnProps>) {
+export function CctBtn({
+  progName,
+  endDate,
+  startDate
+}: Readonly<CctBtnProps>) {
   const dispatch = useAppDispatch();
   const modalState = useAppSelector(state => state.cctCalc.modalOpen);
+  const defaultPropStartDate = calcDefaultPropStartDate(startDate, endDate);
 
   const handleClick = () => {
     dispatch(openCctModal());
     dispatch(setProgName(progName));
     dispatch(setCurrentProgEndDate(endDate));
+    defaultPropStartDate.length > 0 &&
+      dispatch(setPropStartDate(defaultPropStartDate));
   };
   return (
     <Card className="cct-card">
@@ -34,9 +44,9 @@ export function CctBtn({ progName, endDate }: Readonly<CctBtnProps>) {
           data-cy={`cctBtn-${progName}`}
           onClick={handleClick}
           disabled={modalState}
-          title="Get CCT estimate"
+          title="Open CCT Calculator"
         >
-          <span>{"Get CCT estimate"}</span>
+          <span>{"Open CCT Calculator"}</span>
           <FontAwesomeIcon
             icon={faCalculator}
             size="lg"

--- a/cypress/component/forms/cct/Cct.cy.tsx
+++ b/cypress/component/forms/cct/Cct.cy.tsx
@@ -9,7 +9,8 @@ import {
   openCctModal,
   setCurrentProgEndDate,
   setNewEndDates,
-  setProgName
+  setProgName,
+  setPropStartDate
 } from "../../../../redux/slices/cctCalcSlice";
 import dayjs from "dayjs";
 
@@ -21,6 +22,9 @@ describe("Cct", () => {
     store.dispatch(openCctModal());
     store.dispatch(setProgName(progName));
     store.dispatch(setCurrentProgEndDate(endDate.format("YYYY-MM-DD")));
+    store.dispatch(
+      setPropStartDate(dayjs().add(16, "week").format("YYYY-MM-DD"))
+    );
 
     const newEndDate = (newPercent: number, currPercent: number) => {
       const propStartDate = dayjs().add(16, "week").subtract(1, "day");
@@ -39,7 +43,7 @@ describe("Cct", () => {
     );
     cy.get('[data-cy="cct-header"]').contains("CCT Calculator");
     cy.get('[data-cy="cct-disclaimer"]').contains(
-      "Please note, this calculator is only intended"
+      "This calculator is intended to provide a quick rough estimate only."
     );
     cy.get('[data-cy="cctInfoSummary"]')
       .contains("CCT Calculator further information")

--- a/cypress/component/programmes/Programmes.cy.tsx
+++ b/cypress/component/programmes/Programmes.cy.tsx
@@ -89,8 +89,8 @@ describe("Programmes with MFA set up", () => {
       .should("contain.text", "01/08/2022 - 01/08/2025");
     cy.get('[data-cy="cctBtn-Cardiology"]')
       .should("exist")
-      .should("contain.text", "Get CCT estimate")
-      .should("have.attr", "title", "Get CCT estimate");
+      .should("contain.text", "Open CCT Calculator")
+      .should("have.attr", "title", "Open CCT Calculator");
     cy.get('[data-cy="cct-prompt-label"]')
       .should("exist")
       .should("contain.text", "Thinking of changing your hours?");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.99.0",
+  "version": "0.100.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.99.0",
+      "version": "0.100.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",
@@ -12953,11 +12953,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -15451,9 +15451,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -18159,15 +18159,15 @@
       }
     },
     "node_modules/jsdom/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -19324,9 +19324,9 @@
       }
     },
     "node_modules/metro/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "peer": true,
       "engines": {
         "node": ">=8.3.0"
@@ -21355,9 +21355,9 @@
       }
     },
     "node_modules/react-devtools-core/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "peer": true,
       "engines": {
         "node": ">=8.3.0"
@@ -24662,9 +24662,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
       "peer": true,
       "dependencies": {
         "async-limiter": "~1.0.0"
@@ -35131,11 +35131,11 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browser-stdout": {
@@ -37006,9 +37006,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -38982,9 +38982,9 @@
           }
         },
         "ws": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "version": "8.17.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+          "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
           "requires": {}
         }
       }
@@ -39642,9 +39642,9 @@
           }
         },
         "ws": {
-          "version": "7.5.9",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "version": "7.5.10",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+          "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
           "peer": true,
           "requires": {}
         },
@@ -41395,9 +41395,9 @@
       },
       "dependencies": {
         "ws": {
-          "version": "7.5.9",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "version": "7.5.10",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+          "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
           "peer": true,
           "requires": {}
         }
@@ -43884,9 +43884,9 @@
       }
     },
     "ws": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
       "peer": true,
       "requires": {
         "async-limiter": "~1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.99.0",
+  "version": "0.100.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/redux/slices/cctCalcSlice.ts
+++ b/redux/slices/cctCalcSlice.ts
@@ -1,12 +1,12 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import dayjs from "dayjs";
+import { NewEndDatesTypes } from "../../utilities/CctUtilities";
 
 type CctCalcState = {
   modalOpen: boolean;
   progName: string;
-  currentProgEndDate: Date | string;
-  newEndDates: any[];
-  propStartDate: Date | string;
+  currentProgEndDate: string;
+  newEndDates: NewEndDatesTypes[];
+  propStartDate: string;
 };
 
 const initialState: CctCalcState = {
@@ -14,7 +14,7 @@ const initialState: CctCalcState = {
   progName: "",
   currentProgEndDate: "",
   newEndDates: [],
-  propStartDate: dayjs().add(16, "weeks").format("YYYY-MM-DD")
+  propStartDate: ""
 };
 
 const cctCalcSlice = createSlice({
@@ -27,10 +27,13 @@ const cctCalcSlice = createSlice({
     setProgName(state, action: PayloadAction<string>) {
       return { ...state, progName: action.payload };
     },
-    setCurrentProgEndDate(state, action: PayloadAction<Date | string>) {
+    setCurrentProgEndDate(state, action: PayloadAction<string>) {
       return { ...state, currentProgEndDate: action.payload };
     },
-    setNewEndDates(state, action: PayloadAction<any[]>) {
+    setPropStartDate(state, action: PayloadAction<string>) {
+      return { ...state, propStartDate: action.payload };
+    },
+    setNewEndDates(state, action: PayloadAction<NewEndDatesTypes[]>) {
       return { ...state, newEndDates: action.payload };
     },
     resetCctCalc() {
@@ -45,6 +48,7 @@ export const {
   openCctModal,
   setProgName,
   setCurrentProgEndDate,
+  setPropStartDate,
   setNewEndDates,
   resetCctCalc
 } = cctCalcSlice.actions;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -876,7 +876,7 @@ ol[type="a"] {
 
   @media (min-width: 1025px) {
     position: absolute;
-    top: 17rem;
+    top: 25vh;
   }
 
   @media (min-width: 1025px) and (max-width: 1199px) {

--- a/utilities/CctUtilities.ts
+++ b/utilities/CctUtilities.ts
@@ -7,13 +7,18 @@ export type FtePercentsTypes = {
   label: string;
 };
 
+export type NewEndDatesTypes = {
+  ftePercent: string;
+  newEndDate: string;
+};
+
 export function calculateNewEndDates(
   currentFtePercent: number,
   ftePercents: FtePercentsTypes[],
   propStartDate: Date | string,
   propEndDate: Date | string,
   currentProgEndDate: Date | string
-) {
+): NewEndDatesTypes[] {
   const chunkDays = dayjs(propEndDate).diff(propStartDate, "days");
   return ftePercents.map(ftePercent => {
     if (typeof ftePercent.value === "string") {
@@ -38,4 +43,21 @@ export function calculateNewEndDates(
 
 export function handleClose() {
   store.dispatch(resetCctCalc());
+}
+
+export function calcDefaultPropStartDate(
+  programmeStartDate: string,
+  programmeEndDate: string
+): string {
+  const sixteenWeeksFromNow = dayjs().add(16, "weeks").format("YYYY-MM-DD");
+
+  if (dayjs(programmeStartDate).isSameOrAfter(sixteenWeeksFromNow)) {
+    return programmeStartDate;
+  }
+
+  if (dayjs(programmeEndDate).isBefore(sixteenWeeksFromNow)) {
+    return "";
+  }
+
+  return sixteenWeeksFromNow;
 }

--- a/utilities/__test__/CctUtilities.test.ts
+++ b/utilities/__test__/CctUtilities.test.ts
@@ -1,4 +1,9 @@
-import { calculateNewEndDates, FtePercentsTypes } from "../CctUtilities";
+import {
+  calcDefaultPropStartDate,
+  calculateNewEndDates,
+  FtePercentsTypes
+} from "../CctUtilities";
+import dayjs from "dayjs";
 
 describe("calculateNewEndDates", () => {
   beforeAll(() => {
@@ -55,5 +60,42 @@ describe("calculateNewEndDates", () => {
     );
 
     expect(result).toEqual([{ ftePercent: "95%", newEndDate: "17/02/2028" }]);
+  });
+});
+
+describe("calcDefaultPropStartDate", () => {
+  const sixteenWeeksFromNow = dayjs().add(16, "weeks");
+  it("should return the currentProgStartDate if the program start date is at least 16 weeks from now.", () => {
+    const currentProgStartDate = sixteenWeeksFromNow.format("YYYY-MM-DD");
+    const currentProgEndDate = dayjs().add(2, "years").format("YYYY-MM-DD");
+    expect(
+      calcDefaultPropStartDate(currentProgStartDate, currentProgEndDate)
+    ).toBe(sixteenWeeksFromNow.format("YYYY-MM-DD"));
+    expect(
+      calcDefaultPropStartDate(
+        sixteenWeeksFromNow.add(1, "day").format("YYYY-MM-DD"),
+        currentProgEndDate
+      )
+    ).toBe(sixteenWeeksFromNow.add(1, "day").format("YYYY-MM-DD"));
+  });
+  it("should return an empty string if the program end date is before 16 weeks from now.", () => {
+    const currentProgStartDate = dayjs().format("YYYY-MM-DD");
+    const currentProgEndDate = sixteenWeeksFromNow
+      .subtract(1, "day")
+      .format("YYYY-MM-DD");
+    expect(
+      calcDefaultPropStartDate(currentProgStartDate, currentProgEndDate)
+    ).toBe("");
+  });
+  it("should the default sixteenWeeksFromNow if the program start date is less than 16 weeks from now and the program end date is at least 16 weeks away from now.", () => {
+    const currentProgStartDate = sixteenWeeksFromNow
+      .subtract(1, "day")
+      .format("YYYY-MM-DD");
+    const currentProgEndDate = sixteenWeeksFromNow
+      .add(1, "day")
+      .format("YYYY-MM-DD");
+    expect(
+      calcDefaultPropStartDate(currentProgStartDate, currentProgEndDate)
+    ).toBe(sixteenWeeksFromNow.format("YYYY-MM-DD"));
   });
 });


### PR DESCRIPTION
feat: update cct btn wording to better reflect the action
chore: add calcDefaultPropStartDate util (mainly to address the '>16 weeks future programme' issue).
chore: set the draggable cct dialog boundary to parent component to stop it getting completely hidden and unclickable.
chore: make the expander message text less wordy.
chore: add line breaks to disclaimer text (to stop some Safari weirdness with dialog width/print preview (to save PDF)

TIS21-6118