### PR TITLE
fix: default dialog position

### DIFF
--- a/components/forms/cct/CalcForm.tsx
+++ b/components/forms/cct/CalcForm.tsx
@@ -16,7 +16,7 @@ type CalcFormProps = {
   propStartDate: string;
   onCalculate: (values: CalcFormValues) => void;
   newEndDates: NewEndDatesTypes[];
-  handlePrint: () => void;
+  setShouldPrint: (shouldPrint: boolean) => void;
 };
 
 export type CalcFormValues = {
@@ -31,7 +31,7 @@ export function CalcForm({
   propStartDate,
   onCalculate,
   newEndDates = [],
-  handlePrint
+  setShouldPrint
 }: Readonly<CalcFormProps>) {
   const validationSchema = Yup.object().shape({
     currentFtePercent: Yup.string()
@@ -179,7 +179,7 @@ export function CalcForm({
             </Button>
             <Button
               secondary
-              onClick={handlePrint}
+              onClick={() => setShouldPrint(true)}
               disabled={!dirty || !isValid || newEndDates.length === 0}
               data-cy="cct-pdf-btn"
             >

--- a/components/forms/cct/PrintableCct.tsx
+++ b/components/forms/cct/PrintableCct.tsx
@@ -1,0 +1,44 @@
+import { forwardRef } from "react";
+import { useAppSelector } from "../../../redux/hooks/hooks";
+import { CurrentProgInfo, DisclaimerTxt, NewWteAndDateTable } from "./Cct";
+import dayjs from "dayjs";
+
+export const PrintableCct = forwardRef<any>((_, ref) => {
+  const currentProgEndDate = useAppSelector(
+    state => state.cctCalc.currentProgEndDate
+  );
+  const currentWte = useAppSelector(state => state.cctCalc.currentWte);
+  const proposeStartDate = useAppSelector(state => state.cctCalc.propStartDate);
+  const propEndDate = useAppSelector(state => state.cctCalc.propEndDate);
+  const progName = useAppSelector(state => state.cctCalc.progName);
+  const newEndDates = useAppSelector(state => state.cctCalc.newEndDates);
+
+  return (
+    <div ref={ref} className="cct-printable" data-cy="cct-printable">
+      <h1 data-cy="cct-print-header">TIS Self-Service CCT Calculator</h1>
+      <DisclaimerTxt />
+      <section>
+        <h2 data-cy="cct-current-header">Current situation</h2>
+        <CurrentProgInfo
+          progName={progName}
+          currentProgEndDate={currentProgEndDate}
+          currentWte={currentWte}
+        />
+      </section>
+      <section>
+        <h2 data-cy="cct-changes-header">Proposed changes</h2>
+        <p>
+          <b data-cy="cct-new-start">{`Start Date of new WTE: `}</b>
+          {dayjs(proposeStartDate).format("DD/MM/YYYY")}
+        </p>
+        <p>
+          <b data-cy="cct-new-end">{`End Date of new WTE: `}</b>
+          {dayjs(propEndDate).format("DD/MM/YYYY")}
+        </p>
+        <NewWteAndDateTable newEndDates={newEndDates} />
+      </section>
+      <p>{`Calculation created on: ${dayjs().format("DD/MM/YYYY HH:mm")}`}</p>
+    </div>
+  );
+});
+PrintableCct.displayName = "PrintableCct";

--- a/components/programmes/CctBtn.tsx
+++ b/components/programmes/CctBtn.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
 import {
   openCctModal,
   setCurrentProgEndDate,
+  setDialogYPosition,
   setProgName,
   setPropStartDate
 } from "../../redux/slices/cctCalcSlice";
@@ -26,6 +27,7 @@ export function CctBtn({
   const defaultPropStartDate = calcDefaultPropStartDate(startDate, endDate);
 
   const handleClick = () => {
+    dispatch(setDialogYPosition(window.scrollY));
     dispatch(openCctModal());
     dispatch(setProgName(progName));
     dispatch(setCurrentProgEndDate(endDate));

--- a/cypress/component/forms/cct/Cct.cy.tsx
+++ b/cypress/component/forms/cct/Cct.cy.tsx
@@ -41,6 +41,7 @@ describe("Cct", () => {
         </MemoryRouter>
       </Provider>
     );
+    cy.get('[data-cy="cct-printable"]').should("not.exist");
     cy.get('[data-cy="cct-header"]').contains("CCT Calculator");
     cy.get('[data-cy="cct-disclaimer"]').contains(
       "This calculator is intended to provide a quick rough estimate only."
@@ -158,6 +159,8 @@ describe("Cct", () => {
       .should("have.text", newEndDate(100, 80));
 
     cy.get('[data-cy="cctInfoSummary"]').click();
+
+    cy.get('[data-cy="cct-pdf-btn"]').should("not.be.disabled");
 
     cy.get('[data-cy="cct-close-btn"]').click();
     cy.get(".cct-dialog").should("not.exist");

--- a/cypress/component/forms/cct/PrintableCct.cy.tsx
+++ b/cypress/component/forms/cct/PrintableCct.cy.tsx
@@ -1,0 +1,46 @@
+/// <reference types="cypress" />
+/// <reference path="../../../../cypress/support/index.d.ts" />
+import { mount } from "cypress/react18";
+import { MemoryRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import store from "../../../../redux/store/store";
+import { PrintableCct } from "../../../../components/forms/cct/PrintableCct";
+import {
+  setCurrentWte,
+  setNewEndDates
+} from "../../../../redux/slices/cctCalcSlice";
+
+describe("PrintableCct", () => {
+  it("renders the PrintableCct component but hidden", () => {
+    store.dispatch(setCurrentWte("100%"));
+    store.dispatch(
+      setNewEndDates([{ ftePercent: "50%", newEndDate: "01/01/2032" }])
+    );
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/programme"]}>
+          <PrintableCct />
+        </MemoryRouter>
+      </Provider>
+    );
+    cy.get('[data-cy="cct-printable"]').should("exist");
+    cy.get('[data-cy="cct-printable"]').should("have.css", "display", "none");
+    cy.get('[data-cy="cct-print-header"]').contains(
+      "TIS Self-Service CCT Calculator"
+    );
+    cy.get('[data-cy="cct-current-header"]').contains("Current situation");
+    cy.get('[data-cy="cct-curr-prog"]').contains("Programme:");
+    cy.get('[data-cy="cct-curr-prog-end"]').contains(
+      "Current Programme end date:"
+    );
+    cy.get('[data-cy="cct-curr-wte"]').contains("Current WTE:");
+
+    cy.get('[data-cy="cct-changes-header"]').contains("Proposed changes");
+    cy.get('[data-cy="cct-new-start"]').contains("Start Date of new WTE:");
+    cy.get('[data-cy="cct-new-end"]').contains("End Date of new WTE:");
+    cy.get('[data-cy="cct-th-wte"]').contains("New WTE");
+    cy.get('[data-cy="cct-th-new-date"]').contains("New End Date");
+    cy.get('[data-cy="cct-td-new-percent"]').contains("50%");
+    cy.get('[data-cy="cct-td-new-date"]').contains("01/01/2032");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.100.1",
+  "version": "0.100.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.100.1",
+      "version": "0.100.2",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.100.1",
+  "version": "0.100.2",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/redux/slices/cctCalcSlice.ts
+++ b/redux/slices/cctCalcSlice.ts
@@ -5,16 +5,22 @@ type CctCalcState = {
   modalOpen: boolean;
   progName: string;
   currentProgEndDate: string;
+  currentWte: string;
   newEndDates: NewEndDatesTypes[];
   propStartDate: string;
+  propEndDate: string;
+  dialogYPosition: number;
 };
 
 const initialState: CctCalcState = {
   modalOpen: false,
   progName: "",
   currentProgEndDate: "",
+  currentWte: "",
   newEndDates: [],
-  propStartDate: ""
+  propStartDate: "",
+  propEndDate: "",
+  dialogYPosition: 0
 };
 
 const cctCalcSlice = createSlice({
@@ -30,11 +36,20 @@ const cctCalcSlice = createSlice({
     setCurrentProgEndDate(state, action: PayloadAction<string>) {
       return { ...state, currentProgEndDate: action.payload };
     },
+    setCurrentWte(state, action: PayloadAction<string>) {
+      return { ...state, currentWte: action.payload };
+    },
     setPropStartDate(state, action: PayloadAction<string>) {
       return { ...state, propStartDate: action.payload };
     },
+    setPropEndDate(state, action: PayloadAction<string>) {
+      return { ...state, propEndDate: action.payload };
+    },
     setNewEndDates(state, action: PayloadAction<NewEndDatesTypes[]>) {
       return { ...state, newEndDates: action.payload };
+    },
+    setDialogYPosition(state, action: PayloadAction<number>) {
+      return { ...state, dialogYPosition: action.payload };
     },
     resetCctCalc() {
       return initialState;
@@ -48,7 +63,10 @@ export const {
   openCctModal,
   setProgName,
   setCurrentProgEndDate,
+  setCurrentWte,
   setPropStartDate,
+  setPropEndDate,
   setNewEndDates,
+  setDialogYPosition,
   resetCctCalc
 } = cctCalcSlice.actions;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -876,7 +876,6 @@ ol[type="a"] {
 
   @media (min-width: 1025px) {
     position: absolute;
-    top: 25vh;
   }
 
   @media (min-width: 1025px) and (max-width: 1199px) {
@@ -918,4 +917,35 @@ ol[type="a"] {
 
 #cct-btn span {
   margin-right: 0.5em;
+}
+
+// printable CCT
+.cct-printable {
+  // always invisible except print preview
+  display: none;
+}
+
+@media print {
+  .cct-printable {
+    position: relative;
+    top: 16px;
+    left: 16px;
+    max-width: 95vw;
+    display: block;
+  }
+  .cct-printable h1 {
+    color: #444;
+    font-size: 2em;
+  }
+  .cct-printable h2 {
+    color: #444;
+    font-size: 1.5em;
+  }
+  .cct-printable p {
+    font-size: 1em;
+    line-height: 1.6;
+  }
+  .cct-printable section {
+    margin-bottom: 2em;
+  }
 }


### PR DESCRIPTION
Problem: 
If there are a few programmes and the user scrolls to the end and clicks 'open CCT calc', the CCT dialog will open but will not be in view.

Fix: 
Use `window.scrollY` value to align the dialog with the y scroll position so the CCT calc is always in view even when when/if a btn click happens down the page. 
This involves using `defaultPosition` prop rather than `position` - which then means we can't use `position` prop to reset the dialog to 0,0 when printing (clicking 'save PDF') i.e. `defaultPosition` only works on first render.
Best solution is to make a separate `PrintableCct` comp using basic HTML that we can position and render more consistently. This involves only rendering it when `shouldPrint` is `true` and also keeping the contents hidden except when printing (via CSS `@media print`) etc. 
test: Update tests to reflect changes - although not really possible to test some of the logic around the `PrintableCct` rendering etc. via the 'save PDF' click/ print preview.

NO TICKET