### PR TITLE
fix: update support email address

### DIFF
--- a/components/authentication/signup/sharedPrimitives/AuthBtnLink.tsx
+++ b/components/authentication/signup/sharedPrimitives/AuthBtnLink.tsx
@@ -40,7 +40,7 @@ export const SupportLinks = (action: string) => {
       <a
         className="supportEmail"
         title="Please provide your GMC no. and brief description of the issue (include screenshots if necessary)"
-        href={`mailto:tis.support@hee.nhs.uk?subject=TSS Tech Support Query (GMC No.: <your GMC number>)&body=<Please provide brief description of the issue (include screenshots if necessary)>%0A%0AReferred Page:%0A${action}%0A%0ABrowser and OS Info:%0A${getUserAgentInfo()}%0A%0A`}
+        href={`mailto:england.tis.support@nhs.net?subject=TSS Tech Support Query (GMC No.: <your GMC number>)&body=<Please provide brief description of the issue (include screenshots if necessary)>%0A%0AReferred Page:%0A${action}%0A%0ABrowser and OS Info:%0A${getUserAgentInfo()}%0A%0A`}
       >
         Please click here to email Technical Support
       </a>

--- a/components/common/ToastMessage.tsx
+++ b/components/common/ToastMessage.tsx
@@ -45,7 +45,7 @@ export const ToastMessage = ({
         <a
           className="toast-anchor"
           data-cy="techSupportLink"
-          href={`mailto:tis.support@hee.nhs.uk?subject=TSS tech support query (${userIds})&body=Browser and OS info:%0A${getUserAgentInfo()}%0A%0APage URL:%0A${getPageURL()}%0A%0AError message:%0A${actionErrorMsg}%0A%0A%0A%0A`}
+          href={`mailto:england.tis.support@nhs.net?subject=TSS tech support query (${userIds})&body=Browser and OS info:%0A${getUserAgentInfo()}%0A%0APage URL:%0A${getPageURL()}%0A%0AError message:%0A${actionErrorMsg}%0A%0A%0A%0A`}
         >
           Click here to email Support
         </a>

--- a/components/common/__test__/ToastMessage.test.tsx
+++ b/components/common/__test__/ToastMessage.test.tsx
@@ -57,7 +57,7 @@ describe("ToastMessage - error", () => {
     // Wait for any asynchronous tasks to complete
     return waitFor(() => {
       const expectedHref =
-        "mailto:tis.support@hee.nhs.uk?subject=TSS tech support query (GMC no. 11111111, TIS ID 123)&body=Browser and OS info:%0AUser Agent: Mocked User Agent Info%0A%0APage URL:%0Ahttps://www.evertonfc.com%0A%0AError message:%0A808 State%0A%0A%0A%0A";
+        "mailto:england.tis.support@nhs.net?subject=TSS tech support query (GMC no. 11111111, TIS ID 123)&body=Browser and OS info:%0AUser Agent: Mocked User Agent Info%0A%0APage URL:%0Ahttps://www.evertonfc.com%0A%0AError message:%0A808 State%0A%0A%0A%0A";
 
       // Check the href attribute of the support link element
       expect(supportLinkElement.getAttribute("href")).toBe(expectedHref);

--- a/components/support/TechSupport.tsx
+++ b/components/support/TechSupport.tsx
@@ -41,7 +41,7 @@ export function TechSupport({
           {values.supportCatsTech.length > 0 && isValid && (
             <ActionLink
               data-cy="techSupportLink"
-              href={`mailto:tis.support@hee.nhs.uk?subject=TSS Technical support query (${emailIds}, Support categories: ${StringUtilities.alphabetSortedArrAsString(
+              href={`mailto:england.tis.support@nhs.net?subject=TSS Technical support query (${emailIds}, Support categories: ${StringUtilities.alphabetSortedArrAsString(
                 values.supportCatsTech
               )})&body=Browser and OS info:%0A${userAgentData}%0A%0APlease describe your issue(s) below. Include any screenshots you think might help: %0A%0A%0A`}
             >

--- a/components/support/__test__/TechSupport.test.tsx
+++ b/components/support/__test__/TechSupport.test.tsx
@@ -39,7 +39,7 @@ describe("TechSupport", () => {
     });
     clickElement(supportLinkElement);
     const expectedHref =
-      "mailto:tis.support@hee.nhs.uk?subject=TSS Technical support query (TisID: 47165, GMC: 1111111, Support categories: Authenticator, Login)&body=Browser and OS info:%0AMocked User Agent Info%0A%0APlease describe your issue(s) below. Include any screenshots you think might help: %0A%0A%0A";
+      "mailto:england.tis.support@nhs.net?subject=TSS Technical support query (TisID: 47165, GMC: 1111111, Support categories: Authenticator, Login)&body=Browser and OS info:%0AMocked User Agent Info%0A%0APlease describe your issue(s) below. Include any screenshots you think might help: %0A%0A%0A";
     expect(supportLinkElement.getAttribute("href")).toBe(expectedHref);
   });
 

--- a/cypress/e2e/authenticator/Authenticator.spec.ts
+++ b/cypress/e2e/authenticator/Authenticator.spec.ts
@@ -22,7 +22,7 @@ describe("Authenticator", () => {
         );
         expect($anchors.last()).to.contain("email");
         expect($anchors.last().attr("href")).to.contain(
-          "mailto:tis.support@hee.nhs.uk"
+          "mailto:england.tis.support@nhs.net"
         );
       });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.101.0",
+  "version": "0.101.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.101.0",
+  "version": "0.101.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",


### PR DESCRIPTION
The `@hee.nhs.uk` email address is no longer functional due to IT changes, update the support links to use a new `@nhs.net` address for support.

TIS21-6234