### PR TITLE
feat: make .amplify-button links look like links

### DIFF
--- a/components/app/CRAEntryPoint.tsx
+++ b/components/app/CRAEntryPoint.tsx
@@ -17,7 +17,8 @@ import {
   SIGN_UP_HEADING_TEXT,
   YES_TO_PRIVACY,
   YES_TO_PILOT,
-  FORM_FIELD_VALUES
+  FORM_FIELD_VALUES,
+  SIGN_IN_FOOTER_PASSWORD_RESET_WARNING_TEXT
 } from "../authentication/signup/constants/AuthConstants";
 import style from "../authentication/Auth.module.scss";
 import { I18n } from "@aws-amplify/core";
@@ -50,6 +51,9 @@ const components = {
         <>
           {SupportLinks("Sign in")}
           {AuthBtnLink(toResetPassword, SIGN_IN_FOOTER_BTN_LINK_TEXT)}
+          <p className="signin-password-reset-warning-text">
+            {SIGN_IN_FOOTER_PASSWORD_RESET_WARNING_TEXT}
+          </p>
         </>
       );
     }

--- a/components/authentication/signup/constants/AuthConstants.ts
+++ b/components/authentication/signup/constants/AuthConstants.ts
@@ -20,5 +20,6 @@ export const FORM_FIELD_VALUES = {
 
 export const SIGN_UP_HEADING_TEXT = "Create an account";
 
-export const SIGN_IN_FOOTER_BTN_LINK_TEXT =
-  "Password Reset (only works if you create an account and verify your email)";
+export const SIGN_IN_FOOTER_BTN_LINK_TEXT = "Reset Password";
+export const SIGN_IN_FOOTER_PASSWORD_RESET_WARNING_TEXT =
+  "Note: Password reset only works if you create an account and verify your email.";

--- a/components/authentication/signup/sharedPrimitives/AuthBtnLink.tsx
+++ b/components/authentication/signup/sharedPrimitives/AuthBtnLink.tsx
@@ -9,7 +9,8 @@ const AuthBtnLink = (
   return (
     <View textAlign="center">
       <Button
-        fontWeight="bold"
+        data-cy="passwordResetBtnLink"
+        fontWeight="normal"
         onClick={onClickEvent}
         size="small"
         variation="link"

--- a/cypress/e2e/authenticator/Authenticator.spec.ts
+++ b/cypress/e2e/authenticator/Authenticator.spec.ts
@@ -13,7 +13,10 @@ describe("Authenticator", () => {
 
   it("Header should have issue notice", () => {
     cy.get("[data-cy=authAlert]").should("exist");
-    cy.get("[data-cy=authAlert]").should("contain.text", "We are currently having issues with Support emails.");
+    cy.get("[data-cy=authAlert]").should(
+      "contain.text",
+      "We are currently having issues with Support emails."
+    );
   });
 
   it("Body should have the support FAQ and mailto links", () => {
@@ -97,6 +100,18 @@ describe("Authenticator", () => {
     cy.get('input[name="password"]').should("have.attr", "type", "text");
     cy.get("button.amplify-field__show-password").first().click();
     cy.get('input[name="password"]').should("have.attr", "type", "password");
+  });
+
+  it("should show the reset password link and warning text", () => {
+    cy.get(".signin-password-reset-warning-text")
+      .should("exist")
+      .should(
+        "contain.text",
+        "Note: Password reset only works if you create an account and verify your email."
+      );
+    cy.get('[data-cy="passwordResetBtnLink"]')
+      .should("exist")
+      .should("contain.text", "Reset Password");
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.101.3",
+  "version": "0.101.4",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -101,7 +101,13 @@ body {
   }
 
   .amplify-button[data-variation="link"] {
-    color: #005eb8 !important;
+    color: $nhsBlue !important;
+    text-decoration: underline;
+    outline: none;
+    &:hover {
+      text-decoration: none;
+      background: none;
+    }
   }
 
   [data-amplify-router] {
@@ -116,6 +122,11 @@ body {
   }
   .signInSupportLinks .supportEmail:hover {
     cursor: help;
+  }
+
+  .signin-password-reset-warning-text {
+    font-size: 0.75rem;
+    margin: 0 32px 16px 32px;
   }
 }
 


### PR DESCRIPTION
Following on from Reuben's typo fix...
Add some text decoration and separate the link text from the warning msg to make it a bit more accessible.

NO TICKET