### PR TITLE
fix: FormA e2e test fail

### DIFF
--- a/cypress/e2e/formr-a/FormRA.spec.ts
+++ b/cypress/e2e/formr-a/FormRA.spec.ts
@@ -20,7 +20,7 @@ describe("Form R Part A - Basic Form completion and submission", () => {
     cy.startOver();
   });
 
-  it("Should complete a new Form R Part A.", () => {
+  it("should autosave then delete draft via 'start over' btn.", () => {
     cy.get('[data-cy="Submit new form"]').click();
     cy.checkForFormLinkerAndComplete();
     cy.get('[data-cy="progress-header"] > h3').should(
@@ -50,6 +50,9 @@ describe("Form R Part A - Basic Form completion and submission", () => {
 
     cy.log("################ Start over functionality ###################");
     cy.startOver();
+  });
+
+  it("should complete form and submit successfully", () => {
     cy.get('[data-cy="Submit new form"]').click();
     cy.checkForFormLinkerAndComplete();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.103.0",
+  "version": "0.103.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.103.0",
+      "version": "0.103.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.103.0",
+  "version": "0.103.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",


### PR DESCRIPTION
... by splitting the 2nd 'it' block in two.
The test fail appears to be due to the second linker modal not being visible (after the initial modal linkage, startover(), and subsequent "Submit new form" btn click). Cypress appears to be unable to manage these Modal visibility state changes properly within a single 'it' block.

NO TICKET