### PR TITLE
refactor: remove legacy local offices names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.105.0",
+  "version": "0.106.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.105.0",
+      "version": "0.106.2",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.106.1",
+  "version": "0.106.2",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/Constants.tsx
+++ b/utilities/Constants.tsx
@@ -309,34 +309,19 @@ type localOfficeContactsProps = {
   [key: string]: string;
 };
 
-// TODO: remove old local office names once renaming is complete.
 export const localOfficeContacts: localOfficeContactsProps = {
-  "Health Education England East Midlands": "england.tis.em@nhs.net",
   "East Midlands": "england.tis.em@nhs.net",
-  "Health Education England East of England": "england.tis.eoe@nhs.net",
   "East of England": "england.tis.eoe@nhs.net",
-  "Health Education England Kent, Surrey and Sussex": "PGMDE support portal",
   "Kent, Surrey and Sussex": "PGMDE support portal",
-  "Health Education England North Central and East London":
-    "PGMDE support portal",
   "North Central and East London": "PGMDE support portal",
-  "Health Education England North East": "england.specialtytraining.ne@nhs.net",
   "North East": "england.specialtytraining.ne@nhs.net",
-  "Health Education England North West": "england.wpi.nw@nhs.net",
   "North West": "england.wpi.nw@nhs.net",
-  "Health Education England North West London": "PGMDE support portal",
   "North West London": "PGMDE support portal",
-  "Health Education England South London": "PGMDE support portal",
   "South London": "PGMDE support portal",
-  "Health Education England South West": "england.tisqueries.sw@nhs.net",
   "South West": "england.tisqueries.sw@nhs.net",
-  "Health Education England Thames Valley": "england.formr.tv@nhs.net",
   "Thames Valley": "england.formr.tv@nhs.net",
-  "Health Education England Wessex": "england.formr.wx@nhs.net",
   Wessex: "england.formr.wx@nhs.net",
-  "Health Education England West Midlands": "england.tis.wm@nhs.net",
   "West Midlands": "england.tis.wm@nhs.net",
-  "Health Education England Yorkshire and the Humber": "england.tis.yh@nhs.net",
   "Yorkshire and the Humber": "england.tis.yh@nhs.net"
 };
 


### PR DESCRIPTION
Local office names have been updated to remove the "Health Education England" prefix.
Previously the new names were put in alongside the legacy names, now the migration is complete the legacy names can be removed.

TIS21-6418
TIS21-6420