### PR TITLE
feat: download COJ PDF from Forms service

### DIFF
--- a/components/forms/FormSavePDF.tsx
+++ b/components/forms/FormSavePDF.tsx
@@ -5,9 +5,10 @@ import style from "../Common.module.scss";
 type IFormSave = {
   history: any;
   path: string;
+  onClickHandler?: any;
 };
 
-const FormSavePDF = ({ history, path }: IFormSave) => {
+const FormSavePDF = ({ history, path, onClickHandler }: IFormSave) => {
   return (
     <div className="hide-from-print">
       <Row>
@@ -25,20 +26,24 @@ const FormSavePDF = ({ history, path }: IFormSave) => {
         <Col width="one-third">
           <Button
             data-cy="savePdfBtn"
-            onClick={() => FormRUtilities.windowPrint()}
+            onClick={onClickHandler || (() => FormRUtilities.windowPrint())}
           >
             Save a copy as a PDF
           </Button>
         </Col>
         <Col style={{ textAlign: "right" }} width="two-thirds">
-          <ActionLink
-            data-cy="pdfHelpLink"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://tis-support.hee.nhs.uk/trainees/how-to-save-form-as-pdf/"
-          >
-            Click here for help saving form as a PDF
-          </ActionLink>
+          {onClickHandler ? (
+            <></>
+          ) : (
+            <ActionLink
+              data-cy="pdfHelpLink"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://tis-support.hee.nhs.uk/trainees/how-to-save-form-as-pdf/"
+            >
+              Click here for help saving form as a PDF
+            </ActionLink>
+          )}
         </Col>
       </Row>
     </div>

--- a/components/forms/FormSavePDF.tsx
+++ b/components/forms/FormSavePDF.tsx
@@ -1,14 +1,23 @@
 import { ActionLink, BackLink, Button, Col, Row } from "nhsuk-react-components";
 import { FormRUtilities } from "../../utilities/FormRUtilities";
 import style from "../Common.module.scss";
+import { downloadCojPdf } from "../../utilities/FileUtilities";
+import { useAppSelector } from "../../redux/hooks/hooks";
+import { useState } from "react";
 
 type IFormSave = {
   history: any;
   path: string;
-  onClickHandler?: any;
+  pmId: string;
 };
 
-const FormSavePDF = ({ history, path, onClickHandler }: IFormSave) => {
+const FormSavePDF = ({ history, path, pmId }: IFormSave) => {
+  const [showPdfHelp, setShowPdfHelp] = useState<boolean>(false);
+  const matchedPm = useAppSelector(state =>
+    state.traineeProfile.traineeProfileData.programmeMemberships.find(
+      pm => pm.tisId === pmId
+    )
+  );
   return (
     <div className="hide-from-print">
       <Row>
@@ -26,15 +35,15 @@ const FormSavePDF = ({ history, path, onClickHandler }: IFormSave) => {
         <Col width="one-third">
           <Button
             data-cy="savePdfBtn"
-            onClick={onClickHandler || (() => FormRUtilities.windowPrint())}
+            onClick={() => {
+              downloadCojPdf(pmId, matchedPm, setShowPdfHelp);
+            }}
           >
             Save a copy as a PDF
           </Button>
         </Col>
-        <Col style={{ textAlign: "right" }} width="two-thirds">
-          {onClickHandler ? (
-            <></>
-          ) : (
+        {showPdfHelp && (
+          <Col style={{ textAlign: "right" }} width="two-thirds">
             <ActionLink
               data-cy="pdfHelpLink"
               target="_blank"
@@ -43,8 +52,8 @@ const FormSavePDF = ({ history, path, onClickHandler }: IFormSave) => {
             >
               Click here for help saving form as a PDF
             </ActionLink>
-          )}
-        </Col>
+          </Col>
+        )}
       </Row>
     </div>
   );

--- a/components/forms/conditionOfJoining/CojView.tsx
+++ b/components/forms/conditionOfJoining/CojView.tsx
@@ -19,6 +19,7 @@ import { DateUtilities } from "../../../utilities/DateUtilities";
 import FormSavePDF from "../FormSavePDF";
 import CojGg10 from "./CojGg10";
 import CojGg9 from "./CojGg9";
+import { FormsService } from "../../../services/FormsService";
 
 // set intiial values
 const initialValuesDefault = {
@@ -54,8 +55,11 @@ const validationSchema10 = Yup.object({
   isDeclareContacted: acceptanceValidation
 });
 
+const formsService = new FormsService();
+
 export default function CojView() {
   const {
+    signingCojPmId: pmId,
     signingCojProgName: progName,
     signingCojSignedDate: signedDate,
     signingCoj,
@@ -66,7 +70,13 @@ export default function CojView() {
 
   return progName ? (
     <>
-      {signedDate && <FormSavePDF history={history} path={"/programmes"} />}
+      {signedDate && (
+        <FormSavePDF
+          history={history}
+          path={"/programmes"}
+          onClickHandler={() => formsService.downloadTraineeCojPdf(pmId)}
+        />
+      )}
       <ScrollTo />
       {signingCojVersion === "GG9" && (
         <>

--- a/components/forms/conditionOfJoining/CojView.tsx
+++ b/components/forms/conditionOfJoining/CojView.tsx
@@ -19,7 +19,6 @@ import { DateUtilities } from "../../../utilities/DateUtilities";
 import FormSavePDF from "../FormSavePDF";
 import CojGg10 from "./CojGg10";
 import CojGg9 from "./CojGg9";
-import { FormsService } from "../../../services/FormsService";
 
 // set intiial values
 const initialValuesDefault = {
@@ -55,8 +54,6 @@ const validationSchema10 = Yup.object({
   isDeclareContacted: acceptanceValidation
 });
 
-const formsService = new FormsService();
-
 export default function CojView() {
   const {
     signingCojPmId: pmId,
@@ -71,11 +68,7 @@ export default function CojView() {
   return progName ? (
     <>
       {signedDate && (
-        <FormSavePDF
-          history={history}
-          path={"/programmes"}
-          onClickHandler={() => formsService.downloadTraineeCojPdf(pmId)}
-        />
+        <FormSavePDF history={history} path={"/programmes"} pmId={pmId} />
       )}
       <ScrollTo />
       {signingCojVersion === "GG9" && (

--- a/components/forms/form-builder/FormView.tsx
+++ b/components/forms/form-builder/FormView.tsx
@@ -103,7 +103,9 @@ export const FormView = ({
   return formData?.traineeTisId ? (
     <>
       <ScrollTo />
-      {!canEditStatus && <FormSavePDF history={history} path={redirectPath} />}
+      {!canEditStatus && (
+        <FormSavePDF history={history} path={redirectPath} pmId="" />
+      )}
       {canEditStatus && (
         <WarningCallout data-cy="warningConfirmation">
           <WarningCallout.Label visuallyHiddenText={false}>

--- a/cypress/component/forms/FormSavePDF.cy.tsx
+++ b/cypress/component/forms/FormSavePDF.cy.tsx
@@ -8,7 +8,7 @@ import history from "../../../components/navigation/history";
 import React from "react";
 
 describe("FormSavePDF", () => {
-  it("should mount without crashing", () => {
+  it("should push history when clicking back button", () => {
     cy.stub(FormRUtilities, "historyPush").as("Back");
     cy.stub(FormRUtilities, "windowPrint").as("PrintPDF");
 
@@ -21,7 +21,62 @@ describe("FormSavePDF", () => {
     );
     cy.get("[data-cy=backLink]").click();
     cy.get("@Back").should("have.been.called");
+  });
+
+  it("should call windowPrint when client-side PDF", () => {
+    cy.stub(FormRUtilities, "windowPrint").as("PrintPDF");
+
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <FormSavePDF history={[]} path="/formr-b" />
+        </Router>
+      </Provider>
+    );
     cy.get("[data-cy=savePdfBtn]").click();
     cy.get("@PrintPDF").should("have.been.called");
+  });
+
+  it("should show instructions when client-side PDF", () => {
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <FormSavePDF history={[]} path="/formr-b" />
+        </Router>
+      </Provider>
+    );
+    cy.get("[data-cy=pdfHelpLink]").should("exist");
+  });
+
+  it("should call click handler when server-side PDF", () => {
+    cy.stub(FormRUtilities, "windowPrint").as("PrintPDF");
+
+    const clickHandler = cy.stub().as("ClickHandler");
+
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <FormSavePDF
+            history={[]}
+            path="/formr-b"
+            onClickHandler={clickHandler}
+          />
+        </Router>
+      </Provider>
+    );
+    cy.get("[data-cy=savePdfBtn]").click();
+    cy.get("@PrintPDF").should("not.have.been.called");
+    cy.get("@ClickHandler").should("have.been.called");
+  });
+
+  it("should not show instructions when server-side PDF", () => {
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <FormSavePDF history={[]} path="/formr-b" onClickHandler={() => {}} />
+        </Router>
+      </Provider>
+    );
+    cy.get("[data-cy=pdfHelpLink]").should("not.exist");
   });
 });

--- a/cypress/component/forms/conditionOfJoining/CojView.cy.tsx
+++ b/cypress/component/forms/conditionOfJoining/CojView.cy.tsx
@@ -1,0 +1,91 @@
+/// <reference types="cypress" />
+/// <reference path="../../../../cypress/support/index.d.ts" />
+
+import { mount } from "cypress/react18";
+import { MemoryRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import store from "../../../../redux/store/store";
+import {
+  updatedsigningCoj,
+  updatedsigningCojPmId,
+  updatedsigningCojProgName,
+  updatedsigningCojSignedDate,
+  updatedsigningCojVersion
+} from "../../../../redux/slices/userSlice";
+import { mockTraineeProfile } from "../../../../mock-data/trainee-profile";
+import CojView from "../../../../components/forms/conditionOfJoining/CojView";
+
+describe("Conditions of Joining (/programmes/:id/sign-coj)", () => {
+  const pmId = mockTraineeProfile.programmeMemberships[0].tisId;
+
+  beforeEach(() => {
+    store.dispatch(updatedsigningCoj(true));
+    store.dispatch(updatedsigningCojVersion("GG10"));
+    store.dispatch(updatedsigningCojPmId(pmId!));
+    store.dispatch(updatedsigningCojProgName("Test Programme"));
+  });
+
+  it("renders the editable FormView component when not signed", () => {
+    store.dispatch(updatedsigningCojSignedDate(null));
+
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[`/programmes/${pmId}/sign-coj`]}>
+          <CojView />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    cy.get('[data-cy="cojHeading"]').contains(
+      "Conditions of Joining Agreement"
+    );
+    cy.get("h3").contains("Test Programme Specialty Training Programme");
+    cy.get('[data-cy="cojSignBtn"]').contains(
+      "Click to sign Conditions of Joining agreement"
+    );
+
+    cy.get('[data-cy="isDeclareProvisional0"]').should("not.be.checked");
+    cy.get('[data-cy="isDeclareSatisfy0"]').should("not.be.checked");
+    cy.get('[data-cy="isDeclareProvide0"]').should("not.be.checked");
+    cy.get('[data-cy="isDeclareInform0"]').should("not.be.checked");
+    cy.get('[data-cy="isDeclareUpToDate0"]').should("not.be.checked");
+    cy.get('[data-cy="isDeclareAttend0"]').should("not.be.checked");
+    cy.get('[data-cy="isDeclareContacted0"]').should("not.be.checked");
+    cy.get('[data-cy="isDeclareEngage0"]').should("not.be.checked");
+
+    cy.get(`[data-cy="savePdfBtn"]`).should("not.exist");
+    cy.get(`[data-cy="cojSignedOn"]`).should("not.exist");
+  });
+
+  it("renders the readonly FormView component when signed", () => {
+    store.dispatch(updatedsigningCojSignedDate(new Date("2024-03-02T01:00Z")));
+
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[`/programmes/${pmId}/sign-coj`]}>
+          <CojView />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    cy.get('[data-cy="cojHeading"]').contains(
+      "Conditions of Joining Agreement"
+    );
+    cy.get("h3").contains("Test Programme Specialty Training Programme");
+    cy.get('[data-cy="savePdfBtn"]').contains("Save a copy as a PDF");
+    cy.get('[data-cy="cojSignedOn"]').contains(
+      "Signed On: 02/03/2024 01:00 (GMT)"
+    );
+
+    cy.get('[data-cy="isDeclareProvisional0"]').should("be.checked");
+    cy.get('[data-cy="isDeclareSatisfy0"]').should("be.checked");
+    cy.get('[data-cy="isDeclareProvide0"]').should("be.checked");
+    cy.get('[data-cy="isDeclareInform0"]').should("be.checked");
+    cy.get('[data-cy="isDeclareUpToDate0"]').should("be.checked");
+    cy.get('[data-cy="isDeclareAttend0"]').should("be.checked");
+    cy.get('[data-cy="isDeclareContacted0"]').should("be.checked");
+    cy.get('[data-cy="isDeclareEngage0"]').should("be.checked");
+
+    cy.get(`[data-cy="cojSignBtn"]`).should("not.exist");
+  });
+});

--- a/cypress/component/programmes/CoJReadOnlyView.cy.tsx
+++ b/cypress/component/programmes/CoJReadOnlyView.cy.tsx
@@ -12,6 +12,7 @@ import {
   updatedsigningCojVersion
 } from "../../../redux/slices/userSlice";
 import CojView from "../../../components/forms/conditionOfJoining/CojView";
+import { FormRUtilities } from "../../../utilities/FormRUtilities";
 
 describe("COJ Contents ReadOnly View For Gold Guide 9", () => {
   beforeEach(() => {
@@ -66,7 +67,10 @@ describe("COJ Contents ReadOnly View For Gold Guide 9", () => {
       .should("be.checked");
   });
   it("should render view component with save PDF btn/link and declarations for submitted form.", () => {
-    cy.get("[data-cy=savePdfBtn]").should("exist");
+    cy.stub(FormRUtilities, "windowPrint").as("PrintPDF");
+    cy.get("[data-cy=pdfHelpLink]").should("not.exist");
+    cy.get("[data-cy=savePdfBtn]").click();
+    cy.get("@PrintPDF").should("have.been.called");
     cy.get("[data-cy=pdfHelpLink]")
       .should("exist")
       .should(
@@ -133,7 +137,9 @@ describe("COJ Contents ReadOnly View For Gold Guide 10", () => {
       .should("be.checked");
   });
   it("should render view component with save PDF btn/link and declarations for submitted form.", () => {
-    cy.get("[data-cy=savePdfBtn]").should("exist");
+    cy.stub(FormRUtilities, "windowPrint").as("PrintPDF");
+    cy.get("[data-cy=savePdfBtn]").click();
+    cy.get("@PrintPDF").should("have.been.called");
     cy.get("[data-cy=pdfHelpLink]")
       .should("exist")
       .should(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.106.7",
+  "version": "0.107.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.106.7",
+      "version": "0.107.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.106.7",
+  "version": "0.107.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/services/FormsService.ts
+++ b/services/FormsService.ts
@@ -5,37 +5,23 @@ import { FormRPartB } from "../models/FormRPartB";
 import { FeatureFlags } from "../models/FeatureFlags";
 import { IFormR } from "../models/IFormR";
 import { ProgrammeMembership } from "../models/ProgrammeMembership";
-import store from "../redux/store/store";
-import { FileUtilities } from "../utilities/FileUtilities";
 
 export class FormsService extends ApiService {
   constructor() {
     super("/api/forms");
   }
 
-  async downloadTraineeCojPdf(programmeMembershipId: string) {
-    const programmeMemberships =
-      store.getState().traineeProfile.traineeProfileData.programmeMemberships;
-
-    const programmeMembership = programmeMemberships.find(
-      prog => prog.tisId === programmeMembershipId
-    );
-
+  async downloadTraineeCojPdf(programmeMembership: ProgrammeMembership) {
     let requestConfig: AxiosRequestConfig<ProgrammeMembership> = {
       headers: {
         Accept: "application/pdf"
       },
       responseType: "blob"
     };
-
-    const response = this.axiosInstance.put<
-      ProgrammeMembership,
-      AxiosResponse<Blob>
-    >("/coj", programmeMembership, requestConfig);
-
-    FileUtilities.downloadPdf(
-      `conditions-of-joining_${programmeMembershipId}.pdf`,
-      () => response
+    return this.axiosInstance.put<ProgrammeMembership, AxiosResponse<Blob>>(
+      "/coj",
+      programmeMembership,
+      requestConfig
     );
   }
 

--- a/services/FormsService.ts
+++ b/services/FormsService.ts
@@ -1,13 +1,42 @@
-import { AxiosResponse } from "axios";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
 import ApiService from "./apiService";
 import { FormRPartA } from "../models/FormRPartA";
 import { FormRPartB } from "../models/FormRPartB";
 import { FeatureFlags } from "../models/FeatureFlags";
 import { IFormR } from "../models/IFormR";
+import { ProgrammeMembership } from "../models/ProgrammeMembership";
+import store from "../redux/store/store";
+import { FileUtilities } from "../utilities/FileUtilities";
 
 export class FormsService extends ApiService {
   constructor() {
     super("/api/forms");
+  }
+
+  async downloadTraineeCojPdf(programmeMembershipId: string) {
+    const programmeMemberships =
+      store.getState().traineeProfile.traineeProfileData.programmeMemberships;
+
+    const programmeMembership = programmeMemberships.find(
+      prog => prog.tisId === programmeMembershipId
+    );
+
+    let requestConfig: AxiosRequestConfig<ProgrammeMembership> = {
+      headers: {
+        Accept: "application/pdf"
+      },
+      responseType: "blob"
+    };
+
+    const response = this.axiosInstance.put<
+      ProgrammeMembership,
+      AxiosResponse<Blob>
+    >("/coj", programmeMembership, requestConfig);
+
+    FileUtilities.downloadPdf(
+      `conditions-of-joining_${programmeMembershipId}.pdf`,
+      () => response
+    );
   }
 
   async saveTraineeFormRPartA(

--- a/services/__test__/FormsService.test.ts
+++ b/services/__test__/FormsService.test.ts
@@ -5,9 +5,33 @@ import { submittedFormRPartBs } from "../../mock-data/submitted-formr-partb";
 import { errorResponse } from "../../mock-data/service-api-err-res";
 import { FormRPartB } from "../../models/FormRPartB";
 import { FormRPartA } from "../../models/FormRPartA";
+import { FileUtilities } from "../../utilities/FileUtilities";
 
 const mockService = new FormsService();
 describe("FormsService", () => {
+  it("downloadTraineeCojPdf method should download PDF from server", () => {
+    const successResponse: Promise<AxiosResponse<Blob>> = Promise.resolve({
+      data: new Blob(),
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config: {}
+    });
+
+    jest
+      .spyOn(mockService.axiosInstance, "put")
+      .mockReturnValue(successResponse);
+
+    const mockDownloadPdf = jest.spyOn(FileUtilities, "downloadPdf");
+
+    mockService.downloadTraineeCojPdf("123");
+
+    expect(mockDownloadPdf).toHaveBeenCalledWith(
+      "conditions-of-joining_123.pdf",
+      expect.objectContaining(successResponse)
+    );
+  });
+
   it("getTraineeFormRPartA method should return success response", () => {
     const successResponse: Promise<AxiosResponse<FormRPartA[]>> =
       Promise.resolve({

--- a/services/__test__/FormsService.test.ts
+++ b/services/__test__/FormsService.test.ts
@@ -5,31 +5,37 @@ import { submittedFormRPartBs } from "../../mock-data/submitted-formr-partb";
 import { errorResponse } from "../../mock-data/service-api-err-res";
 import { FormRPartB } from "../../models/FormRPartB";
 import { FormRPartA } from "../../models/FormRPartA";
-import { FileUtilities } from "../../utilities/FileUtilities";
+import { mockProgrammeMemberships } from "../../mock-data/trainee-profile";
 
 const mockService = new FormsService();
 describe("FormsService", () => {
-  it("downloadTraineeCojPdf method should download PDF from server", () => {
-    const successResponse: Promise<AxiosResponse<Blob>> = Promise.resolve({
+  it("downloadTraineeCojPdf method should download PDF from server", async () => {
+    const programmeMembership = mockProgrammeMemberships[0];
+    const successResponse: AxiosResponse<Blob> = {
       data: new Blob(),
       status: 200,
       statusText: "OK",
       headers: {},
       config: {}
-    });
+    };
 
     jest
       .spyOn(mockService.axiosInstance, "put")
-      .mockReturnValue(successResponse);
+      .mockResolvedValue(successResponse);
 
-    const mockDownloadPdf = jest.spyOn(FileUtilities, "downloadPdf");
+    const result = await mockService.downloadTraineeCojPdf(programmeMembership);
 
-    mockService.downloadTraineeCojPdf("123");
-
-    expect(mockDownloadPdf).toHaveBeenCalledWith(
-      "conditions-of-joining_123.pdf",
-      expect.objectContaining(successResponse)
+    expect(mockService.axiosInstance.put).toHaveBeenCalledWith(
+      "/coj",
+      programmeMembership,
+      {
+        headers: {
+          Accept: "application/pdf"
+        },
+        responseType: "blob"
+      }
     );
+    expect(result).toEqual(successResponse);
   });
 
   it("getTraineeFormRPartA method should return success response", () => {

--- a/utilities/FileUtilities.ts
+++ b/utilities/FileUtilities.ts
@@ -1,5 +1,8 @@
 import { AxiosResponse } from "axios";
 import { showToast, ToastType } from "../components/common/ToastMessage";
+import { FormsService } from "../services/FormsService";
+import { ProgrammeMembership } from "../models/ProgrammeMembership";
+import { FormRUtilities } from "./FormRUtilities";
 
 type PdfFunction = () => Promise<AxiosResponse<Blob>>;
 
@@ -30,5 +33,21 @@ export class FileUtilities {
         ToastType.ERROR
       );
     }
+  }
+}
+
+const formsService = new FormsService();
+export function downloadCojPdf(
+  id: string,
+  matchedPm: ProgrammeMembership | undefined,
+  setShowPdfHelp: (showPdfHelp: boolean) => void
+) {
+  if (matchedPm) {
+    FileUtilities.downloadPdf(`conditions-of-joining_${id}.pdf`, () =>
+      formsService.downloadTraineeCojPdf(matchedPm)
+    );
+  } else {
+    FormRUtilities.windowPrint();
+    return setShowPdfHelp(true);
   }
 }

--- a/utilities/__test__/FormBuilderUtilities.test.ts
+++ b/utilities/__test__/FormBuilderUtilities.test.ts
@@ -3,14 +3,21 @@ import {
   mockedCombinedReference
 } from "../../mock-data/combinedReferenceData";
 import { mockForms } from "../../mock-data/formr-list";
+import { mockTraineeProfile } from "../../mock-data/trainee-profile";
 import { CombinedReferenceData } from "../../models/CombinedReferenceData";
 import { LifeCycleState } from "../../models/LifeCycleState";
+import { updatedTraineeProfileData } from "../../redux/slices/traineeProfileSlice";
+import store from "../../redux/store/store";
 import {
   setDraftFormProps,
   transformReferenceData
 } from "../FormBuilderUtilities";
 
 describe("transformReferenceData", () => {
+  beforeEach(() => {
+    store.dispatch(updatedTraineeProfileData(mockTraineeProfile));
+  })
+
   it("should transform reference data to a new format", () => {
     const data: CombinedReferenceData = mockedCombinedReference;
     const expected = mockTransformedCombinedReferenceData;


### PR DESCRIPTION
Use the forms service to download a Conditions of Joining PDF instead of
relying on client/browser functionality.

The COJ PDF is generated on the server when signed, but past COJ have
not had PDFs generated. As such the endpoint accepts the programme
membership data as JSON, and will generated the PDF on-demand if it does
not already exist.

TIS21-6106
TIS21-6123