### PR TITLE
fix: coj e2e test

### DIFF
--- a/components/forms/form-builder/form-r/part-b/FormRPartB.tsx
+++ b/components/forms/form-builder/form-r/part-b/FormRPartB.tsx
@@ -6,7 +6,7 @@ import CreateList from "../../../CreateList";
 import { useAppSelector } from "../../../../../redux/hooks/hooks";
 import PageNotFound from "../../../../common/PageNotFound";
 import formBJson from "./formB.json";
-import FormBuilder, { Form, FormName } from "../../FormBuilder";
+import FormBuilder, { Form } from "../../FormBuilder";
 import { getFormBValidationSchema } from "./formBValidationSchema";
 import { useSelectFormData } from "../../../../../utilities/hooks/useSelectFormData";
 import { selectAllReference } from "../../../../../redux/slices/referenceSlice";
@@ -24,7 +24,7 @@ export default function FormB() {
 
   const redirectPath = "/formr-b";
   const formJson = formBJson as Form;
-  const formData = useSelectFormData(formJson.name as FormName) as FormRPartB;
+  const formData = useSelectFormData(formJson.name) as FormRPartB;
 
   const formDataWithSortedWork = {
     ...formData,

--- a/cypress/component/programmes/CoJReadOnlyView.cy.tsx
+++ b/cypress/component/programmes/CoJReadOnlyView.cy.tsx
@@ -146,6 +146,7 @@ describe("COJ Contents ReadOnly View For Gold Guide 10", () => {
         "have.attr",
         "href",
         "https://tis-support.hee.nhs.uk/trainees/how-to-save-form-as-pdf/"
-      );
+      )
+      .click();
   });
 });

--- a/cypress/e2e/formr-b/FormRB.spec.ts
+++ b/cypress/e2e/formr-b/FormRB.spec.ts
@@ -151,7 +151,6 @@ describe("Form R (Part B) - Submit a new form", () => {
       `Form submitted on: ${today.format("DD/MM/YYYY")}`
     );
     cy.checkElement("savePdfBtn");
-    cy.get(".nhsuk-action-link__text").click();
     cy.checkElement("forename-value", "Bob-edited");
     cy.checkElement("surname-value", `Smith-${today.format("YYYY-MM-DD")}`);
     cy.get('[data-cy="isDeclarationAccepted"]').should("be.checked");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.107.0",
+  "version": "0.107.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.107.0",
+      "version": "0.107.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.107.0",
+  "version": "0.107.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",


### PR DESCRIPTION
Given that the FormB test doesn't do much except click the link, the simplest fix is to move the pdfHelpLink click to a Cypress comp test that tests the same FormSavePDF comp (more reliable and better for test coverage too).

NO TICKET