### PR TITLE
feat: filter out past PM's

### DIFF
--- a/components/forms/cct/CctCalcCreate.tsx
+++ b/components/forms/cct/CctCalcCreate.tsx
@@ -37,6 +37,7 @@ import FieldWarningMsg from "../FieldWarningMsg";
 import SelectInputField from "../SelectInputField";
 import { TraineeProfileName } from "../../../models/TraineeProfile";
 import {
+  cctCalcWarningsMsgs,
   fteOptions,
   getProfilePanelFutureWarningText
 } from "../../../utilities/Constants";
@@ -63,7 +64,6 @@ export function CctCalcCreate() {
   const progsArrNotPast = useAppSelector(
     selectTraineeProfile
   ).programmeMemberships.filter(prog => !isPastIt(prog.endDate));
-  console.log("progsArrNotPast", progsArrNotPast);
   const programmeOptions = makeProgrammeOptions(progsArrNotPast);
   const [showProgModal, setShowProgModal] = useState(false);
   const handleProgModalClose = () => {
@@ -73,6 +73,8 @@ export function CctCalcCreate() {
     state => state.cct.cctCalc
   );
   const { name, created, lastModified } = initialFormData;
+  const { noActiveProgsMsg, shortNoticeMsg, wteCustomMsg, wteIncreaseMsg } =
+    cctCalcWarningsMsgs;
 
   return (
     <>
@@ -344,7 +346,9 @@ export function CctCalcCreate() {
                                                 .add(16, "week")
                                                 .subtract(1, "day") && (
                                               <span data-cy="start-short-notice-warn">
-                                                <FieldWarningMsg warningMsg="Actioning a change in WTE hours with less than 16 weeks notice might not be possible logistically (e.g. rota constraints)." />
+                                                <FieldWarningMsg
+                                                  warningMsg={shortNoticeMsg}
+                                                />
                                               </span>
                                             )}
                                         </Col>
@@ -418,7 +422,9 @@ export function CctCalcCreate() {
                                               (values.programmeMembership
                                                 .wte as number) && (
                                               <span data-cy="wte-increase-return-warn">
-                                                <FieldWarningMsg warningMsg="Actioning an increase in WTE hours needs a suitable post to be available, which might not be possible." />
+                                                <FieldWarningMsg
+                                                  warningMsg={wteIncreaseMsg}
+                                                />
                                               </span>
                                             )}
                                           {!(
@@ -433,7 +439,9 @@ export function CctCalcCreate() {
                                                   100
                                             ) && (
                                               <span data-cy="wte-custom-warn">
-                                                <FieldWarningMsg warningMsg="Actioning a custom WTE change might not be possible; it will require Dean approval." />
+                                                <FieldWarningMsg
+                                                  warningMsg={wteCustomMsg}
+                                                />
                                               </span>
                                             )}
                                         </Col>
@@ -472,10 +480,7 @@ export function CctCalcCreate() {
               )}
             </>
           ) : (
-            <p data-cy="cct-only-past-progs-msg">
-              You do not have any current, upcoming or future programmes to link
-              to a CCT calculation.
-            </p>
+            <p data-cy="cct-only-past-progs-msg">{noActiveProgsMsg}</p>
           )}
         </Card.Content>
       </Card>

--- a/components/forms/cct/CctCalcCreate.tsx
+++ b/components/forms/cct/CctCalcCreate.tsx
@@ -36,8 +36,12 @@ import { Link } from "react-router-dom";
 import FieldWarningMsg from "../FieldWarningMsg";
 import SelectInputField from "../SelectInputField";
 import { TraineeProfileName } from "../../../models/TraineeProfile";
-import { getProfilePanelFutureWarningText } from "../../../utilities/Constants";
+import {
+  fteOptions,
+  getProfilePanelFutureWarningText
+} from "../../../utilities/Constants";
 import { ProfilePanels } from "../../profile/ProfilePanels";
+import { isPastIt } from "../../../utilities/DateUtilities";
 
 type CctCalculationErrors = {
   programmeMembership?: {
@@ -54,18 +58,13 @@ type CctCalculationErrors = {
   }[];
 };
 
-const fteOptions = [
-  { value: 100, label: "100%" },
-  { value: 80, label: "80%" },
-  { value: 70, label: "70%" },
-  { value: 60, label: "60%" },
-  { value: 50, label: "50%" }
-];
-
 export function CctCalcCreate() {
   const dispatch = useAppDispatch();
-  const progsArr = useAppSelector(selectTraineeProfile).programmeMemberships;
-  const programmeOptions = makeProgrammeOptions(progsArr);
+  const progsArrNotPast = useAppSelector(
+    selectTraineeProfile
+  ).programmeMemberships.filter(prog => !isPastIt(prog.endDate));
+  console.log("progsArrNotPast", progsArrNotPast);
+  const programmeOptions = makeProgrammeOptions(progsArrNotPast);
   const [showProgModal, setShowProgModal] = useState(false);
   const handleProgModalClose = () => {
     setShowProgModal(false);
@@ -111,352 +110,372 @@ export function CctCalcCreate() {
               <Link to="/support">contact your Local Office support</Link>
             </p>
           </WarningCallout>
-          <ProgrammesModal
-            isOpen={showProgModal}
-            onClose={handleProgModalClose}
-          />
-          <Formik
-            initialValues={initialFormData}
-            validationSchema={cctValidationSchema}
-            onSubmit={(values: CctCalculation) => {
-              const newCctEndDate = calcLtftChange(
-                values.programmeMembership.endDate,
-                values.programmeMembership.wte as number,
-                values.changes[0]
-              );
-              dispatch(updatedCctCalc({ ...values, cctDate: newCctEndDate }));
-              dispatch(updatedNewCalcMade(true));
-              history.push(values.id ? `/cct/view/${values.id}` : "/cct/view");
-            }}
-          >
-            {({
-              values,
-              errors,
-              setFieldValue,
-              isValid,
-              handleSubmit,
-              resetForm,
-              dirty
-            }) => (
-              <Form data-cy="cct-calc-form">
-                <Row>
-                  <Col width="two-thirds">
-                    <Button
-                      type="button"
-                      reverse
-                      onClick={() => setShowProgModal(true)}
-                      data-cy="show-prog-modal-btn"
-                    >
-                      View your programmes & placements
-                    </Button>
-                  </Col>
-                </Row>
-                <Container>
-                  <h3
-                    className={style.panelSubHeader}
-                    data-cy="linked-prog-header"
-                  >
-                    Linked Programme
-                  </h3>
-                  <Row>
-                    <Col width="two-thirds">
-                      <AutocompleteSelect
-                        value={values.programmeMembership.id}
-                        onChange={(field, value: string) => {
-                          setFieldValue(field, value);
-                          if (value) {
-                            const selectedProgramme = findLinkedProgramme(
-                              value,
-                              progsArr
-                            );
-                            if (selectedProgramme) {
-                              setFieldValue(
-                                "programmeMembership.name",
-                                selectedProgramme.programmeName,
-                                false
-                              );
-                              setFieldValue(
-                                "programmeMembership.startDate",
-                                selectedProgramme.startDate,
-                                true
-                              );
-                              setFieldValue(
-                                "programmeMembership.endDate",
-                                selectedProgramme.endDate,
-                                false
-                              );
-                            }
-                          } else {
-                            resetForm({ values: defaultCctCalc });
-                          }
-                        }}
-                        error=""
-                        options={programmeOptions}
-                        name="programmeMembership.id"
-                        label=""
-                        isMulti={false}
-                        closeMenuOnSelect={true}
-                        defaultOption={setDefaultProgrammeOption(
-                          values.programmeMembership.id,
-                          progsArr
-                        )}
-                      />
-                    </Col>
-                  </Row>
-                  {values.programmeMembership.id && (
-                    <>
-                      <Row>
-                        <Col width="three-quarters">
-                          <Table responsive data-cy="linked-prog-table">
-                            <Table.Head>
-                              <Table.Row>
-                                <Table.Cell data-cy="table-header-linked-prog-name">
-                                  Linked Programme
-                                </Table.Cell>
-                                <Table.Cell>Start date</Table.Cell>
-                                <Table.Cell>
-                                  Current Completion date (on TIS)
-                                </Table.Cell>
-                              </Table.Row>
-                            </Table.Head>
-                            <Table.Body>
-                              <Table.Row>
-                                <Table.Cell data-cy="table-data-linked-prog-name">
-                                  {values.programmeMembership.name}
-                                </Table.Cell>
-                                <Table.Cell>
-                                  {dayjs(
-                                    values.programmeMembership.startDate
-                                  ).format("DD/MM/YYYY")}
-                                </Table.Cell>
-                                <Table.Cell>
-                                  {dayjs(
-                                    values.programmeMembership.endDate
-                                  ).format("DD/MM/YYYY")}
-                                </Table.Cell>
-                              </Table.Row>
-                            </Table.Body>
-                          </Table>
-                        </Col>
-                      </Row>
-                      <h3
-                        className={style.panelSubHeader}
-                        data-cy="currentWte-header"
-                      >
-                        Current WTE percentage
-                      </h3>
-                      <Row>
-                        <Col width="one-half">
-                          <AutocompleteSelect
-                            value={values.programmeMembership.wte}
-                            onChange={(field, value) => {
-                              const parsedValue =
-                                typeof value === "string" && value.endsWith("%")
-                                  ? Number(value.slice(0, -1))
-                                  : value;
-                              if (parsedValue) {
-                                setFieldValue(field, parsedValue / 100);
-                              } else {
-                                setFieldValue(field, null);
-                              }
-                            }}
-                            error={
-                              (
-                                errors.programmeMembership as CctCalculationErrors["programmeMembership"]
-                              )?.wte
-                            }
-                            options={fteOptions}
-                            name="programmeMembership.wte"
-                            label=""
-                            isMulti={false}
-                            closeMenuOnSelect={true}
-                            isCreatable={true}
-                            defaultOption={
-                              values.programmeMembership.wte && {
-                                value: values.programmeMembership.wte,
-                                label: `${
-                                  values.programmeMembership.wte * 100
-                                }%`
-                              }
-                            }
-                          />
-                        </Col>
-                      </Row>
-                    </>
-                  )}
-                  {values.programmeMembership.id &&
-                  values.programmeMembership.wte ? (
-                    <>
-                      <h3
-                        className={style.panelSubHeader}
-                        data-cy="proposed-changes-header"
-                      >
-                        Proposed changes
-                      </h3>
-                      <FieldArray
-                        name="changes"
-                        render={_ => (
-                          <div>
-                            {values.changes.map((_, index: number) => (
-                              <Fragment key={index}>
-                                <div
-                                  style={{
-                                    background: "#D8DDE0",
-                                    border: "solid grey 4px",
-                                    padding: "16px",
-                                    marginBottom: "16px"
-                                  }}
-                                >
-                                  <Row>
-                                    <Col width="one-quarter">
-                                      <SelectInputField
-                                        name={`changes[${index}].type`}
-                                        label="Change type"
-                                        options={[
-                                          {
-                                            value: "LTFT",
-                                            label: "WTE (e.g. LTFT)"
-                                          }
-                                        ]}
-                                        disabled={true}
-                                      />
-                                    </Col>
-                                    <Col width="one-quarter">
-                                      <TextInputField
-                                        name={`changes[${index}].startDate`}
-                                        label="Start date"
-                                        type="date"
-                                        data-cy="change-start-date"
-                                      />
-                                      {!(
-                                        errors.changes as CctCalculationErrors["changes"]
-                                      )?.[index]?.startDate &&
-                                        dayjs(values.changes[index].startDate) <
-                                          dayjs()
-                                            .add(16, "week")
-                                            .subtract(1, "day") && (
-                                          <span data-cy="start-short-notice-warn">
-                                            <FieldWarningMsg warningMsg="Actioning a change in WTE hours with less than 16 weeks notice might not be possible logistically (e.g. rota constraints)." />
-                                          </span>
-                                        )}
-                                    </Col>
-                                    <Col width="one-quarter">
-                                      {values.changes[index].type !== "LTFT" ||
-                                        (!values.changes[index].type && (
-                                          <TextInputField
-                                            name={`changes[${index}].endDate`}
-                                            label="End date"
-                                            type="date"
-                                            data-cy="change-date"
-                                          />
-                                        ))}
-                                    </Col>
-                                    <Col width="one-quarter">
-                                      {values.changes[index].type ===
-                                        "LTFT" && (
-                                        <AutocompleteSelect
-                                          value={
-                                            values.changes[index].wte ?? null
-                                          }
-                                          onChange={(field, value) => {
-                                            const parsedValue =
-                                              typeof value === "string" &&
-                                              value.endsWith("%")
-                                                ? Number(value.slice(0, -1))
-                                                : value;
-                                            if (parsedValue) {
-                                              setFieldValue(
-                                                field,
-                                                parsedValue / 100
-                                              );
-                                            } else {
-                                              setFieldValue(field, null);
-                                            }
-                                          }}
-                                          error={
-                                            errors.changes &&
-                                            (
-                                              errors.changes as CctCalculationErrors["changes"]
-                                            )?.[index]?.wte
-                                          }
-                                          options={fteOptions}
-                                          name={`changes[${index}].wte`}
-                                          label="Proposed WTE (%)"
-                                          isMulti={false}
-                                          closeMenuOnSelect={true}
-                                          isCreatable={true}
-                                          defaultOption={
-                                            values.changes[index].wte
-                                              ? {
-                                                  value:
-                                                    values.changes[index].wte,
-                                                  label: `${
-                                                    (values.changes[index]
-                                                      .wte as number) * 100
-                                                  }%`
-                                                }
-                                              : null
-                                          }
-                                        />
-                                      )}
-                                      {!(
-                                        errors.changes as CctCalculationErrors["changes"]
-                                      )?.[index]?.wte &&
-                                        (values.changes[index]?.wte as number) >
-                                          (values.programmeMembership
-                                            .wte as number) && (
-                                          <span data-cy="wte-increase-return-warn">
-                                            <FieldWarningMsg warningMsg="Actioning an increase in WTE hours needs a suitable post to be available, which might not be possible." />
-                                          </span>
-                                        )}
-                                      {!(
-                                        errors.changes as CctCalculationErrors["changes"]
-                                      )?.[index]?.wte &&
-                                        values.changes[index].wte &&
-                                        !fteOptions.some(
-                                          option =>
-                                            option.value ===
-                                            (values.changes[index]
-                                              .wte as number) *
-                                              100
-                                        ) && (
-                                          <span data-cy="wte-custom-warn">
-                                            <FieldWarningMsg warningMsg="Actioning a custom WTE change might not be possible; it will require Dean approval." />
-                                          </span>
-                                        )}
-                                    </Col>
-                                  </Row>
-                                </div>
-                              </Fragment>
-                            ))}
-                          </div>
-                        )}
-                      />
-                    </>
-                  ) : null}
-                  <br />
-                  {values.programmeMembership.id && isValid && dirty && (
+          {progsArrNotPast.length > 0 ? (
+            <>
+              <ProgrammesModal
+                isOpen={showProgModal}
+                onClose={handleProgModalClose}
+              />
+              <Formik
+                initialValues={initialFormData}
+                validationSchema={cctValidationSchema}
+                onSubmit={(values: CctCalculation) => {
+                  const newCctEndDate = calcLtftChange(
+                    values.programmeMembership.endDate,
+                    values.programmeMembership.wte as number,
+                    values.changes[0]
+                  );
+                  dispatch(
+                    updatedCctCalc({ ...values, cctDate: newCctEndDate })
+                  );
+                  dispatch(updatedNewCalcMade(true));
+                  history.push(
+                    values.id ? `/cct/view/${values.id}` : "/cct/view"
+                  );
+                }}
+              >
+                {({
+                  values,
+                  errors,
+                  setFieldValue,
+                  isValid,
+                  handleSubmit,
+                  resetForm,
+                  dirty
+                }) => (
+                  <Form data-cy="cct-calc-form">
                     <Row>
-                      <Col width="full">
+                      <Col width="two-thirds">
                         <Button
-                          data-cy="cct-calc-btn"
-                          onClick={() => handleSubmit}
+                          type="button"
+                          reverse
+                          onClick={() => setShowProgModal(true)}
+                          data-cy="show-prog-modal-btn"
                         >
-                          Calculate new completion date
+                          View your programmes & placements
                         </Button>
                       </Col>
                     </Row>
-                  )}
-                </Container>
-              </Form>
-            )}
-          </Formik>
-          {name && created && lastModified && (
-            <CalcDetails
-              created={created}
-              lastModified={lastModified}
-              name={name}
-            />
+                    <Container>
+                      <h3
+                        className={style.panelSubHeader}
+                        data-cy="linked-prog-header"
+                      >
+                        Linked Programme
+                      </h3>
+                      <Row>
+                        <Col width="two-thirds">
+                          <AutocompleteSelect
+                            value={values.programmeMembership.id}
+                            onChange={(field, value: string) => {
+                              setFieldValue(field, value);
+                              if (value) {
+                                const selectedProgramme = findLinkedProgramme(
+                                  value,
+                                  progsArrNotPast
+                                );
+                                if (selectedProgramme) {
+                                  setFieldValue(
+                                    "programmeMembership.name",
+                                    selectedProgramme.programmeName,
+                                    false
+                                  );
+                                  setFieldValue(
+                                    "programmeMembership.startDate",
+                                    selectedProgramme.startDate,
+                                    true
+                                  );
+                                  setFieldValue(
+                                    "programmeMembership.endDate",
+                                    selectedProgramme.endDate,
+                                    false
+                                  );
+                                }
+                              } else {
+                                resetForm({ values: defaultCctCalc });
+                              }
+                            }}
+                            error=""
+                            options={programmeOptions}
+                            name="programmeMembership.id"
+                            label=""
+                            isMulti={false}
+                            closeMenuOnSelect={true}
+                            defaultOption={setDefaultProgrammeOption(
+                              values.programmeMembership.id,
+                              progsArrNotPast
+                            )}
+                          />
+                        </Col>
+                      </Row>
+                      {values.programmeMembership.id && (
+                        <>
+                          <Row>
+                            <Col width="three-quarters">
+                              <Table responsive data-cy="linked-prog-table">
+                                <Table.Head>
+                                  <Table.Row>
+                                    <Table.Cell data-cy="table-header-linked-prog-name">
+                                      Linked Programme
+                                    </Table.Cell>
+                                    <Table.Cell>Start date</Table.Cell>
+                                    <Table.Cell>
+                                      Current Completion date (on TIS)
+                                    </Table.Cell>
+                                  </Table.Row>
+                                </Table.Head>
+                                <Table.Body>
+                                  <Table.Row>
+                                    <Table.Cell data-cy="table-data-linked-prog-name">
+                                      {values.programmeMembership.name}
+                                    </Table.Cell>
+                                    <Table.Cell>
+                                      {dayjs(
+                                        values.programmeMembership.startDate
+                                      ).format("DD/MM/YYYY")}
+                                    </Table.Cell>
+                                    <Table.Cell>
+                                      {dayjs(
+                                        values.programmeMembership.endDate
+                                      ).format("DD/MM/YYYY")}
+                                    </Table.Cell>
+                                  </Table.Row>
+                                </Table.Body>
+                              </Table>
+                            </Col>
+                          </Row>
+                          <h3
+                            className={style.panelSubHeader}
+                            data-cy="currentWte-header"
+                          >
+                            Current WTE percentage
+                          </h3>
+                          <Row>
+                            <Col width="one-half">
+                              <AutocompleteSelect
+                                value={values.programmeMembership.wte}
+                                onChange={(field, value) => {
+                                  const parsedValue =
+                                    typeof value === "string" &&
+                                    value.endsWith("%")
+                                      ? Number(value.slice(0, -1))
+                                      : value;
+                                  if (parsedValue) {
+                                    setFieldValue(field, parsedValue / 100);
+                                  } else {
+                                    setFieldValue(field, null);
+                                  }
+                                }}
+                                error={
+                                  (
+                                    errors.programmeMembership as CctCalculationErrors["programmeMembership"]
+                                  )?.wte
+                                }
+                                options={fteOptions}
+                                name="programmeMembership.wte"
+                                label=""
+                                isMulti={false}
+                                closeMenuOnSelect={true}
+                                isCreatable={true}
+                                defaultOption={
+                                  values.programmeMembership.wte && {
+                                    value: values.programmeMembership.wte,
+                                    label: `${
+                                      values.programmeMembership.wte * 100
+                                    }%`
+                                  }
+                                }
+                              />
+                            </Col>
+                          </Row>
+                        </>
+                      )}
+                      {values.programmeMembership.id &&
+                      values.programmeMembership.wte ? (
+                        <>
+                          <h3
+                            className={style.panelSubHeader}
+                            data-cy="proposed-changes-header"
+                          >
+                            Proposed changes
+                          </h3>
+                          <FieldArray
+                            name="changes"
+                            render={_ => (
+                              <div>
+                                {values.changes.map((_, index: number) => (
+                                  <Fragment key={index}>
+                                    <div
+                                      style={{
+                                        background: "#D8DDE0",
+                                        border: "solid grey 4px",
+                                        padding: "16px",
+                                        marginBottom: "16px"
+                                      }}
+                                    >
+                                      <Row>
+                                        <Col width="one-quarter">
+                                          <SelectInputField
+                                            name={`changes[${index}].type`}
+                                            label="Change type"
+                                            options={[
+                                              {
+                                                value: "LTFT",
+                                                label: "WTE (e.g. LTFT)"
+                                              }
+                                            ]}
+                                            disabled={true}
+                                          />
+                                        </Col>
+                                        <Col width="one-quarter">
+                                          <TextInputField
+                                            name={`changes[${index}].startDate`}
+                                            label="Start date"
+                                            type="date"
+                                            data-cy="change-start-date"
+                                          />
+                                          {!(
+                                            errors.changes as CctCalculationErrors["changes"]
+                                          )?.[index]?.startDate &&
+                                            dayjs(
+                                              values.changes[index].startDate
+                                            ) <
+                                              dayjs()
+                                                .add(16, "week")
+                                                .subtract(1, "day") && (
+                                              <span data-cy="start-short-notice-warn">
+                                                <FieldWarningMsg warningMsg="Actioning a change in WTE hours with less than 16 weeks notice might not be possible logistically (e.g. rota constraints)." />
+                                              </span>
+                                            )}
+                                        </Col>
+                                        <Col width="one-quarter">
+                                          {values.changes[index].type !==
+                                            "LTFT" ||
+                                            (!values.changes[index].type && (
+                                              <TextInputField
+                                                name={`changes[${index}].endDate`}
+                                                label="End date"
+                                                type="date"
+                                                data-cy="change-date"
+                                              />
+                                            ))}
+                                        </Col>
+                                        <Col width="one-quarter">
+                                          {values.changes[index].type ===
+                                            "LTFT" && (
+                                            <AutocompleteSelect
+                                              value={
+                                                values.changes[index].wte ??
+                                                null
+                                              }
+                                              onChange={(field, value) => {
+                                                const parsedValue =
+                                                  typeof value === "string" &&
+                                                  value.endsWith("%")
+                                                    ? Number(value.slice(0, -1))
+                                                    : value;
+                                                if (parsedValue) {
+                                                  setFieldValue(
+                                                    field,
+                                                    parsedValue / 100
+                                                  );
+                                                } else {
+                                                  setFieldValue(field, null);
+                                                }
+                                              }}
+                                              error={
+                                                errors.changes &&
+                                                (
+                                                  errors.changes as CctCalculationErrors["changes"]
+                                                )?.[index]?.wte
+                                              }
+                                              options={fteOptions}
+                                              name={`changes[${index}].wte`}
+                                              label="Proposed WTE (%)"
+                                              isMulti={false}
+                                              closeMenuOnSelect={true}
+                                              isCreatable={true}
+                                              defaultOption={
+                                                values.changes[index].wte
+                                                  ? {
+                                                      value:
+                                                        values.changes[index]
+                                                          .wte,
+                                                      label: `${
+                                                        (values.changes[index]
+                                                          .wte as number) * 100
+                                                      }%`
+                                                    }
+                                                  : null
+                                              }
+                                            />
+                                          )}
+                                          {!(
+                                            errors.changes as CctCalculationErrors["changes"]
+                                          )?.[index]?.wte &&
+                                            (values.changes[index]
+                                              ?.wte as number) >
+                                              (values.programmeMembership
+                                                .wte as number) && (
+                                              <span data-cy="wte-increase-return-warn">
+                                                <FieldWarningMsg warningMsg="Actioning an increase in WTE hours needs a suitable post to be available, which might not be possible." />
+                                              </span>
+                                            )}
+                                          {!(
+                                            errors.changes as CctCalculationErrors["changes"]
+                                          )?.[index]?.wte &&
+                                            values.changes[index].wte &&
+                                            !fteOptions.some(
+                                              option =>
+                                                option.value ===
+                                                (values.changes[index]
+                                                  .wte as number) *
+                                                  100
+                                            ) && (
+                                              <span data-cy="wte-custom-warn">
+                                                <FieldWarningMsg warningMsg="Actioning a custom WTE change might not be possible; it will require Dean approval." />
+                                              </span>
+                                            )}
+                                        </Col>
+                                      </Row>
+                                    </div>
+                                  </Fragment>
+                                ))}
+                              </div>
+                            )}
+                          />
+                        </>
+                      ) : null}
+                      <br />
+                      {values.programmeMembership.id && isValid && dirty && (
+                        <Row>
+                          <Col width="full">
+                            <Button
+                              data-cy="cct-calc-btn"
+                              onClick={() => handleSubmit}
+                            >
+                              Calculate new completion date
+                            </Button>
+                          </Col>
+                        </Row>
+                      )}
+                    </Container>
+                  </Form>
+                )}
+              </Formik>
+              {name && created && lastModified && (
+                <CalcDetails
+                  created={created}
+                  lastModified={lastModified}
+                  name={name}
+                />
+              )}
+            </>
+          ) : (
+            <p data-cy="cct-only-past-progs-msg">
+              You do not have any current, upcoming or future programmes to link
+              to a CCT calculation.
+            </p>
           )}
         </Card.Content>
       </Card>

--- a/cypress/component/forms/cct/CctCalcCreate.cy.tsx
+++ b/cypress/component/forms/cct/CctCalcCreate.cy.tsx
@@ -14,6 +14,9 @@ import {
   updatedCctCalc
 } from "../../../../redux/slices/cctSlice";
 import { mockCctCalcData1 } from "../../../../mock-data/mock-cct-data";
+import { cctCalcWarningsMsgs } from "../../../../utilities/Constants";
+
+const { noActiveProgsMsg } = cctCalcWarningsMsgs;
 
 const mountCctWithMockData = (
   profileData: TraineeProfile = mockTraineeProfile,
@@ -31,18 +34,20 @@ const mountCctWithMockData = (
 };
 
 describe("CctCalcCreate - alt msg if no/past programmes", () => {
-  const msg =
-    "You do not have any current, upcoming or future programmes to link to a CCT calculation.";
   it("doesn't render the calc form if no programmes", () => {
     mountCctWithMockData({ ...mockTraineeProfile, programmeMemberships: [] });
-    cy.get('[data-cy="cct-only-past-progs-msg"]').should("exist").contains(msg);
+    cy.get('[data-cy="cct-only-past-progs-msg"]')
+      .should("exist")
+      .contains(noActiveProgsMsg);
   });
   it("doesn't render the calc form if only past programmes", () => {
     mountCctWithMockData({
       ...mockTraineeProfile,
       programmeMemberships: [mockProgrammeMembershipsForGrouping[0]]
     });
-    cy.get('[data-cy="cct-only-past-progs-msg"]').should("exist").contains(msg);
+    cy.get('[data-cy="cct-only-past-progs-msg"]')
+      .should("exist")
+      .contains(noActiveProgsMsg);
   });
 });
 

--- a/cypress/component/forms/cct/CctCalcCreate.cy.tsx
+++ b/cypress/component/forms/cct/CctCalcCreate.cy.tsx
@@ -3,7 +3,10 @@ import { mount } from "cypress/react18";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { updatedTraineeProfileData } from "../../../../redux/slices/traineeProfileSlice";
-import { mockTraineeProfile } from "../../../../mock-data/trainee-profile";
+import {
+  mockProgrammeMembershipsForGrouping,
+  mockTraineeProfile
+} from "../../../../mock-data/trainee-profile";
 import { CctCalcCreate } from "../../../../components/forms/cct/CctCalcCreate";
 import { TraineeProfile } from "../../../../models/TraineeProfile";
 import {
@@ -26,6 +29,22 @@ const mountCctWithMockData = (
     </Provider>
   );
 };
+
+describe("CctCalcCreate - alt msg if no/past programmes", () => {
+  const msg =
+    "You do not have any current, upcoming or future programmes to link to a CCT calculation.";
+  it("doesn't render the calc form if no programmes", () => {
+    mountCctWithMockData({ ...mockTraineeProfile, programmeMemberships: [] });
+    cy.get('[data-cy="cct-only-past-progs-msg"]').should("exist").contains(msg);
+  });
+  it("doesn't render the calc form if only past programmes", () => {
+    mountCctWithMockData({
+      ...mockTraineeProfile,
+      programmeMemberships: [mockProgrammeMembershipsForGrouping[0]]
+    });
+    cy.get('[data-cy="cct-only-past-progs-msg"]').should("exist").contains(msg);
+  });
+});
 
 describe("CctCalcCreate - new", () => {
   it("renders the new cct calc form for completion", () => {

--- a/cypress/e2e/navbar/Navbar.spec.ts
+++ b/cypress/e2e/navbar/Navbar.spec.ts
@@ -28,7 +28,7 @@ describe("Desktop/ tablet header", () => {
         .contains(/Sign out/);
       if (size === mobileView) {
         cy.get(".nhsuk-header__menu-toggle").should("exist").click();
-        cy.get(':nth-child(9) > [data-cy="signOutBtn"]');
+        cy.get('[data-cy="signOutBtn"]');
       } else {
         cy.get(
           '.top-nav-container > .top-nav-container > [data-cy="signOutBtn"]'

--- a/cypress/e2e/placements/Placements.spec.ts
+++ b/cypress/e2e/placements/Placements.spec.ts
@@ -14,52 +14,8 @@ describe("Placements", () => {
     cy.get(".nhsuk-fieldset__heading")
       .should("exist")
       .should("contain.text", "Placements");
-    cy.get("[data-cy=site0Key]").should("exist");
-    cy.get("[data-cy=site0Val]").should("exist");
-    cy.get("[data-cy=siteKnownAs0Key]").should("exist");
-    cy.get("[data-cy=siteKnownAs0Val]").should("exist");
-    cy.get("[data-cy=specialty0Val]").should("exist");
-    cy.get("[data-cy=subSpecialty0Val]").should("not.exist"); //since no specialty
-
-    // CCT calc user journey from placements
-    cy.get('[data-cy="cct-link-header"]')
-      .first()
-      .contains("Need a Changing hours (LTFT) calculation?");
-    cy.get('[data-cy="cct-link"]').first().click();
-    cy.get(".nhsuk-fieldset__heading").contains(
-      "Certificate of Completion of Training (CCT)"
-    );
-    cy.get('[data-cy="cct-home-new-calc-btn"]').click();
-    cy.checkAndFillNewCctCalcForm();
-
-    // edit new wte
-    cy.get('[data-cy="cct-view-new-wte"]').contains("50%");
-    cy.get('[data-cy="cct-edit-btn"]').click();
-    cy.clickSelect('[data-cy="changes[0].wte"]', "60%");
-    cy.get('[data-cy="cct-calc-btn"]').click();
-    cy.get('[data-cy="cct-view-new-wte"]').contains("60%");
-
-    // name and save new calc
-    cy.get('[data-cy="cct-save-btn"]').should("exist").click();
-    cy.get('[data-cy="name"]').type(`😎_${dayjs().toISOString()}`, {
-      parseSpecialCharSequences: false
-    });
-    cy.get('[data-cy="cct-modal-save-btn"]').click();
-    cy.get('[data-cy="cct-home-subheader-calcs"]').contains(
-      "Saved calculations"
-    );
-    cy.get('[data-cy="1_name"]')
-      .first()
-      .should("include.text", `😎_${dayjs().format("YYYY-MM-DD")}`);
-    cy.get('[data-cy="1_name"]').first().click();
-    cy.get('[data-cy="saved-cct-details"] > :nth-child(1)').should(
-      "include.text",
-      `Name: 😎_${dayjs().format("YYYY-MM-DD")}`
-    );
-    cy.get('[data-cy="cct-save-btn"]').should("not.exist");
-    // back to cct home via nav link
-    cy.get('[data-cy="CCT"]').click();
-    cy.get('[data-cy="cct-home-subheader-calcs"]').should("exist");
+    cy.get('[data-cy="currentExpand"]').click();
+    cy.get('[data-cy="notAssignedplacements"]').should("exist");
   });
 });
 

--- a/cypress/e2e/programmes/Programmes.spec.ts
+++ b/cypress/e2e/programmes/Programmes.spec.ts
@@ -25,7 +25,7 @@ describe("Programmes", () => {
     cy.checkAndFillNewCctCalcForm();
 
     // edit new wte
-    cy.get('[data-cy="cct-view-new-wte"]').contains("50%");
+    cy.get('[data-cy="cct-view-new-wte"]').contains("90%");
     cy.get('[data-cy="cct-edit-btn"]').click();
     cy.clickSelect('[data-cy="changes[0].wte"]', "60%");
     cy.get('[data-cy="cct-calc-btn"]').click();

--- a/cypress/e2e/programmes/Programmes.spec.ts
+++ b/cypress/e2e/programmes/Programmes.spec.ts
@@ -1,6 +1,8 @@
 /// <reference types="cypress" />
 /// <reference path="../../support/index.d.ts" />
 
+import dayjs from "dayjs";
+
 describe("Programmes", () => {
   beforeEach(() => {
     cy.signInToTss(30000, "/programmes");
@@ -10,9 +12,46 @@ describe("Programmes", () => {
     cy.get('[data-cy="homeLink"]').should("exist");
     cy.get('[data-cy="homeWelcomeHeaderText"]').should("not.exist");
     cy.get(".nhsuk-fieldset__heading").should("contain.text", "Programmes");
-    // check nav to cct home
+    cy.get('[data-cy="currentExpand"]').click();
+    // CCT calc user journey from placements
+    cy.get('[data-cy="cct-link-header"]')
+      .first()
+      .contains("Need a Changing hours (LTFT) calculation?");
     cy.get('[data-cy="cct-link"]').first().click();
-    cy.url().should("include", "/cct");
+    cy.get(".nhsuk-fieldset__heading").contains(
+      "Certificate of Completion of Training (CCT)"
+    );
+    cy.get('[data-cy="cct-home-new-calc-btn"]').click();
+    cy.checkAndFillNewCctCalcForm();
+
+    // edit new wte
+    cy.get('[data-cy="cct-view-new-wte"]').contains("50%");
+    cy.get('[data-cy="cct-edit-btn"]').click();
+    cy.clickSelect('[data-cy="changes[0].wte"]', "60%");
+    cy.get('[data-cy="cct-calc-btn"]').click();
+    cy.get('[data-cy="cct-view-new-wte"]').contains("60%");
+
+    // name and save new calc
+    cy.get('[data-cy="cct-save-btn"]').should("exist").click();
+    cy.get('[data-cy="name"]').type(`😎_${dayjs().toISOString()}`, {
+      parseSpecialCharSequences: false
+    });
+    cy.get('[data-cy="cct-modal-save-btn"]').click();
+    cy.get('[data-cy="cct-home-subheader-calcs"]').contains(
+      "Saved calculations"
+    );
+    cy.get('[data-cy="0_name"]')
+      .first()
+      .should("include.text", `😎_${dayjs().format("YYYY-MM-DD")}`);
+    cy.get('[data-cy="0_name"]').first().click();
+    cy.get('[data-cy="saved-cct-details"] > :nth-child(1)').should(
+      "include.text",
+      `Name: 😎_${dayjs().format("YYYY-MM-DD")}`
+    );
+    cy.get('[data-cy="cct-save-btn"]').should("not.exist");
+    // back to cct home via nav link
+    cy.get('[data-cy="CCT"]').click();
+    cy.get('[data-cy="cct-home-subheader-calcs"]').should("exist");
   });
 });
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 import dayjs from "dayjs";
+import { cctCalcWarningsMsgs } from "../../utilities/Constants";
 
 const currentDate = dayjs().format("YYYY-MM-DD");
 const currRevalDate = dayjs().add(3, "month").format("YYYY-MM-DD");
@@ -1035,6 +1036,7 @@ Cypress.Commands.add("checkFlags", (name: string) => {
 });
 
 Cypress.Commands.add("checkAndFillNewCctCalcForm", () => {
+  const { shortNoticeMsg, wteCustomMsg, wteIncreaseMsg } = cctCalcWarningsMsgs;
   cy.get('[data-cy="backLink-to-cct-home"]').should("exist");
   cy.url().should("include", "/cct");
   cy.get('[data-cy="cct-calc-warning"]')
@@ -1088,7 +1090,9 @@ Cypress.Commands.add("checkAndFillNewCctCalcForm", () => {
     .contains("Change date cannot be before today.");
   cy.get('[data-cy="start-short-notice-warn"]').should("not.exist");
   cy.get('[data-cy="changes[0].startDate"]').type(dayjs().format("YYYY-MM-DD"));
-  cy.get('[data-cy="start-short-notice-warn"]').should("exist");
+  cy.get('[data-cy="start-short-notice-warn"]')
+    .should("exist")
+    .contains(shortNoticeMsg);
   cy.get('[data-cy="changes[0].wte"] > .nhsuk-error-message').contains(
     "Please enter a Proposed WTE"
   );
@@ -1096,6 +1100,11 @@ Cypress.Commands.add("checkAndFillNewCctCalcForm", () => {
   cy.get('[data-cy="changes[0].wte"] > .nhsuk-error-message').contains(
     "WTE values must be different"
   );
-  cy.clickSelect('[data-cy="changes[0].wte"]', null, false);
+  cy.clickSelect('[data-cy="programmeMembership.wte"]', "80%", false);
+  cy.clickSelect('[data-cy="changes[0].wte"]', "90%", false);
+  cy.get('[data-cy="wte-increase-return-warn"]')
+    .should("exist")
+    .contains(wteIncreaseMsg);
+  cy.get('[data-cy="wte-custom-warn"]').should("exist").contains(wteCustomMsg);
   cy.get('[data-cy="cct-calc-btn"]').should("exist").click();
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.108.1",
+  "version": "0.109.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/Constants.tsx
+++ b/utilities/Constants.tsx
@@ -545,3 +545,11 @@ export const getProfilePanelFutureWarningText = (
 ): string => {
   return `The information we have for future ${profileName} with a start date more than 12 weeks from today is not yet finalised and may be subject to change.`;
 };
+
+export const fteOptions = [
+  { value: 100, label: "100%" },
+  { value: 80, label: "80%" },
+  { value: 70, label: "70%" },
+  { value: 60, label: "60%" },
+  { value: 50, label: "50%" }
+];

--- a/utilities/Constants.tsx
+++ b/utilities/Constants.tsx
@@ -553,3 +553,15 @@ export const fteOptions = [
   { value: 60, label: "60%" },
   { value: 50, label: "50%" }
 ];
+
+// cct calc warning messages
+export const cctCalcWarningsMsgs = {
+  noActiveProgsMsg:
+    "You do not have any current, upcoming or future programmes to link to a CCT calculation.",
+  shortNoticeMsg:
+    "Changing your WTE hours with less than 16 week's notice may not be possible (e.g. rota constraints).",
+  wteIncreaseMsg:
+    "Increasing your WTE hours requires a suitable post to be available, which may not be possible.",
+  wteCustomMsg:
+    "A custom WTE change may not be possible; it will require Dean approval."
+};


### PR DESCRIPTION
- No past PM's are included in the CCT form 'linked programme' select options
- The CCT form is not rendered (and msg displayed instead) if there are:
1. No PM's
2. Only past PM's.

fix: e2e tests (forgot about stage data!)
1. PL/PM tests: swap the CCT calc journey from PL's to PM's which should work for now.
2. Navbar tests: target the correct element.

NO TICKET