### PR TITLE
fix: e2e webpack compile error.

### DIFF
--- a/components/forms/cct/CctCalcCreate.tsx
+++ b/components/forms/cct/CctCalcCreate.tsx
@@ -37,10 +37,10 @@ import FieldWarningMsg from "../FieldWarningMsg";
 import SelectInputField from "../SelectInputField";
 import { TraineeProfileName } from "../../../models/TraineeProfile";
 import {
-  cctCalcWarningsMsgs,
   fteOptions,
   getProfilePanelFutureWarningText
 } from "../../../utilities/Constants";
+import { cctCalcWarningsMsgs } from "../../../utilities/CctConstants";
 import { ProfilePanels } from "../../profile/ProfilePanels";
 import { isPastIt } from "../../../utilities/DateUtilities";
 

--- a/cypress/component/forms/cct/CctCalcCreate.cy.tsx
+++ b/cypress/component/forms/cct/CctCalcCreate.cy.tsx
@@ -14,7 +14,7 @@ import {
   updatedCctCalc
 } from "../../../../redux/slices/cctSlice";
 import { mockCctCalcData1 } from "../../../../mock-data/mock-cct-data";
-import { cctCalcWarningsMsgs } from "../../../../utilities/Constants";
+import { cctCalcWarningsMsgs } from "../../../../utilities/CctConstants";
 
 const { noActiveProgsMsg } = cctCalcWarningsMsgs;
 

--- a/cypress/e2e/placements/Placements.spec.ts
+++ b/cypress/e2e/placements/Placements.spec.ts
@@ -1,8 +1,6 @@
 /// <reference types="cypress" />
 /// <reference path="../../support/index.d.ts" />
 
-import dayjs from "dayjs";
-
 describe("Placements", () => {
   beforeEach(() => {
     cy.signInToTss(30000, "/placements");

--- a/cypress/e2e/programmes/Programmes.spec.ts
+++ b/cypress/e2e/programmes/Programmes.spec.ts
@@ -40,10 +40,10 @@ describe("Programmes", () => {
     cy.get('[data-cy="cct-home-subheader-calcs"]').contains(
       "Saved calculations"
     );
-    cy.get('[data-cy="0_name"]')
+    cy.get('[data-cy*="_name"]')
       .first()
       .should("include.text", `😎_${dayjs().format("YYYY-MM-DD")}`);
-    cy.get('[data-cy="0_name"]').first().click();
+    cy.get('[data-cy*="_name"]').first().click();
     cy.get('[data-cy="saved-cct-details"] > :nth-child(1)').should(
       "include.text",
       `Name: 😎_${dayjs().format("YYYY-MM-DD")}`

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 
 import dayjs from "dayjs";
-import { cctCalcWarningsMsgs } from "../../utilities/Constants";
+import { cctCalcWarningsMsgs } from "../../utilities/CctConstants";
 
 const currentDate = dayjs().format("YYYY-MM-DD");
 const currRevalDate = dayjs().add(3, "month").format("YYYY-MM-DD");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.108.0",
+  "version": "0.109.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.108.0",
+      "version": "0.109.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.109.0",
+  "version": "0.109.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/CctConstants.ts
+++ b/utilities/CctConstants.ts
@@ -1,0 +1,11 @@
+// cct calc warning messages
+export const cctCalcWarningsMsgs = {
+  noActiveProgsMsg:
+    "You do not have any current, upcoming or future programmes to link to a CCT calculation.",
+  shortNoticeMsg:
+    "Changing your WTE hours with less than 16 week's notice may not be possible (e.g. rota constraints).",
+  wteIncreaseMsg:
+    "Increasing your WTE hours requires a suitable post to be available, which may not be possible.",
+  wteCustomMsg:
+    "A custom WTE change may not be possible; it will require Dean approval."
+};

--- a/utilities/Constants.tsx
+++ b/utilities/Constants.tsx
@@ -553,15 +553,3 @@ export const fteOptions = [
   { value: 60, label: "60%" },
   { value: 50, label: "50%" }
 ];
-
-// cct calc warning messages
-export const cctCalcWarningsMsgs = {
-  noActiveProgsMsg:
-    "You do not have any current, upcoming or future programmes to link to a CCT calculation.",
-  shortNoticeMsg:
-    "Changing your WTE hours with less than 16 week's notice may not be possible (e.g. rota constraints).",
-  wteIncreaseMsg:
-    "Increasing your WTE hours requires a suitable post to be available, which may not be possible.",
-  wteCustomMsg:
-    "A custom WTE change may not be possible; it will require Dean approval."
-};


### PR DESCRIPTION
- Make new CctConstants.ts file (rather than the .tsx file that causes issue with e2e test webpack compilation) to hold the cctCalcWarningsMsgs.
- fix: the targeting of the saved cct calc from list (as we can't rely on the number prefix on stage).

Testing is 💩

NO TICKET