### PR TITLE
fix(form-r): print to PDF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.109.1",
+  "version": "0.109.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.109.1",
+      "version": "0.109.2",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.109.1",
+  "version": "0.109.2",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1138,9 +1138,6 @@ html:has(dialog[data-cy="formLinkerModal"][open]) {
 
 // used in cct calc view atm
 @media print {
-  body * {
-    visibility: hidden;
-  }
   .pdf-visible,
   .pdf-visible * {
     visibility: visible;


### PR DESCRIPTION
The Form-Rs print to PDF functionality is outputting blank pages due to a CSS change which inadvertently hides the body.
There is a `pdf-visible` class which is intended as a flag for what should be printed, but it has not yet been added to the Form-R views.

Remove the CSS change until the Form-R views can be properly flagged as PDF visible.

TIS21-6799