### PR TITLE
Refactor/form builder state management

### DIFF
--- a/components/forms/form-builder/FormArrayPanelBuilder.tsx
+++ b/components/forms/form-builder/FormArrayPanelBuilder.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Field, FieldWarning } from "./FormBuilder";
+import { Field } from "./FormBuilder";
 import { Button, Card } from "nhsuk-react-components";
 import {
   formatFieldName,

--- a/components/forms/form-builder/FormArrayPanelBuilder.tsx
+++ b/components/forms/form-builder/FormArrayPanelBuilder.tsx
@@ -6,30 +6,23 @@ import {
   showFormField
 } from "../../../utilities/FormBuilderUtilities";
 import { FormFieldBuilder } from "./FormFieldBuilder";
+import { useFormContext } from "./FormContext";
 
 type FormArrayPanelBuilderProps = {
-  fieldWarning: FieldWarning | undefined;
   field: Field;
-  setFormData: React.Dispatch<any>;
-  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
   panelErrors: any;
   options?: any;
-  formData?: any;
   isFormDirty: React.MutableRefObject<boolean>;
 };
 
 export function FormArrayPanelBuilder({
   field,
-  formData,
-  setFormData,
-  handleChange,
-  handleBlur,
   panelErrors,
-  fieldWarning,
   options,
   isFormDirty
 }: Readonly<FormArrayPanelBuilderProps>) {
+  const { formData, setFormData } = useFormContext();
+
   const newPanel = () => {
     const arrPanel = field.objectFields?.reduce((panel, objField) => {
       panel[objField.name] = "";
@@ -70,15 +63,8 @@ export function FormArrayPanelBuilder({
                     field={objField}
                     value={formData[field.name][index][objField.name] ?? ""}
                     error={panelErrors?.[index]?.[objField.name] ?? ""}
-                    fieldWarning={fieldWarning}
-                    handlers={{
-                      handleChange: handleChange,
-                      handleBlur: handleBlur,
-                      setFormData: setFormData
-                    }}
                     options={options}
                     arrayDetails={{ arrayIndex: index, arrayName: field.name }}
-                    formData={formData}
                     isFormDirty={isFormDirty}
                   />
                 ) : null}

--- a/components/forms/form-builder/FormArrayPanelBuilder.tsx
+++ b/components/forms/form-builder/FormArrayPanelBuilder.tsx
@@ -12,16 +12,14 @@ type FormArrayPanelBuilderProps = {
   field: Field;
   panelErrors: any;
   options?: any;
-  isFormDirty: React.MutableRefObject<boolean>;
 };
 
 export function FormArrayPanelBuilder({
   field,
   panelErrors,
-  options,
-  isFormDirty
+  options
 }: Readonly<FormArrayPanelBuilderProps>) {
-  const { formData, setFormData } = useFormContext();
+  const { formData, setFormData, setIsFormDirty } = useFormContext();
 
   const newPanel = () => {
     const arrPanel = field.objectFields?.reduce((panel, objField) => {
@@ -32,14 +30,14 @@ export function FormArrayPanelBuilder({
   };
 
   const addPanel = () => {
-    isFormDirty.current = true;
+    setIsFormDirty(true);
     const currentPanelsArray = formData[field.name] ?? [];
     const newPanelsArray = [...currentPanelsArray, newPanel()];
     setFormData({ ...formData, [field.name]: newPanelsArray });
   };
 
   const removePanel = (index: number) => {
-    isFormDirty.current = true;
+    setIsFormDirty(true);
     const newPanelsArray = formData[field.name].filter(
       (_arrObj: any, i: number) => i !== index
     );
@@ -65,7 +63,6 @@ export function FormArrayPanelBuilder({
                     error={panelErrors?.[index]?.[objField.name] ?? ""}
                     options={options}
                     arrayDetails={{ arrayIndex: index, arrayName: field.name }}
-                    isFormDirty={isFormDirty}
                   />
                 ) : null}
               </div>

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -93,13 +93,14 @@ type FormBuilderProps = {
   validationSchema: any;
 };
 export type MatcherName = "prevDateTest" | "postcodeTest";
-export type FieldWarning = {
-  fieldName: MatcherName;
-  warningMsg: string;
-};
 export type Warning = {
-  matcher: string;
+  matcher: MatcherName;
   msgText: string;
+};
+
+export type ReturnedWidthData = {
+  fieldName: string;
+  width: number;
 };
 
 export default function FormBuilder({
@@ -115,8 +116,6 @@ export default function FormBuilder({
     setCurrentPageFields,
     formName
   } = useFormContext();
-
-  console.log("formData in FormBuilder: ", formData);
 
   const jsonFormName = formName;
   const pages = jsonForm.pages;

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -112,10 +112,11 @@ export default function FormBuilder({
     isFormDirty,
     setIsFormDirty,
     currentPageFields,
-    setCurrentPageFields
+    setCurrentPageFields,
+    formName
   } = useFormContext();
 
-  const jsonFormName = jsonForm.name;
+  const jsonFormName = formName;
   const pages = jsonForm.pages;
   const lastPage = pages.length - 1;
   const initialPageValue = getEditPageNumber(jsonFormName);

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -153,7 +153,6 @@ export default function FormBuilder({
     validateFields(currentPageFields, formData, validationSchema)
       .then(() => {
         if (currentPage === lastPage || canEditStatus) {
-          console.log("form data for reviewing: ", formData);
           continueToConfirm(jsonFormName, formData);
         } else {
           setCurrentPage(currentPage + 1);
@@ -170,7 +169,6 @@ export default function FormBuilder({
   const handleSaveBtnClick = () => {
     setIsSubmitting(true);
     saveDraftForm(jsonFormName, formData);
-    console.log("form data for saving", formData);
     setIsSubmitting(false);
   };
 

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -122,14 +122,13 @@ export default function FormBuilder({
   const [currentPage, setCurrentPage] = useState(initialPageValue);
   const [formErrors, setFormErrors] = useState<any>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const canEditStatus = useAppSelector(state => state[jsonFormName].canEdit);
 
   useEffect(() => {
     setCurrentPageFields(
       pages[currentPage].sections.flatMap((section: Section) => section.fields)
     );
   }, [currentPage, pages, formData]);
-
-  const canEditStatus = useAppSelector(state => state[jsonFormName].canEdit);
 
   useEffect(() => {
     if (isFormDirty) {
@@ -151,7 +150,7 @@ export default function FormBuilder({
     setIsFormDirty(false);
     validateFields(currentPageFields, formData, validationSchema)
       .then(() => {
-        if (currentPage === lastPage) {
+        if (currentPage === lastPage || canEditStatus) {
           console.log("form data for reviewing: ", formData);
           continueToConfirm(jsonFormName, formData);
         } else {
@@ -284,20 +283,17 @@ export default function FormBuilder({
       </nav>
       <Container>
         <Row>
-          {/* {canEditStatus && (
+          {canEditStatus && (
             <Col width="one-half">
               <Button
-                onClick={(e: { preventDefault: () => void }) => {
-                  e.preventDefault();
-                  handleShortcutToConfirm();
-                }}
+                onClick={handlePageChange}
                 data-cy="BtnShortcutToConfirm"
                 disabled={Object.keys(formErrors).length > 0}
               >
                 {"Shortcut to Confirm"}
               </Button>
             </Col>
-          )} */}
+          )}
           <Col width="one-quarter">
             <Button
               secondary

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -116,6 +116,8 @@ export default function FormBuilder({
     formName
   } = useFormContext();
 
+  console.log("formData in FormBuilder: ", formData);
+
   const jsonFormName = formName;
   const pages = jsonForm.pages;
   const lastPage = pages.length - 1;
@@ -129,7 +131,7 @@ export default function FormBuilder({
     setCurrentPageFields(
       pages[currentPage].sections.flatMap((section: Section) => section.fields)
     );
-  }, [currentPage, pages, formData]);
+  }, [currentPage, pages, formData, setCurrentPageFields]);
 
   useEffect(() => {
     if (isFormDirty) {
@@ -144,7 +146,7 @@ export default function FormBuilder({
           });
         });
     }
-  }, [formData, currentPageFields, validationSchema]);
+  }, [formData, currentPageFields, validationSchema, isFormDirty]);
 
   const handlePageChange = (e: { preventDefault: () => void }) => {
     e.preventDefault();

--- a/components/forms/form-builder/FormContext.tsx
+++ b/components/forms/form-builder/FormContext.tsx
@@ -4,6 +4,10 @@ import {
   determineCurrentValue,
   sumFieldValues
 } from "../../../utilities/FormBuilderUtilities";
+import useFormAutosave from "../../../utilities/hooks/useFormAutosave";
+import { FormRPartA } from "../../../models/FormRPartA";
+import { FormRPartB } from "../../../models/FormRPartB";
+import { LtftObj } from "../../../redux/slices/ltftSlice";
 
 type FormContextType = {
   formData: FormData;
@@ -51,6 +55,12 @@ export const FormProvider: React.FC<FormProviderProps> = ({
   const [isFormDirty, setIsFormDirty] = useState<boolean>(false);
   const [currentPageFields, setCurrentPageFields] =
     useState<Field[]>(initialPageFields);
+
+  useFormAutosave(
+    formName,
+    formData as FormRPartA | FormRPartB | LtftObj,
+    isFormDirty
+  );
 
   const handleBlur = (event: any) => {
     const { name, value } = event.currentTarget;

--- a/components/forms/form-builder/FormContext.tsx
+++ b/components/forms/form-builder/FormContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState } from "react";
-import { Field, FormData } from "./FormBuilder";
+import { Field, FormData, FormName } from "./FormBuilder";
 import {
   determineCurrentValue,
   sumFieldValues
@@ -21,6 +21,7 @@ type FormContextType = {
   setIsFormDirty: React.Dispatch<React.SetStateAction<boolean>>;
   currentPageFields: Field[];
   setCurrentPageFields: React.Dispatch<React.SetStateAction<Field[]>>;
+  formName: FormName;
 };
 
 const FormContext = createContext<FormContextType | undefined>(undefined);
@@ -36,13 +37,15 @@ export const useFormContext = () => {
 type FormProviderProps = {
   initialData: FormData;
   initialPageFields: Field[];
+  formName: FormName;
   children: React.ReactNode;
 };
 
 export const FormProvider: React.FC<FormProviderProps> = ({
   children,
   initialData,
-  initialPageFields
+  initialPageFields,
+  formName
 }) => {
   const [formData, setFormData] = useState<FormData>(initialData);
   const [isFormDirty, setIsFormDirty] = useState<boolean>(false);
@@ -120,7 +123,8 @@ export const FormProvider: React.FC<FormProviderProps> = ({
       isFormDirty,
       setIsFormDirty,
       currentPageFields,
-      setCurrentPageFields
+      setCurrentPageFields,
+      formName
     }),
     [formData, isFormDirty, currentPageFields]
   );

--- a/components/forms/form-builder/FormContext.tsx
+++ b/components/forms/form-builder/FormContext.tsx
@@ -1,0 +1,99 @@
+import React, { createContext, useContext, useState } from "react";
+import { FormData } from "./FormBuilder";
+import {
+  determineCurrentValue
+  // updateFormData
+} from "../../../utilities/FormBuilderUtilities";
+
+type FormContextType = {
+  formData: FormData;
+  setFormData: React.Dispatch<React.SetStateAction<FormData>>;
+  handleChange: (
+    event: any,
+    selectedOption?: any,
+    checkedStatus?: boolean,
+    arrayIndex?: number,
+    arrayName?: string,
+    dtoName?: string
+  ) => void;
+  handleBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
+};
+
+const FormContext = createContext<FormContextType | undefined>(undefined);
+
+export const useFormContext = () => {
+  const context = useContext(FormContext);
+  if (!context) {
+    throw new Error("useFormContext must be used within a FormProvider");
+  }
+  return context;
+};
+
+type FormProviderProps = {
+  initialData: FormData;
+  children: React.ReactNode;
+};
+
+export const FormProvider: React.FC<FormProviderProps> = ({
+  children,
+  initialData
+}) => {
+  const [formData, setFormData] = useState<FormData>(initialData);
+
+  const handleBlur = (event: any) => {
+    const { name, value } = event.currentTarget;
+    setFormData((formData: FormData) => {
+      return { ...formData, [name]: value.trim() };
+    });
+  };
+
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    selectedOption?: any,
+    checkedStatus?: boolean,
+    arrayIndex?: number,
+    arrayName?: string,
+    dtoName?: string
+  ) => {
+    const name = event.currentTarget.name;
+    const currentValue = determineCurrentValue(
+      event,
+      selectedOption,
+      checkedStatus
+    );
+
+    setFormData(formData => {
+      if (typeof arrayIndex === "number" && arrayName) {
+        const newArray = [...(formData[arrayName] || [])];
+        newArray[arrayIndex] = {
+          ...newArray[arrayIndex],
+          [name]: currentValue
+        };
+        return { ...formData, [arrayName]: newArray };
+      } else if (dtoName) {
+        const dto = formData[dtoName] || {};
+        const updatedDto = {
+          ...dto,
+          [name]: currentValue
+        };
+        return { ...formData, [dtoName]: updatedDto };
+      } else {
+        return { ...formData, [name]: currentValue };
+      }
+    });
+  };
+
+  const contextValue = React.useMemo(
+    () => ({
+      formData,
+      setFormData,
+      handleChange,
+      handleBlur
+    }),
+    [formData]
+  );
+
+  return (
+    <FormContext.Provider value={contextValue}>{children}</FormContext.Provider>
+  );
+};

--- a/components/forms/form-builder/FormContext.tsx
+++ b/components/forms/form-builder/FormContext.tsx
@@ -17,6 +17,8 @@ type FormContextType = {
     dtoName?: string
   ) => void;
   handleBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
+  isFormDirty: boolean;
+  setIsFormDirty: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const FormContext = createContext<FormContextType | undefined>(undefined);
@@ -39,6 +41,7 @@ export const FormProvider: React.FC<FormProviderProps> = ({
   initialData
 }) => {
   const [formData, setFormData] = useState<FormData>(initialData);
+  const [isFormDirty, setIsFormDirty] = useState<boolean>(false);
 
   const handleBlur = (event: any) => {
     const { name, value } = event.currentTarget;
@@ -81,6 +84,7 @@ export const FormProvider: React.FC<FormProviderProps> = ({
         return { ...formData, [name]: currentValue };
       }
     });
+    setIsFormDirty(true);
   };
 
   const contextValue = React.useMemo(
@@ -88,9 +92,11 @@ export const FormProvider: React.FC<FormProviderProps> = ({
       formData,
       setFormData,
       handleChange,
-      handleBlur
+      handleBlur,
+      isFormDirty,
+      setIsFormDirty
     }),
-    [formData]
+    [formData, isFormDirty]
   );
 
   return (

--- a/components/forms/form-builder/FormDtoBuilder.tsx
+++ b/components/forms/form-builder/FormDtoBuilder.tsx
@@ -2,30 +2,22 @@ import React from "react";
 import { Field, FieldWarning } from "./FormBuilder";
 import { showFormField } from "../../../utilities/FormBuilderUtilities";
 import { FormFieldBuilder } from "./FormFieldBuilder";
+import { useFormContext } from "./FormContext";
 
 type FormDtoBuilderProps = {
   field: Field;
-  formData: any;
-  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
-  setFormData: React.Dispatch<any>;
   dtoErrors: any;
   options?: any;
-  fieldWarning: FieldWarning | undefined;
   isFormDirty: React.MutableRefObject<boolean>;
 };
 
 export function FormDtoBuilder({
   field,
-  formData,
-  handleChange,
-  handleBlur,
-  setFormData,
   dtoErrors,
   options,
-  fieldWarning,
   isFormDirty
 }: Readonly<FormDtoBuilderProps>) {
+  const { formData } = useFormContext();
   return (
     <div>
       <h2>{field.label}</h2>
@@ -36,11 +28,8 @@ export function FormDtoBuilder({
               field={objField}
               value={formData[field.name][objField.name]}
               error={dtoErrors?.[objField.name]}
-              fieldWarning={fieldWarning}
-              handlers={{ handleChange, handleBlur, setFormData }}
               options={options}
               dtoName={field.name}
-              formData={formData}
               isFormDirty={isFormDirty}
             />
           ) : null}

--- a/components/forms/form-builder/FormDtoBuilder.tsx
+++ b/components/forms/form-builder/FormDtoBuilder.tsx
@@ -8,14 +8,12 @@ type FormDtoBuilderProps = {
   field: Field;
   dtoErrors: any;
   options?: any;
-  isFormDirty: React.MutableRefObject<boolean>;
 };
 
 export function FormDtoBuilder({
   field,
   dtoErrors,
-  options,
-  isFormDirty
+  options
 }: Readonly<FormDtoBuilderProps>) {
   const { formData } = useFormContext();
   return (
@@ -30,7 +28,6 @@ export function FormDtoBuilder({
               error={dtoErrors?.[objField.name]}
               options={options}
               dtoName={field.name}
-              isFormDirty={isFormDirty}
             />
           ) : null}
         </div>

--- a/components/forms/form-builder/FormDtoBuilder.tsx
+++ b/components/forms/form-builder/FormDtoBuilder.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Field, FieldWarning } from "./FormBuilder";
+import { Field } from "./FormBuilder";
 import { showFormField } from "../../../utilities/FormBuilderUtilities";
 import { FormFieldBuilder } from "./FormFieldBuilder";
 import { useFormContext } from "./FormContext";

--- a/components/forms/form-builder/FormFieldBuilder.tsx
+++ b/components/forms/form-builder/FormFieldBuilder.tsx
@@ -15,16 +15,9 @@ type FormFieldBuilderProps = {
   field: Field;
   value: any;
   error: string;
-  fieldWarning: FieldWarning | undefined;
-  handlers: {
-    handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-    handleBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
-    setFormData: React.Dispatch<any>;
-  };
   options?: any;
   arrayDetails?: { arrayIndex: number; arrayName: string };
   dtoName?: string;
-  formData?: any;
   isFormDirty: React.MutableRefObject<boolean>;
 };
 
@@ -32,12 +25,9 @@ export function FormFieldBuilder({
   field,
   value,
   error,
-  fieldWarning,
-  handlers,
   options,
   arrayDetails,
   dtoName,
-  formData,
   isFormDirty
 }: Readonly<FormFieldBuilderProps>) {
   const {
@@ -53,7 +43,6 @@ export function FormFieldBuilder({
     rows,
     isMultiSelect
   } = field;
-  const { handleChange, handleBlur, setFormData } = handlers;
   const { arrayIndex, arrayName } = arrayDetails ?? {};
 
   switch (type) {
@@ -61,13 +50,8 @@ export function FormFieldBuilder({
       return (
         <FormArrayPanelBuilder
           field={field}
-          setFormData={setFormData}
-          handleChange={handleChange}
-          handleBlur={handleBlur}
           panelErrors={error}
-          fieldWarning={fieldWarning}
           options={options}
-          formData={formData}
           isFormDirty={isFormDirty}
         />
       );
@@ -75,13 +59,8 @@ export function FormFieldBuilder({
       return (
         <FormDtoBuilder
           field={field}
-          formData={formData}
-          setFormData={setFormData}
-          handleChange={handleChange}
-          handleBlur={handleBlur}
           dtoErrors={error}
           options={options}
-          fieldWarning={fieldWarning}
           isFormDirty={isFormDirty}
         />
       );
@@ -90,11 +69,8 @@ export function FormFieldBuilder({
         <Text
           name={name}
           label={label}
-          handleChange={handleChange}
           fieldError={error}
-          fieldWarning={fieldWarning}
           placeholder={placeholder}
-          handleBlur={handleBlur}
           value={value}
           arrayIndex={arrayIndex}
           arrayName={arrayName}
@@ -110,10 +86,8 @@ export function FormFieldBuilder({
         <TextArea
           name={name}
           label={label}
-          handleChange={handleChange}
           fieldError={error}
           placeholder={placeholder}
-          handleBlur={handleBlur}
           value={value}
           arrayIndex={arrayIndex}
           arrayName={arrayName}
@@ -128,7 +102,6 @@ export function FormFieldBuilder({
           name={name}
           label={label}
           options={filteredOptions(optionsKey, options)}
-          handleChange={handleChange}
           fieldError={error}
           value={value}
           arrayIndex={arrayIndex}
@@ -143,7 +116,6 @@ export function FormFieldBuilder({
           name={name}
           label={label}
           options={filteredOptions(optionsKey, options)}
-          handleChange={handleChange}
           fieldError={error}
           value={value}
           arrayIndex={arrayIndex}
@@ -158,14 +130,12 @@ export function FormFieldBuilder({
         <Dates
           name={name}
           label={label}
-          handleChange={handleChange}
           fieldError={error}
           placeholder={placeholder}
           value={value}
           arrayIndex={arrayIndex}
           arrayName={arrayName}
           dtoName={dtoName}
-          fieldWarning={fieldWarning}
         />
       );
 
@@ -174,7 +144,6 @@ export function FormFieldBuilder({
         <Phone
           name={name}
           label={label}
-          handleChange={handleChange}
           fieldError={error}
           value={value}
           arrayIndex={arrayIndex}
@@ -187,7 +156,6 @@ export function FormFieldBuilder({
         <Checkboxes
           name={name}
           label={label}
-          handleChange={handleChange}
           fieldError={error}
           value={value}
           arrayIndex={arrayIndex}

--- a/components/forms/form-builder/FormFieldBuilder.tsx
+++ b/components/forms/form-builder/FormFieldBuilder.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Field, FieldWarning } from "./FormBuilder";
+import { Field } from "./FormBuilder";
 import { FormDtoBuilder } from "./FormDtoBuilder";
 import { Text } from "./form-fields/Text";
 import { TextArea } from "./form-fields/TextArea";

--- a/components/forms/form-builder/FormFieldBuilder.tsx
+++ b/components/forms/form-builder/FormFieldBuilder.tsx
@@ -18,7 +18,6 @@ type FormFieldBuilderProps = {
   options?: any;
   arrayDetails?: { arrayIndex: number; arrayName: string };
   dtoName?: string;
-  isFormDirty: React.MutableRefObject<boolean>;
 };
 
 export function FormFieldBuilder({
@@ -27,8 +26,7 @@ export function FormFieldBuilder({
   error,
   options,
   arrayDetails,
-  dtoName,
-  isFormDirty
+  dtoName
 }: Readonly<FormFieldBuilderProps>) {
   const {
     name,
@@ -52,17 +50,11 @@ export function FormFieldBuilder({
           field={field}
           panelErrors={error}
           options={options}
-          isFormDirty={isFormDirty}
         />
       );
     case "dto":
       return (
-        <FormDtoBuilder
-          field={field}
-          dtoErrors={error}
-          options={options}
-          isFormDirty={isFormDirty}
-        />
+        <FormDtoBuilder field={field} dtoErrors={error} options={options} />
       );
     case "text":
       return (

--- a/components/forms/form-builder/FormView.tsx
+++ b/components/forms/form-builder/FormView.tsx
@@ -165,7 +165,7 @@ export const FormView = ({
                 secondary
                 onClick={() => {
                   setIsSubmitting(true);
-                  saveDraftForm(formName, formData, history);
+                  saveDraftForm(formName, formData);
                 }}
                 disabled={isSubmitting}
                 data-cy="BtnSaveDraft"

--- a/components/forms/form-builder/form-fields/Checkboxes.tsx
+++ b/components/forms/form-builder/form-fields/Checkboxes.tsx
@@ -1,18 +1,11 @@
 import React from "react";
 import { handleKeyDown } from "../../../../utilities/FormBuilderUtilities";
 import FieldErrorInline from "./FieldErrorInline";
+import { useFormContext } from "../FormContext";
 
 type CheckboxesProps = {
   name: string;
   label: string | undefined;
-  handleChange: (
-    event: any,
-    selectedOption?: any,
-    checkedStatus?: boolean,
-    arrayIndex?: number,
-    arrayName?: string,
-    dtoName?: string
-  ) => void;
   fieldError: string;
   placeholder?: string;
   value: string;
@@ -24,7 +17,6 @@ type CheckboxesProps = {
 export const Checkboxes: React.FC<CheckboxesProps> = ({
   name,
   label,
-  handleChange,
   fieldError,
   placeholder,
   value,
@@ -32,6 +24,7 @@ export const Checkboxes: React.FC<CheckboxesProps> = ({
   arrayName,
   dtoName
 }: CheckboxesProps) => {
+  const { handleChange } = useFormContext();
   return (
     <div className="nhsuk-checkboxes">
       <div className="nhsuk-checkboxes__item">

--- a/components/forms/form-builder/form-fields/Dates.tsx
+++ b/components/forms/form-builder/form-fields/Dates.tsx
@@ -1,6 +1,5 @@
 import { handleKeyDown } from "../../../../utilities/FormBuilderUtilities";
 import FieldWarningMsg from "../../FieldWarningMsg";
-import { FieldWarning } from "../FormBuilder";
 import { useFormContext } from "../FormContext";
 import FieldErrorInline from "./FieldErrorInline";
 
@@ -13,7 +12,6 @@ type DatesProps = {
   arrayIndex?: number;
   arrayName?: string;
   dtoName?: string;
-  fieldWarning?: FieldWarning;
 };
 
 export const Dates = ({
@@ -24,10 +22,9 @@ export const Dates = ({
   value,
   arrayIndex,
   arrayName,
-  dtoName,
-  fieldWarning
+  dtoName
 }: DatesProps) => {
-  const { handleChange } = useFormContext();
+  const { handleBlur, handleChange, fieldWarning } = useFormContext();
   return (
     <div data-cy={name}>
       <label className="nhsuk-label" htmlFor={name} data-cy={`${name}-label`}>
@@ -49,6 +46,16 @@ export const Dates = ({
             dtoName
           );
         }}
+        onBlur={(event: React.FocusEvent<HTMLInputElement>) =>
+          handleBlur(
+            event,
+            undefined,
+            undefined,
+            arrayIndex,
+            arrayName,
+            dtoName
+          )
+        }
         className={`nhsuk-input nhsuk-input--width-20 ${
           fieldError ? "nhsuk-input--error" : ""
         }`}
@@ -59,7 +66,7 @@ export const Dates = ({
       {fieldError && (
         <FieldErrorInline fieldError={fieldError} fieldName={name} />
       )}
-      {fieldWarning?.fieldName === name ? (
+      {fieldWarning?.fieldName === name && !fieldError ? (
         <FieldWarningMsg warningMsg={fieldWarning?.warningMsg} />
       ) : null}
     </div>

--- a/components/forms/form-builder/form-fields/Dates.tsx
+++ b/components/forms/form-builder/form-fields/Dates.tsx
@@ -1,19 +1,12 @@
 import { handleKeyDown } from "../../../../utilities/FormBuilderUtilities";
 import FieldWarningMsg from "../../FieldWarningMsg";
 import { FieldWarning } from "../FormBuilder";
+import { useFormContext } from "../FormContext";
 import FieldErrorInline from "./FieldErrorInline";
 
 type DatesProps = {
   name: string;
   label: string | undefined;
-  handleChange: (
-    event: any,
-    selectedOption?: any,
-    checkedStatus?: boolean,
-    arrayIndex?: number,
-    arrayName?: string,
-    dtoName?: string
-  ) => void;
   fieldError: string;
   placeholder?: string;
   value: string;
@@ -26,7 +19,6 @@ type DatesProps = {
 export const Dates = ({
   name,
   label,
-  handleChange,
   fieldError,
   placeholder,
   value,
@@ -35,6 +27,7 @@ export const Dates = ({
   dtoName,
   fieldWarning
 }: DatesProps) => {
+  const { handleChange } = useFormContext();
   return (
     <div data-cy={name}>
       <label className="nhsuk-label" htmlFor={name} data-cy={`${name}-label`}>

--- a/components/forms/form-builder/form-fields/Phone.tsx
+++ b/components/forms/form-builder/form-fields/Phone.tsx
@@ -2,18 +2,11 @@ import React from "react";
 import { handleKeyDown } from "../../../../utilities/FormBuilderUtilities";
 import PhoneInput from "react-phone-number-input";
 import FieldErrorInline from "./FieldErrorInline";
+import { useFormContext } from "../FormContext";
 
 type PhoneProps = {
   name: string;
   label: string | undefined;
-  handleChange: (
-    event: any,
-    selectedOption?: any,
-    checkedStatus?: boolean,
-    arrayIndex?: number,
-    arrayName?: string,
-    dtoName?: string
-  ) => void;
   fieldError: string;
   value: string;
   arrayIndex?: number;
@@ -24,13 +17,13 @@ type PhoneProps = {
 export const Phone = ({
   name,
   label,
-  handleChange,
   fieldError,
   value,
   arrayIndex,
   arrayName,
   dtoName
 }: PhoneProps) => {
+  const { handleChange } = useFormContext();
   return (
     <div data-cy={name}>
       <label className="nhsuk-label" htmlFor={name} data-cy={`${name}-label`}>

--- a/components/forms/form-builder/form-fields/Radios.tsx
+++ b/components/forms/form-builder/form-fields/Radios.tsx
@@ -1,19 +1,12 @@
 import React from "react";
 import { handleKeyDown } from "../../../../utilities/FormBuilderUtilities";
 import FieldErrorInline from "./FieldErrorInline";
+import { useFormContext } from "../FormContext";
 
 type RadiosProps = {
   name: string;
   label: string | undefined;
   options: any;
-  handleChange: (
-    event: any,
-    selectedOption?: any,
-    checkedStatus?: boolean,
-    arrayIndex?: number,
-    arrayName?: string,
-    dtoName?: string
-  ) => void;
   fieldError: string;
   value: string | boolean | null;
   arrayIndex?: number;
@@ -25,13 +18,13 @@ export const Radios: React.FC<RadiosProps> = ({
   name,
   label,
   options,
-  handleChange,
   fieldError,
   value,
   arrayIndex,
   arrayName,
   dtoName
 }: RadiosProps) => {
+  const { handleChange } = useFormContext();
   return (
     <div className="nhsuk-radios">
       <label className="nhsuk-label" htmlFor={name} data-cy={`${name}-label`}>

--- a/components/forms/form-builder/form-fields/Selector.tsx
+++ b/components/forms/form-builder/form-fields/Selector.tsx
@@ -5,19 +5,12 @@ import {
   handleKeyDown
 } from "../../../../utilities/FormBuilderUtilities";
 import FieldErrorInline from "./FieldErrorInline";
+import { useFormContext } from "../FormContext";
 
 type SelectorProps = {
   name: string;
   label: string | undefined;
   options: any;
-  handleChange: (
-    event: any,
-    selectedOption?: any,
-    checkedStatus?: boolean,
-    arrayIndex?: number,
-    arrayName?: string,
-    dtoName?: string
-  ) => void;
   fieldError: string;
   value: string | string[];
   arrayIndex?: number;
@@ -30,7 +23,6 @@ export const Selector = ({
   name,
   label,
   options,
-  handleChange,
   fieldError,
   value,
   arrayIndex,
@@ -38,6 +30,7 @@ export const Selector = ({
   dtoName,
   isMultiSelect
 }: SelectorProps) => {
+  const { handleChange } = useFormContext();
   return (
     <div data-cy={name}>
       <label className="nhsuk-label" htmlFor={name} data-cy={`${name}-label`}>

--- a/components/forms/form-builder/form-fields/Text.tsx
+++ b/components/forms/form-builder/form-fields/Text.tsx
@@ -6,22 +6,14 @@ import {
 import FieldWarningMsg from "../../FieldWarningMsg";
 import { FieldWarning } from "../FormBuilder";
 import FieldErrorInline from "./FieldErrorInline";
+import { useFormContext } from "../FormContext";
 
 type TextProps = {
   name: string;
   label: string | undefined;
-  handleChange: (
-    event: any,
-    selectedOption?: any,
-    checkedStatus?: boolean,
-    index?: number | undefined,
-    name?: string | undefined,
-    dtoName?: string
-  ) => void;
   fieldError: string;
   placeholder?: string;
   fieldWarning?: FieldWarning;
-  handleBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
   value: string;
   arrayIndex?: number;
   arrayName?: string;
@@ -35,11 +27,9 @@ type TextProps = {
 export const Text: React.FC<TextProps> = ({
   name,
   label,
-  handleChange,
   fieldError,
   placeholder,
   fieldWarning,
-  handleBlur,
   value,
   arrayIndex,
   arrayName,
@@ -49,6 +39,7 @@ export const Text: React.FC<TextProps> = ({
   readOnly,
   dtoName
 }: TextProps) => {
+  const { handleBlur, handleChange } = useFormContext();
   return (
     <>
       <label className="nhsuk-label" htmlFor={name} data-cy={`${name}-label`}>

--- a/components/forms/form-builder/form-fields/Text.tsx
+++ b/components/forms/form-builder/form-fields/Text.tsx
@@ -4,7 +4,6 @@ import {
   handleNumberInput
 } from "../../../../utilities/FormBuilderUtilities";
 import FieldWarningMsg from "../../FieldWarningMsg";
-import { FieldWarning } from "../FormBuilder";
 import FieldErrorInline from "./FieldErrorInline";
 import { useFormContext } from "../FormContext";
 
@@ -13,7 +12,6 @@ type TextProps = {
   label: string | undefined;
   fieldError: string;
   placeholder?: string;
-  fieldWarning?: FieldWarning;
   value: string;
   arrayIndex?: number;
   arrayName?: string;
@@ -29,17 +27,17 @@ export const Text: React.FC<TextProps> = ({
   label,
   fieldError,
   placeholder,
-  fieldWarning,
   value,
   arrayIndex,
   arrayName,
-  width,
+  width = 20,
   isNumberField,
   isTotal,
   readOnly,
   dtoName
 }: TextProps) => {
-  const { handleBlur, handleChange } = useFormContext();
+  const { handleBlur, handleChange, fieldWarning, fieldWidthData } =
+    useFormContext();
   return (
     <>
       <label className="nhsuk-label" htmlFor={name} data-cy={`${name}-label`}>
@@ -62,9 +60,11 @@ export const Text: React.FC<TextProps> = ({
             dtoName
           )
         }
-        className={`nhsuk-input nhsuk-input--width-${width ?? 20} ${
-          fieldError ? "nhsuk-input--error" : ""
-        } ${isTotal ? "total-field" : ""}`}
+        className={`nhsuk-input nhsuk-input--width-${
+          fieldWidthData?.fieldName === name ? fieldWidthData.width : width
+        } ${fieldError ? "nhsuk-input--error" : ""} ${
+          isTotal ? "total-field" : ""
+        }`}
         placeholder={placeholder}
         aria-labelledby={`${name}--label`}
         onBlur={(event: React.FocusEvent<HTMLInputElement>) =>
@@ -77,14 +77,13 @@ export const Text: React.FC<TextProps> = ({
             dtoName
           )
         }
-        width={width}
         maxLength={isNumberField ? 4 : 4096}
         readOnly={readOnly}
       />
       {fieldError && (
         <FieldErrorInline fieldError={fieldError} fieldName={name} />
       )}
-      {fieldWarning?.fieldName === name ? (
+      {fieldWarning?.fieldName === name && !fieldError ? (
         <FieldWarningMsg warningMsg={fieldWarning?.warningMsg} />
       ) : null}
     </>

--- a/components/forms/form-builder/form-fields/Text.tsx
+++ b/components/forms/form-builder/form-fields/Text.tsx
@@ -52,23 +52,31 @@ export const Text: React.FC<TextProps> = ({
         type="text"
         name={name}
         value={value ?? ""}
-        onChange={
-          ((event: any) =>
-            handleChange(
-              event,
-              undefined,
-              undefined,
-              arrayIndex,
-              arrayName,
-              dtoName
-            )) as any
+        onChange={(event: any) =>
+          handleChange(
+            event,
+            undefined,
+            undefined,
+            arrayIndex,
+            arrayName,
+            dtoName
+          )
         }
         className={`nhsuk-input nhsuk-input--width-${width ?? 20} ${
           fieldError ? "nhsuk-input--error" : ""
         } ${isTotal ? "total-field" : ""}`}
         placeholder={placeholder}
         aria-labelledby={`${name}--label`}
-        onBlur={handleBlur}
+        onBlur={(event: React.FocusEvent<HTMLInputElement>) =>
+          handleBlur(
+            event,
+            undefined,
+            undefined,
+            arrayIndex,
+            arrayName,
+            dtoName
+          )
+        }
         width={width}
         maxLength={isNumberField ? 4 : 4096}
         readOnly={readOnly}

--- a/components/forms/form-builder/form-fields/TextArea.tsx
+++ b/components/forms/form-builder/form-fields/TextArea.tsx
@@ -1,21 +1,13 @@
 import { Textarea } from "nhsuk-react-components";
 import { handleKeyDown } from "../../../../utilities/FormBuilderUtilities";
 import FieldErrorInline from "./FieldErrorInline";
+import { useFormContext } from "../FormContext";
 
 type TextAreaProps = {
   name: string;
   label: string | undefined;
-  handleChange: (
-    event: any,
-    selectedOption?: any,
-    checkedStatus?: boolean,
-    index?: number | undefined,
-    name?: string | undefined,
-    dtoName?: string
-  ) => void;
   fieldError: string;
   placeholder?: string;
-  handleBlur: (event: any) => void;
   value: string;
   arrayIndex?: number;
   arrayName?: string;
@@ -26,16 +18,15 @@ type TextAreaProps = {
 export const TextArea: React.FC<TextAreaProps> = ({
   name,
   label,
-  handleChange,
   fieldError,
   placeholder,
-  handleBlur,
   value,
   arrayIndex,
   arrayName,
   rows,
   dtoName
 }: TextAreaProps) => {
+  const { handleBlur, handleChange } = useFormContext();
   return (
     <>
       <label className="nhsuk-label" htmlFor={name} data-cy={`${name}-label`}>
@@ -48,7 +39,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
         value={value ?? ""}
         onChange={event =>
           handleChange(
-            event,
+            event as any,
             undefined,
             undefined,
             arrayIndex,
@@ -56,7 +47,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
             dtoName
           )
         }
-        onBlur={handleBlur}
+        onBlur={handleBlur as any}
         placeholder={placeholder}
         rows={rows ?? 10}
         spellCheck={true}

--- a/components/forms/form-builder/form-r/part-a/FormRPartA.tsx
+++ b/components/forms/form-builder/form-r/part-a/FormRPartA.tsx
@@ -19,7 +19,6 @@ import {
   selectCurriculumOptions
 } from "../../../../../redux/slices/referenceSlice";
 import { FORMR_PARTA_DECLARATIONS } from "../../../../../utilities/Constants";
-import history from "../../../../navigation/history";
 import { FormRPartA } from "../../../../../models/FormRPartA";
 import { FormProvider } from "../../FormContext";
 
@@ -44,6 +43,9 @@ export default function FormA() {
   const preferredMfa = useAppSelector(state => state.user.preferredMfa);
   const canEditStatus = useAppSelector(state => state.formA.canEdit);
   const formJson = formAJson as Form;
+  const initialPageFields = formJson.pages[0].sections.flatMap(
+    section => section.fields
+  );
   const redirectPath = "/formr-a";
 
   if (preferredMfa === "NOMFA") {
@@ -76,12 +78,14 @@ export default function FormA() {
           path="/formr-a/create"
           render={() => {
             return formData.traineeTisId ? (
-              <FormProvider initialData={formData}>
+              <FormProvider
+                initialData={formData}
+                initialPageFields={initialPageFields}
+              >
                 <FormBuilder
                   jsonForm={formJson}
                   options={formOptions}
                   validationSchema={formAValidationSchema}
-                  history={history}
                 />
               </FormProvider>
             ) : (

--- a/components/forms/form-builder/form-r/part-a/FormRPartA.tsx
+++ b/components/forms/form-builder/form-r/part-a/FormRPartA.tsx
@@ -21,6 +21,7 @@ import {
 import { FORMR_PARTA_DECLARATIONS } from "../../../../../utilities/Constants";
 import history from "../../../../navigation/history";
 import { FormRPartA } from "../../../../../models/FormRPartA";
+import { FormProvider } from "../../FormContext";
 
 export default function FormA() {
   const formData = useSelectFormData(formAJson.name as FormName) as FormRPartA;
@@ -75,12 +76,14 @@ export default function FormA() {
           path="/formr-a/create"
           render={() => {
             return formData.traineeTisId ? (
-              <FormBuilder
-                jsonForm={formJson}
-                options={formOptions}
-                validationSchema={formAValidationSchema}
-                history={history}
-              />
+              <FormProvider initialData={formData}>
+                <FormBuilder
+                  jsonForm={formJson}
+                  options={formOptions}
+                  validationSchema={formAValidationSchema}
+                  history={history}
+                />
+              </FormProvider>
             ) : (
               <Redirect to={redirectPath} />
             );

--- a/components/forms/form-builder/form-r/part-a/FormRPartA.tsx
+++ b/components/forms/form-builder/form-r/part-a/FormRPartA.tsx
@@ -81,6 +81,7 @@ export default function FormA() {
               <FormProvider
                 initialData={formData}
                 initialPageFields={initialPageFields}
+                formName={formJson.name}
               >
                 <FormBuilder
                   jsonForm={formJson}

--- a/components/forms/form-builder/form-r/part-a/FormRPartA.tsx
+++ b/components/forms/form-builder/form-r/part-a/FormRPartA.tsx
@@ -77,7 +77,6 @@ export default function FormA() {
             return formData.traineeTisId ? (
               <FormBuilder
                 jsonForm={formJson}
-                fetchedFormData={formData}
                 options={formOptions}
                 validationSchema={formAValidationSchema}
                 history={history}

--- a/components/forms/form-builder/form-r/part-a/FormRPartA.tsx
+++ b/components/forms/form-builder/form-r/part-a/FormRPartA.tsx
@@ -48,9 +48,8 @@ export default function FormA() {
   );
   const redirectPath = "/formr-a";
 
-  if (preferredMfa === "NOMFA") {
-    return <Redirect to="/mfa" />;
-  }
+  if (preferredMfa === "NOMFA") return <Redirect to="/mfa" />;
+
   return (
     <>
       <PageTitle title="Form R Part-A" />

--- a/components/forms/form-builder/form-r/part-b/FormRPartB.tsx
+++ b/components/forms/form-builder/form-r/part-b/FormRPartB.tsx
@@ -12,11 +12,11 @@ import { useSelectFormData } from "../../../../../utilities/hooks/useSelectFormD
 import { selectAllReference } from "../../../../../redux/slices/referenceSlice";
 import { DesignatedBodyKeyValue } from "../../../../../models/DesignatedBodyKeyValue";
 import { transformReferenceData } from "../../../../../utilities/FormBuilderUtilities";
-import history from "../../../../navigation/history";
 import { FormView } from "../../FormView";
 import { FormRPartB } from "../../../../../models/FormRPartB";
 import { COVID_RESULT_DECLARATIONS } from "../../../../../utilities/Constants";
 import { ProfileUtilities } from "../../../../../utilities/ProfileUtilities";
+import { FormProvider } from "../../FormContext";
 
 export default function FormB() {
   const preferredMfa = useAppSelector(state => state.user.preferredMfa);
@@ -25,6 +25,9 @@ export default function FormB() {
   const redirectPath = "/formr-b";
   const formJson = formBJson as Form;
   const formData = useSelectFormData(formJson.name) as FormRPartB;
+  const initialPageFields = formJson.pages[0].sections.flatMap(
+    section => section.fields
+  );
 
   const formDataWithSortedWork = {
     ...formData,
@@ -97,13 +100,16 @@ export default function FormB() {
           path="/formr-b/create"
           render={() => {
             return formData.traineeTisId ? (
-              <FormBuilder
-                jsonForm={finalFormJson}
-                fetchedFormData={formDataWithSortedWork}
-                options={formOptions}
-                validationSchema={formValidationSchema}
-                history={history}
-              />
+              <FormProvider
+                initialData={formDataWithSortedWork}
+                initialPageFields={initialPageFields}
+              >
+                <FormBuilder
+                  jsonForm={finalFormJson}
+                  options={formOptions}
+                  validationSchema={formValidationSchema}
+                />
+              </FormProvider>
             ) : (
               <Redirect to={redirectPath} />
             );

--- a/components/forms/form-builder/form-r/part-b/FormRPartB.tsx
+++ b/components/forms/form-builder/form-r/part-b/FormRPartB.tsx
@@ -103,6 +103,7 @@ export default function FormB() {
               <FormProvider
                 initialData={formDataWithSortedWork}
                 initialPageFields={initialPageFields}
+                formName={formJson.name}
               >
                 <FormBuilder
                   jsonForm={finalFormJson}

--- a/components/forms/ltft/LtftForm.tsx
+++ b/components/forms/ltft/LtftForm.tsx
@@ -52,6 +52,7 @@ export function LtftForm() {
       <FormProvider
         initialData={formData}
         initialPageFields={initialPageFields}
+        formName={ltftJson.name as FormName}
       >
         <FormBuilder
           jsonForm={formJson}

--- a/components/forms/ltft/LtftForm.tsx
+++ b/components/forms/ltft/LtftForm.tsx
@@ -1,7 +1,6 @@
 import { LtftObj } from "../../../redux/slices/ltftSlice";
 import { useSelectFormData } from "../../../utilities/hooks/useSelectFormData";
 import ErrorPage from "../../common/ErrorPage";
-import history from "../../navigation/history";
 import FormBuilder, { Form, FormName } from "../form-builder/FormBuilder";
 import { FormProvider } from "../form-builder/FormContext";
 import ltftJson from "./ltft.json";
@@ -10,6 +9,9 @@ import { ltftValidationSchema } from "./ltftValidationSchema";
 export function LtftForm() {
   const formData = useSelectFormData(ltftJson.name as FormName) as LtftObj;
   const formJson = ltftJson as Form;
+  const initialPageFields = formJson.pages[0].sections.flatMap(
+    section => section.fields
+  );
   const yesNo = [
     { value: "Yes", label: "Yes" },
     { value: "No", label: "No" }
@@ -47,12 +49,14 @@ export function LtftForm() {
   return formData?.declarations.discussedWithTpd ? (
     <div>
       <h2>Main application form</h2>
-      <FormProvider initialData={formData}>
+      <FormProvider
+        initialData={formData}
+        initialPageFields={initialPageFields}
+      >
         <FormBuilder
           jsonForm={formJson}
           options={{ yesNo, ltftReasons, ltftRoles }}
           validationSchema={ltftValidationSchema}
-          history={history}
         />
       </FormProvider>
     </div>

--- a/components/forms/ltft/LtftForm.tsx
+++ b/components/forms/ltft/LtftForm.tsx
@@ -3,6 +3,7 @@ import { useSelectFormData } from "../../../utilities/hooks/useSelectFormData";
 import ErrorPage from "../../common/ErrorPage";
 import history from "../../navigation/history";
 import FormBuilder, { Form, FormName } from "../form-builder/FormBuilder";
+import { FormProvider } from "../form-builder/FormContext";
 import ltftJson from "./ltft.json";
 import { ltftValidationSchema } from "./ltftValidationSchema";
 
@@ -46,13 +47,14 @@ export function LtftForm() {
   return formData?.declarations.discussedWithTpd ? (
     <div>
       <h2>Main application form</h2>
-      <FormBuilder
-        jsonForm={formJson}
-        fetchedFormData={formData}
-        options={{ yesNo, ltftReasons, ltftRoles }}
-        validationSchema={ltftValidationSchema}
-        history={history}
-      />
+      <FormProvider initialData={formData}>
+        <FormBuilder
+          jsonForm={formJson}
+          options={{ yesNo, ltftReasons, ltftRoles }}
+          validationSchema={ltftValidationSchema}
+          history={history}
+        />
+      </FormProvider>
     </div>
   ) : (
     <ErrorPage message="Please try again" />

--- a/cypress/component/forms/formr-part-a/FormA.cy.tsx
+++ b/cypress/component/forms/formr-part-a/FormA.cy.tsx
@@ -20,6 +20,9 @@ import {
 import { ProfileToFormRPartAInitialValues } from "../../../../models/ProfileToFormRPartAInitialValues";
 import { mockTraineeProfile } from "../../../../mock-data/trainee-profile";
 import { submittedFormRPartAs } from "../../../../mock-data/submitted-formr-parta";
+import { FormProvider } from "../../../../components/forms/form-builder/FormContext";
+import formAJson from "../../../../components/forms/form-builder/form-r/part-a/formA.json";
+import { Field } from "../../../../components/forms/form-builder/FormBuilder";
 
 describe("FormA", () => {
   beforeEach(() => {
@@ -35,10 +38,19 @@ describe("FormA", () => {
     const initialisedFormAData =
       ProfileToFormRPartAInitialValues(mockTraineeProfile);
     store.dispatch(updatedFormA(initialisedFormAData));
+    const initialPageFields = formAJson.pages[0].sections.flatMap(
+      section => section.fields as Field[]
+    );
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/formr-a/create"]}>
-          <FormA />
+          <FormProvider
+            initialData={initialisedFormAData}
+            initialPageFields={initialPageFields}
+            formName="formA"
+          >
+            <FormA />
+          </FormProvider>
         </MemoryRouter>
       </Provider>
     );

--- a/cypress/component/forms/formr-part-b/FormB.cy.tsx
+++ b/cypress/component/forms/formr-part-b/FormB.cy.tsx
@@ -25,8 +25,13 @@ import {
   mockTraineeProfileFormBCovid
 } from "../../../../mock-data/trainee-profile";
 import { submittedFormRPartBs } from "../../../../mock-data/submitted-formr-partb";
+import { FormProvider } from "../../../../components/forms/form-builder/FormContext";
+import { FormRPartB } from "../../../../models/FormRPartB";
+import formBJson from "../../../../components/forms/form-builder/form-r/part-b/formB.json";
+import { Field } from "../../../../components/forms/form-builder/FormBuilder";
 
 describe("FormB /create (without Covid)", () => {
+  let initialFormBData: FormRPartB;
   beforeEach(() => {
     store.dispatch(
       updatedCurriculumOptions(mockedCombinedReference.curriculumOptions)
@@ -35,17 +40,26 @@ describe("FormB /create (without Covid)", () => {
       updatedReference(transformReferenceData(mockedCombinedReference))
     );
     store.dispatch(updatedPreferredMfa("SMS"));
-    const initialFormBData = ProfileToFormRPartBInitialValues(
+    initialFormBData = ProfileToFormRPartBInitialValues(
       mockTraineeProfileFormB
     );
     store.dispatch(updatedFormB(initialFormBData));
   });
 
   it("should render FormB", () => {
+    const initialPageFields = formBJson.pages[0].sections.flatMap(
+      section => section.fields as Field[]
+    );
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/formr-b/create"]}>
-          <FormB />
+          <FormProvider
+            initialData={initialFormBData}
+            initialPageFields={initialPageFields}
+            formName="formB"
+          >
+            <FormB />
+          </FormProvider>
         </MemoryRouter>
       </Provider>
     );

--- a/cypress/component/forms/ltft/LtftForm.cy.tsx
+++ b/cypress/component/forms/ltft/LtftForm.cy.tsx
@@ -5,13 +5,25 @@ import { MemoryRouter } from "react-router-dom";
 import { mockLtftDraft0 } from "../../../../mock-data/mock-ltft-data";
 import { LtftForm } from "../../../../components/forms/ltft/LtftForm";
 import { updatedLtft } from "../../../../redux/slices/ltftSlice";
+import { FormProvider } from "../../../../components/forms/form-builder/FormContext";
+import ltftJson from "../../../../components/forms/ltft/ltft.json";
+import { Field } from "../../../../components/forms/form-builder/FormBuilder";
 
 const mountLtftWithMockData = () => {
   store.dispatch(updatedLtft(mockLtftDraft0));
+  const initialPageFields = ltftJson.pages[0].sections.flatMap(
+    section => section.fields as Field[]
+  );
   mount(
     <Provider store={store}>
       <MemoryRouter initialEntries={["/ltft/create"]}>
-        <LtftForm />
+        <FormProvider
+          initialData={mockLtftDraft0}
+          initialPageFields={initialPageFields}
+          formName="ltft"
+        >
+          <LtftForm />
+        </FormProvider>
       </MemoryRouter>
     </Provider>
   );

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -259,7 +259,11 @@ Cypress.Commands.add("checkAndFillFormASection1", () => {
     "have.text",
     "Warning: Non-UK postcode detected. Please ignore if valid."
   );
-
+  cy.get('[data-cy="postCode-input"]').clear();
+  cy.get(".field-warning-msg").should("not.exist");
+  cy.get('[data-cy="postCode-inline-error-msg"]').should("exist");
+  cy.clearAndType('[data-cy="postCode-input"]', "123456");
+  cy.get(".field-warning-msg").should("exist");
   cy.get('[data-cy="postCode-inline-error-msg"]').should("not.exist");
 
   // check disabled next button

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.110.0",
+      "version": "0.110.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -148,11 +148,18 @@ const ltftSlice = createSlice({
     },
     updatedLtft(state, action: PayloadAction<LtftObj>) {
       state.formData = action.payload;
+    },
+    updatedCanEditLtft(state, action: PayloadAction<boolean>) {
+      state.canEdit = action.payload;
     }
   }
 });
 
-export const { resetToInit, setLtftCctSnapshot, updatedLtft } =
-  ltftSlice.actions;
+export const {
+  resetToInit,
+  setLtftCctSnapshot,
+  updatedLtft,
+  updatedCanEditLtft
+} = ltftSlice.actions;
 
 export default ltftSlice.reducer;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -304,7 +304,8 @@ button:disabled {
 
 // field warning
 .field-warning-container {
-  padding-bottom: 1.5rem;
+  margin: 0.5rem 0 0 0;
+  padding-bottom: 0.5rem;
   text-align: left;
   display: flex;
 }

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -42,7 +42,11 @@ import { IFormR } from "../models/IFormR";
 import dayjs from "dayjs";
 import { LinkedFormRDataType } from "../components/forms/form-linker/FormLinkerForm";
 import history from "../components/navigation/history";
-import { LtftObj } from "../redux/slices/ltftSlice";
+import {
+  LtftObj,
+  updatedCanEditLtft,
+  updatedLtft
+} from "../redux/slices/ltftSlice";
 
 export function mapItemToNewFormat(item: KeyValue): {
   value: string;
@@ -264,7 +268,7 @@ export function continueToConfirm(formName: string, formData: FormData) {
       updatedCanEditB
     );
   } else if (formName === "ltft") {
-    // dispatchUpdateActions(formData as LtftObj, updatedLtft, updatedCanEditLtft);
+    dispatchUpdateActions(formData as LtftObj, updatedLtft, updatedCanEditLtft);
   }
   history.push(redirectPath);
 }

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -17,7 +17,6 @@ import {
 import store from "../redux/store/store";
 import {
   Field,
-  FieldWarning,
   Form,
   FormData,
   FormName,
@@ -330,12 +329,17 @@ export function transformReferenceData(
   return transformedData;
 }
 
+export type ReturnedWarning = {
+  fieldName: string;
+  warningMsg: string;
+};
+
 export function showFieldMatchWarning(
   inputValue: string,
   matcher: MatcherName,
   warningMsg: string,
   fieldName: string
-) {
+): ReturnedWarning | null {
   if (matcher === "prevDateTest") {
     const testDate = dayjs().subtract(1, "day");
     const inputDate = dayjs(inputValue);
@@ -348,39 +352,8 @@ export function showFieldMatchWarning(
   return null;
 }
 
-export function handleSoftValidationWarningMsgVisibility(
-  inputVal: string,
-  primaryFormField: Field | undefined,
-  fieldName: string,
-  setFieldWarning: (warning: FieldWarning) => void
-) {
-  if (inputVal?.length && primaryFormField?.warning) {
-    const matcher = primaryFormField.warning.matcher as MatcherName;
-    const msg = primaryFormField.warning.msgText;
-    const warning = showFieldMatchWarning(inputVal, matcher, msg, fieldName);
-    setFieldWarning(warning as FieldWarning);
-  }
-}
-
 export function setTextFieldWidth(width: number) {
   return width < 20 ? 20 : Math.floor(width / 10) * 10;
-}
-
-export function handleTextFieldWidth(
-  event: React.ChangeEvent<
-    HTMLInputElement | HTMLSelectElement | HTMLDivElement
-  >,
-  currentValue: string,
-  primaryField: Field | undefined
-) {
-  if (
-    primaryField?.type === "text" &&
-    currentValue.length >= 20 &&
-    primaryField?.canGrow
-  ) {
-    const thisFieldWidth = setTextFieldWidth(currentValue?.length);
-    event.currentTarget.className = `nhsuk-input nhsuk-input--width-${thisFieldWidth}`;
-  }
 }
 
 export function handleKeyDown(

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -635,11 +635,10 @@ export const updateFormData = (
   name: string,
   currentValue: any,
   setFormData: React.Dispatch<React.SetStateAction<FormData>>,
-  arrayIndex: number | undefined,
-  arrayName: string | undefined,
-  dtoName: string | undefined
+  arrayIndex?: number,
+  arrayName?: string,
+  dtoName?: string
 ) => {
-  let updatedFormData: FormData = {};
   if (typeof arrayIndex === "number" && arrayName) {
     setFormData((prevFormData: FormData) => {
       const newArray = [...prevFormData[arrayName]];
@@ -647,8 +646,7 @@ export const updateFormData = (
         ...newArray[arrayIndex],
         [name]: currentValue
       };
-      updatedFormData = { ...prevFormData, [arrayName]: newArray };
-      return updatedFormData;
+      return { ...prevFormData, [arrayName]: newArray };
     });
   } else if (dtoName) {
     setFormData((prevFormData: FormData) => {
@@ -657,19 +655,11 @@ export const updateFormData = (
         ...dto,
         [name]: currentValue
       };
-      updatedFormData = {
-        ...prevFormData,
-        [dtoName]: updatedDto
-      };
-      return updatedFormData;
+      return { ...prevFormData, [dtoName]: updatedDto };
     });
   } else {
     setFormData((prevFormData: FormData) => {
-      updatedFormData = {
-        ...prevFormData,
-        [name]: currentValue
-      };
-      return updatedFormData;
+      return { ...prevFormData, [name]: currentValue };
     });
   }
 };
@@ -767,3 +757,5 @@ export const colourStyles = {
     maxWidth: "100%"
   })
 };
+
+export const handlePageChange = () => "page change";

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -631,39 +631,6 @@ export const determineCurrentValue = (
   }
 };
 
-export const updateFormData = (
-  name: string,
-  currentValue: any,
-  setFormData: React.Dispatch<React.SetStateAction<FormData>>,
-  arrayIndex?: number,
-  arrayName?: string,
-  dtoName?: string
-) => {
-  if (typeof arrayIndex === "number" && arrayName) {
-    setFormData((prevFormData: FormData) => {
-      const newArray = [...prevFormData[arrayName]];
-      newArray[arrayIndex] = {
-        ...newArray[arrayIndex],
-        [name]: currentValue
-      };
-      return { ...prevFormData, [arrayName]: newArray };
-    });
-  } else if (dtoName) {
-    setFormData((prevFormData: FormData) => {
-      const dto = prevFormData[dtoName];
-      const updatedDto = {
-        ...dto,
-        [name]: currentValue
-      };
-      return { ...prevFormData, [dtoName]: updatedDto };
-    });
-  } else {
-    setFormData((prevFormData: FormData) => {
-      return { ...prevFormData, [name]: currentValue };
-    });
-  }
-};
-
 export const updateTotalField = (
   totalName: string,
   currentPageFields: Field[],
@@ -757,5 +724,3 @@ export const colourStyles = {
     maxWidth: "100%"
   })
 };
-
-export const handlePageChange = () => "page change";

--- a/utilities/hooks/useFormAutosave.ts
+++ b/utilities/hooks/useFormAutosave.ts
@@ -1,25 +1,27 @@
-import { MutableRefObject, useEffect, useState } from "react";
-import { autosaveFormR } from "../FormBuilderUtilities";
+import { useEffect } from "react";
+import { autosaveFormR } from "../../utilities/FormBuilderUtilities";
+import { FormName } from "../../components/forms/form-builder/FormBuilder";
+import { FormRPartA } from "../../models/FormRPartA";
+import { FormRPartB } from "../../models/FormRPartB";
+import { LtftObj } from "../../redux/slices/ltftSlice";
 
 const useFormAutosave = (
-  fetchedFormData: any,
-  formName: string,
-  isFormDirty: MutableRefObject<boolean>
+  formName: FormName,
+  formData: FormRPartA | FormRPartB | LtftObj,
+  isFormDirty: boolean
 ) => {
-  const [formData, setFormData] = useState(fetchedFormData);
-
   useEffect(() => {
-    if (isFormDirty.current) {
+    // TODO needs ltft implementation
+    if (isFormDirty && formName !== "ltft") {
       const timeoutId = setTimeout(() => {
-        autosaveFormR(formName, formData);
+        autosaveFormR(formName, formData as FormRPartA | FormRPartB);
       }, 2000);
+
       return () => {
         clearTimeout(timeoutId);
       };
     }
-  }, [formData]);
-
-  return { formData, setFormData };
+  }, [formData, formName, isFormDirty]);
 };
 
 export default useFormAutosave;


### PR DESCRIPTION
Separate the form rendering from the form state management by creating a FormProvider to manage formData and other related state. This makes the FormBuilder easier to maintain and will help when creating the LTFT logic.

This ticket should result in no difference in functionality for FormRs.

(Note: the error state is still handled in the FormBuilder atm)  

TIS21-6972