### PR TITLE
Feat/ltft summary

### DIFF
--- a/components/forms/ltft/LtftHome.tsx
+++ b/components/forms/ltft/LtftHome.tsx
@@ -1,12 +1,28 @@
 import { Button, Card, Col, Container, Row } from "nhsuk-react-components";
 import { LtftTracker } from "./LtftTracker";
 import history from "../../navigation/history";
-import { LtftSummaryObj } from "../../../redux/slices/ltftSummaryListSlice";
+import {
+  fetchLtftSummaryList,
+  LtftSummaryObj
+} from "../../../redux/slices/ltftSummaryListSlice";
+import { useAppDispatch, useAppSelector } from "../../../redux/hooks/hooks";
+import useIsBetaTester from "../../../utilities/hooks/useIsBetaTester";
+import { useEffect } from "react";
+import LtftSummary from "./LtftSummary";
 
 //TODO temp - refactor when BE is ready
 const draftOrUnsubmittedLtftSummary = undefined;
 
 export function LtftHome() {
+  const dispatch = useAppDispatch();
+  const isBetaTester = useIsBetaTester();
+  useEffect(() => {
+    if (isBetaTester) dispatch(fetchLtftSummaryList());
+  }, [dispatch, isBetaTester]);
+  const ltftSummaryList = useAppSelector(
+    state => state.ltftSummaryList?.ltftList || []
+  );
+
   return (
     <>
       <Card>
@@ -31,7 +47,7 @@ export function LtftHome() {
           <Card.Heading data-cy="ltft-summary-header">
             Previous applications summary
           </Card.Heading>
-          <p>No previous applications</p>
+          <LtftSummary ltftSummaryList={ltftSummaryList} />
         </Card.Content>
       </Card>
     </>

--- a/components/forms/ltft/LtftHome.tsx
+++ b/components/forms/ltft/LtftHome.tsx
@@ -1,28 +1,13 @@
 import { Button, Card, Col, Container, Row } from "nhsuk-react-components";
 import { LtftTracker } from "./LtftTracker";
 import history from "../../navigation/history";
-import {
-  fetchLtftSummaryList,
-  LtftSummaryObj
-} from "../../../redux/slices/ltftSummaryListSlice";
-import { useAppDispatch, useAppSelector } from "../../../redux/hooks/hooks";
-import useIsBetaTester from "../../../utilities/hooks/useIsBetaTester";
-import { useEffect } from "react";
+import { LtftSummaryObj } from "../../../redux/slices/ltftSummaryListSlice";
 import LtftSummary from "./LtftSummary";
 
 //TODO temp - refactor when BE is ready
 const draftOrUnsubmittedLtftSummary = undefined;
 
 export function LtftHome() {
-  const dispatch = useAppDispatch();
-  const isBetaTester = useIsBetaTester();
-  useEffect(() => {
-    if (isBetaTester) dispatch(fetchLtftSummaryList());
-  }, [dispatch, isBetaTester]);
-  const ltftSummaryList = useAppSelector(
-    state => state.ltftSummaryList?.ltftList || []
-  );
-
   return (
     <>
       <Card>
@@ -47,7 +32,7 @@ export function LtftHome() {
           <Card.Heading data-cy="ltft-summary-header">
             Previous applications summary
           </Card.Heading>
-          <LtftSummary ltftSummaryList={ltftSummaryList} />
+          <LtftSummary />
         </Card.Content>
       </Card>
     </>

--- a/components/forms/ltft/LtftHome.tsx
+++ b/components/forms/ltft/LtftHome.tsx
@@ -1,4 +1,11 @@
-import { Button, Card, Col, Container, Row } from "nhsuk-react-components";
+import {
+  Button,
+  Card,
+  Col,
+  Container,
+  Row,
+  WarningCallout
+} from "nhsuk-react-components";
 import { LtftTracker } from "./LtftTracker";
 import history from "../../navigation/history";
 import { LtftSummaryObj } from "../../../redux/slices/ltftSummaryListSlice";
@@ -29,6 +36,16 @@ export function LtftHome() {
       </Card>
       <Card>
         <Card.Content>
+          <WarningCallout data-cy="ltftWarning">
+            <WarningCallout.Label visuallyHiddenText={false}>
+              For Demonstration Only
+            </WarningCallout.Label>
+            <p>
+              The table below has <strong>dummy data</strong> and is read only
+              for demonstrating the future layout of the LTFT Applications
+              Summary.
+            </p>
+          </WarningCallout>
           <Card.Heading data-cy="ltft-summary-header">
             Previous applications summary
           </Card.Heading>

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -1,5 +1,8 @@
 import { Table } from "nhsuk-react-components";
-import { fetchLtftSummaryList } from "../../../redux/slices/ltftSummaryListSlice";
+import {
+  fetchLtftSummaryList,
+  LtftSummaryObj
+} from "../../../redux/slices/ltftSummaryListSlice";
 import { DateUtilities } from "../../../utilities/DateUtilities";
 import { useEffect, useState } from "react";
 import { Button, CheckboxField } from "@aws-amplify/ui-react";
@@ -7,17 +10,26 @@ import { useAppDispatch, useAppSelector } from "../../../redux/hooks/hooks";
 import useIsBetaTester from "../../../utilities/hooks/useIsBetaTester";
 import Loading from "../../common/Loading";
 import history from "../../navigation/history";
+import { mockLtftsList1 } from "../../../mock-data/mock-ltft-data";
 
-const LtftSummary = () => {
+type LtftSummaryProps = {
+  ltftSummaryList?: LtftSummaryObj[];
+};
+
+const LtftSummary = ({ ltftSummaryList }: Readonly<LtftSummaryProps>) => {
   const dispatch = useAppDispatch();
   const isBetaTester = useIsBetaTester();
   useEffect(() => {
     if (isBetaTester) dispatch(fetchLtftSummaryList());
   }, [dispatch, isBetaTester]);
-  const ltftSummaryList = useAppSelector(
-    state => state.ltftSummaryList?.ltftList || []
-  );
-  const ltftListStatus = useAppSelector(state => state.ltftSummaryList?.status);
+
+  // TODO: remove the mock data mockLtftsList1 and resume the data from useAppSelector when ready
+  // const ltftSummaryList = useAppSelector(
+  //   state => state.ltftSummaryList?.ltftList || []
+  // );
+  // const ltftListStatus = useAppSelector(state => state.ltftSummaryList?.status);
+  ltftSummaryList = mockLtftsList1;
+  const ltftListStatus = "succeeded";
 
   const ltftSummaries = ltftSummaryList || [];
   const [showSubmitted, setShowSubmitted] = useState(true);
@@ -50,6 +62,7 @@ const LtftSummary = () => {
       <>
         <div>
           <CheckboxField
+            data-cy="filterApprovedLtft"
             name="yesToShowApproved"
             value="yes"
             label="APPROVED"
@@ -59,6 +72,7 @@ const LtftSummary = () => {
             }
           />
           <CheckboxField
+            data-cy="filterSubmittedLtft"
             name="yesToShowSubmitted"
             value="yes"
             label="SUBMITTED"
@@ -68,6 +82,7 @@ const LtftSummary = () => {
             }
           />
           <CheckboxField
+            data-cy="filterWithdrawnLtft"
             name="yesToShowWithdrawn"
             value="yes"
             label="WITHDRAWN"
@@ -81,9 +96,9 @@ const LtftSummary = () => {
               <Table.Row>
                 <Table.Cell>Name</Table.Cell>
                 <Table.Cell>Created date</Table.Cell>
-                <Table.Cell>Last Modified date</Table.Cell>
                 <Table.Cell>Status</Table.Cell>
-                <Table.Cell>Operation</Table.Cell>
+                <Table.Cell>Status date</Table.Cell>
+                <Table.Cell>Operations</Table.Cell>
               </Table.Row>
             </Table.Head>
             <Table.Body>
@@ -91,20 +106,20 @@ const LtftSummary = () => {
                 return (
                   <Table.Row
                     key={index}
-                    onClick={e => {
-                      e.stopPropagation();
-                      // history.push(`/cct/view/${row.original.id}`);
-                      history.push(`/cct/view/67a22bbaac62fa4e421baa50`);
-                    }}
+                    // TODO: click to show LTFT details
+                    // onClick={e => {
+                    //   e.stopPropagation();
+                    //   history.push(`/ltft/view/${row.original.id}`);
+                    // }}
                   >
                     <Table.Cell>{item.name}</Table.Cell>
                     <Table.Cell>
                       {new Date(item.created).toLocaleDateString()}
                     </Table.Cell>
+                    <Table.Cell>{item.status}</Table.Cell>
                     <Table.Cell data-cy={`lastModified-${index}`}>
                       {new Date(item.lastModified).toLocaleDateString()}
                     </Table.Cell>
-                    <Table.Cell>{item.status}</Table.Cell>
                     <Table.Cell>
                       {item.status === "SUBMITTED" &&
                       item === latestSubmitted ? (

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -1,0 +1,50 @@
+import { Table } from "nhsuk-react-components";
+import { LtftSummaryObj } from "../../../redux/slices/ltftSummaryListSlice";
+import { DateUtilities } from "../../../utilities/DateUtilities";
+
+type LtftSummaryProps = {
+  ltftSummaryList?: LtftSummaryObj[];
+};
+
+const LtftSummary = ({ ltftSummaryList }: Readonly<LtftSummaryProps>) => {
+  const ltftSummaries = ltftSummaryList || [];
+
+  const nonDraftLtftSummaries = ltftSummaries.filter(
+    item => item.status !== "DRAFT"
+  );
+
+  const sortedLtftSummaries = DateUtilities.genericSort(
+    nonDraftLtftSummaries.slice(),
+    "lastModified",
+    true
+  );
+
+  return (
+    <Table responsive data-cy="ltftSummary">
+      <Table.Head>
+        <Table.Row>
+          <Table.Cell>Name</Table.Cell>
+          <Table.Cell>Created date</Table.Cell>
+          <Table.Cell>Last Modified date</Table.Cell>
+          <Table.Cell>Status</Table.Cell>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        {sortedLtftSummaries.map((item, index) => (
+          <Table.Row key={index}>
+            <Table.Cell>{item.name}</Table.Cell>
+            <Table.Cell>
+              {new Date(item.created).toLocaleDateString()}
+            </Table.Cell>
+            <Table.Cell>
+              {new Date(item.lastModified).toLocaleDateString()}
+            </Table.Cell>
+            <Table.Cell>{item.status}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+};
+
+export default LtftSummary;

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -6,6 +6,7 @@ import { Button, CheckboxField } from "@aws-amplify/ui-react";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks/hooks";
 import useIsBetaTester from "../../../utilities/hooks/useIsBetaTester";
 import Loading from "../../common/Loading";
+import history from "../../navigation/history";
 
 const LtftSummary = () => {
   const dispatch = useAppDispatch();
@@ -36,6 +37,10 @@ const LtftSummary = () => {
     filteredLtftSummaries.slice(),
     "lastModified",
     true
+  );
+
+  const latestSubmitted = sortedLtftSummaries.find(
+    i => i.status === "SUBMITTED"
   );
 
   let content: JSX.Element = <></>;
@@ -82,43 +87,53 @@ const LtftSummary = () => {
               </Table.Row>
             </Table.Head>
             <Table.Body>
-              {sortedLtftSummaries.map((item, index) => (
-                <Table.Row key={index}>
-                  <Table.Cell>{item.name}</Table.Cell>
-                  <Table.Cell>
-                    {new Date(item.created).toLocaleDateString()}
-                  </Table.Cell>
-                  <Table.Cell data-cy={`lastModified-${index}`}>
-                    {new Date(item.lastModified).toLocaleDateString()}
-                  </Table.Cell>
-                  <Table.Cell>{item.status}</Table.Cell>
-                  <Table.Cell>
-                    {/* TODO: update logic */}
-                    {item.status === "APPROVED" ? (
-                      <>
-                        <Button
-                          data-cy="unsubmitLtftBtnLink"
-                          fontWeight="normal"
-                          // onClick={onClickEvent}
-                          size="small"
-                          type="reset"
-                        >
-                          Unsubmit
-                        </Button>
-                        <Button
-                          data-cy="withdrawLtftBtnLink"
-                          fontWeight="normal"
-                          // onClick={onClickEvent}
-                          size="small"
-                          type="reset"
-                        >
-                          Withdraw
-                        </Button>
-                      </>
-                    ) : null}
-                  </Table.Cell>
-                </Table.Row>
-              ))}
+              {sortedLtftSummaries.map((item, index) => {
+                return (
+                  <Table.Row
+                    key={index}
+                    onClick={e => {
+                      e.stopPropagation();
+                      // history.push(`/cct/view/${row.original.id}`);
+                      history.push(`/cct/view/67a22bbaac62fa4e421baa50`);
+                    }}
+                  >
+                    <Table.Cell>{item.name}</Table.Cell>
+                    <Table.Cell>
+                      {new Date(item.created).toLocaleDateString()}
+                    </Table.Cell>
+                    <Table.Cell data-cy={`lastModified-${index}`}>
+                      {new Date(item.lastModified).toLocaleDateString()}
+                    </Table.Cell>
+                    <Table.Cell>{item.status}</Table.Cell>
+                    <Table.Cell>
+                      {item.status === "SUBMITTED" &&
+                      item === latestSubmitted ? (
+                        <>
+                          <Button
+                            data-cy="unsubmitLtftBtnLink"
+                            fontWeight="normal"
+                            // onClick={onClickEvent}
+                            size="small"
+                            type="reset"
+                            style={{ marginRight: "0.5em" }}
+                          >
+                            Unsubmit
+                          </Button>
+                          <Button
+                            data-cy="withdrawLtftBtnLink"
+                            fontWeight="normal"
+                            // onClick={onClickEvent}
+                            size="small"
+                            type="reset"
+                          >
+                            Withdraw
+                          </Button>
+                        </>
+                      ) : null}
+                    </Table.Cell>
+                  </Table.Row>
+                );
+              })}
             </Table.Body>
           </Table>
         </div>

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -2,7 +2,7 @@ import { Table } from "nhsuk-react-components";
 import { LtftSummaryObj } from "../../../redux/slices/ltftSummaryListSlice";
 import { DateUtilities } from "../../../utilities/DateUtilities";
 import { useState } from "react";
-import { CheckboxField } from "@aws-amplify/ui-react";
+import { Button, CheckboxField } from "@aws-amplify/ui-react";
 
 type LtftSummaryProps = {
   ltftSummaryList?: LtftSummaryObj[];
@@ -11,13 +11,16 @@ type LtftSummaryProps = {
 const LtftSummary = ({ ltftSummaryList }: Readonly<LtftSummaryProps>) => {
   const ltftSummaries = ltftSummaryList || [];
   const [showSubmitted, setShowSubmitted] = useState(true);
-  const [showUnsubmitted, setShowUnsubmitted] = useState(true);
+  const [showApproved, setShowApproved] = useState(true);
+  const [showWithdrawn, setShowWithdrawn] = useState(true);
 
   const filteredLtftSummaries = ltftSummaries.filter(
     item =>
       item.status !== "DRAFT" &&
+      item.status !== "UNSUBMITTED" &&
       (showSubmitted || item.status !== "SUBMITTED") &&
-      (showUnsubmitted || item.status !== "UNSUBMITTED")
+      (showApproved || item.status !== "APPROVED") &&
+      (showWithdrawn || item.status !== "WITHDRAWN")
   );
 
   const sortedLtftSummaries = DateUtilities.genericSort(
@@ -29,6 +32,13 @@ const LtftSummary = ({ ltftSummaryList }: Readonly<LtftSummaryProps>) => {
   return (
     <div>
       <CheckboxField
+        name="yesToShowApproved"
+        value="yes"
+        label="APPROVED"
+        checked={showApproved}
+        onChange={() => setShowApproved(prevShowApproved => !prevShowApproved)}
+      />
+      <CheckboxField
         name="yesToShowSubmitted"
         value="yes"
         label="SUBMITTED"
@@ -38,12 +48,12 @@ const LtftSummary = ({ ltftSummaryList }: Readonly<LtftSummaryProps>) => {
         }
       />
       <CheckboxField
-        name="yesToShowUnsubmitted"
+        name="yesToShowWithdrawn"
         value="yes"
-        label="UNSUBMITTED"
-        checked={showUnsubmitted}
+        label="WITHDRAWN"
+        checked={showWithdrawn}
         onChange={() =>
-          setShowUnsubmitted(prevShowUnsubmitted => !prevShowUnsubmitted)
+          setShowWithdrawn(prevShowWithdrawn => !prevShowWithdrawn)
         }
       />
       <Table responsive data-cy="ltftSummary">
@@ -53,6 +63,7 @@ const LtftSummary = ({ ltftSummaryList }: Readonly<LtftSummaryProps>) => {
             <Table.Cell>Created date</Table.Cell>
             <Table.Cell>Last Modified date</Table.Cell>
             <Table.Cell>Status</Table.Cell>
+            <Table.Cell>Operation</Table.Cell>
           </Table.Row>
         </Table.Head>
         <Table.Body>
@@ -66,6 +77,31 @@ const LtftSummary = ({ ltftSummaryList }: Readonly<LtftSummaryProps>) => {
                 {new Date(item.lastModified).toLocaleDateString()}
               </Table.Cell>
               <Table.Cell>{item.status}</Table.Cell>
+              <Table.Cell>
+                {/* TODO: update logic */}
+                {item.status === "APPROVED" ? (
+                  <>
+                    <Button
+                      data-cy="unsubmitLtftBtnLink"
+                      fontWeight="normal"
+                      // onClick={onClickEvent}
+                      size="small"
+                      type="reset"
+                    >
+                      Unsubmit
+                    </Button>
+                    <Button
+                      data-cy="withdrawLtftBtnLink"
+                      fontWeight="normal"
+                      // onClick={onClickEvent}
+                      size="small"
+                      type="reset"
+                    >
+                      Withdraw
+                    </Button>
+                  </>
+                ) : null}
+              </Table.Cell>
             </Table.Row>
           ))}
         </Table.Body>

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -1,14 +1,23 @@
 import { Table } from "nhsuk-react-components";
-import { LtftSummaryObj } from "../../../redux/slices/ltftSummaryListSlice";
+import { fetchLtftSummaryList } from "../../../redux/slices/ltftSummaryListSlice";
 import { DateUtilities } from "../../../utilities/DateUtilities";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, CheckboxField } from "@aws-amplify/ui-react";
+import { useAppDispatch, useAppSelector } from "../../../redux/hooks/hooks";
+import useIsBetaTester from "../../../utilities/hooks/useIsBetaTester";
+import Loading from "../../common/Loading";
 
-type LtftSummaryProps = {
-  ltftSummaryList?: LtftSummaryObj[];
-};
+const LtftSummary = () => {
+  const dispatch = useAppDispatch();
+  const isBetaTester = useIsBetaTester();
+  useEffect(() => {
+    if (isBetaTester) dispatch(fetchLtftSummaryList());
+  }, [dispatch, isBetaTester]);
+  const ltftSummaryList = useAppSelector(
+    state => state.ltftSummaryList?.ltftList || []
+  );
+  const ltftListStatus = useAppSelector(state => state.ltftSummaryList?.status);
 
-const LtftSummary = ({ ltftSummaryList }: Readonly<LtftSummaryProps>) => {
   const ltftSummaries = ltftSummaryList || [];
   const [showSubmitted, setShowSubmitted] = useState(true);
   const [showApproved, setShowApproved] = useState(true);
@@ -29,85 +38,93 @@ const LtftSummary = ({ ltftSummaryList }: Readonly<LtftSummaryProps>) => {
     true
   );
 
-  return (
-    <div>
-      <CheckboxField
-        name="yesToShowApproved"
-        value="yes"
-        label="APPROVED"
-        checked={showApproved}
-        onChange={() => setShowApproved(prevShowApproved => !prevShowApproved)}
-      />
-      <CheckboxField
-        name="yesToShowSubmitted"
-        value="yes"
-        label="SUBMITTED"
-        checked={showSubmitted}
-        onChange={() =>
-          setShowSubmitted(prevShowSubmitted => !prevShowSubmitted)
-        }
-      />
-      <CheckboxField
-        name="yesToShowWithdrawn"
-        value="yes"
-        label="WITHDRAWN"
-        checked={showWithdrawn}
-        onChange={() =>
-          setShowWithdrawn(prevShowWithdrawn => !prevShowWithdrawn)
-        }
-      />
-      <Table responsive data-cy="ltftSummary">
-        <Table.Head>
-          <Table.Row>
-            <Table.Cell>Name</Table.Cell>
-            <Table.Cell>Created date</Table.Cell>
-            <Table.Cell>Last Modified date</Table.Cell>
-            <Table.Cell>Status</Table.Cell>
-            <Table.Cell>Operation</Table.Cell>
-          </Table.Row>
-        </Table.Head>
-        <Table.Body>
-          {sortedLtftSummaries.map((item, index) => (
-            <Table.Row key={index}>
-              <Table.Cell>{item.name}</Table.Cell>
-              <Table.Cell>
-                {new Date(item.created).toLocaleDateString()}
-              </Table.Cell>
-              <Table.Cell data-cy={`lastModified-${index}`}>
-                {new Date(item.lastModified).toLocaleDateString()}
-              </Table.Cell>
-              <Table.Cell>{item.status}</Table.Cell>
-              <Table.Cell>
-                {/* TODO: update logic */}
-                {item.status === "APPROVED" ? (
-                  <>
-                    <Button
-                      data-cy="unsubmitLtftBtnLink"
-                      fontWeight="normal"
-                      // onClick={onClickEvent}
-                      size="small"
-                      type="reset"
-                    >
-                      Unsubmit
-                    </Button>
-                    <Button
-                      data-cy="withdrawLtftBtnLink"
-                      fontWeight="normal"
-                      // onClick={onClickEvent}
-                      size="small"
-                      type="reset"
-                    >
-                      Withdraw
-                    </Button>
-                  </>
-                ) : null}
-              </Table.Cell>
-            </Table.Row>
-          ))}
-        </Table.Body>
-      </Table>
-    </div>
-  );
+  let content: JSX.Element = <></>;
+  if (ltftListStatus === "loading") content = <Loading />;
+  if (ltftListStatus === "succeeded")
+    content = (
+      <>
+        <div>
+          <CheckboxField
+            name="yesToShowApproved"
+            value="yes"
+            label="APPROVED"
+            checked={showApproved}
+            onChange={() =>
+              setShowApproved(prevShowApproved => !prevShowApproved)
+            }
+          />
+          <CheckboxField
+            name="yesToShowSubmitted"
+            value="yes"
+            label="SUBMITTED"
+            checked={showSubmitted}
+            onChange={() =>
+              setShowSubmitted(prevShowSubmitted => !prevShowSubmitted)
+            }
+          />
+          <CheckboxField
+            name="yesToShowWithdrawn"
+            value="yes"
+            label="WITHDRAWN"
+            checked={showWithdrawn}
+            onChange={() =>
+              setShowWithdrawn(prevShowWithdrawn => !prevShowWithdrawn)
+            }
+          />
+          <Table responsive data-cy="ltftSummary">
+            <Table.Head>
+              <Table.Row>
+                <Table.Cell>Name</Table.Cell>
+                <Table.Cell>Created date</Table.Cell>
+                <Table.Cell>Last Modified date</Table.Cell>
+                <Table.Cell>Status</Table.Cell>
+                <Table.Cell>Operation</Table.Cell>
+              </Table.Row>
+            </Table.Head>
+            <Table.Body>
+              {sortedLtftSummaries.map((item, index) => (
+                <Table.Row key={index}>
+                  <Table.Cell>{item.name}</Table.Cell>
+                  <Table.Cell>
+                    {new Date(item.created).toLocaleDateString()}
+                  </Table.Cell>
+                  <Table.Cell data-cy={`lastModified-${index}`}>
+                    {new Date(item.lastModified).toLocaleDateString()}
+                  </Table.Cell>
+                  <Table.Cell>{item.status}</Table.Cell>
+                  <Table.Cell>
+                    {/* TODO: update logic */}
+                    {item.status === "APPROVED" ? (
+                      <>
+                        <Button
+                          data-cy="unsubmitLtftBtnLink"
+                          fontWeight="normal"
+                          // onClick={onClickEvent}
+                          size="small"
+                          type="reset"
+                        >
+                          Unsubmit
+                        </Button>
+                        <Button
+                          data-cy="withdrawLtftBtnLink"
+                          fontWeight="normal"
+                          // onClick={onClickEvent}
+                          size="small"
+                          type="reset"
+                        >
+                          Withdraw
+                        </Button>
+                      </>
+                    ) : null}
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </div>
+      </>
+    );
+  return content;
 };
 
 export default LtftSummary;

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -1,6 +1,8 @@
 import { Table } from "nhsuk-react-components";
 import { LtftSummaryObj } from "../../../redux/slices/ltftSummaryListSlice";
 import { DateUtilities } from "../../../utilities/DateUtilities";
+import { useState } from "react";
+import { CheckboxField } from "@aws-amplify/ui-react";
 
 type LtftSummaryProps = {
   ltftSummaryList?: LtftSummaryObj[];
@@ -8,42 +10,67 @@ type LtftSummaryProps = {
 
 const LtftSummary = ({ ltftSummaryList }: Readonly<LtftSummaryProps>) => {
   const ltftSummaries = ltftSummaryList || [];
+  const [showSubmitted, setShowSubmitted] = useState(true);
+  const [showUnsubmitted, setShowUnsubmitted] = useState(true);
 
-  const nonDraftLtftSummaries = ltftSummaries.filter(
-    item => item.status !== "DRAFT"
+  const filteredLtftSummaries = ltftSummaries.filter(
+    item =>
+      item.status !== "DRAFT" &&
+      (showSubmitted || item.status !== "SUBMITTED") &&
+      (showUnsubmitted || item.status !== "UNSUBMITTED")
   );
 
   const sortedLtftSummaries = DateUtilities.genericSort(
-    nonDraftLtftSummaries.slice(),
+    filteredLtftSummaries.slice(),
     "lastModified",
     true
   );
 
   return (
-    <Table responsive data-cy="ltftSummary">
-      <Table.Head>
-        <Table.Row>
-          <Table.Cell>Name</Table.Cell>
-          <Table.Cell>Created date</Table.Cell>
-          <Table.Cell>Last Modified date</Table.Cell>
-          <Table.Cell>Status</Table.Cell>
-        </Table.Row>
-      </Table.Head>
-      <Table.Body>
-        {sortedLtftSummaries.map((item, index) => (
-          <Table.Row key={index}>
-            <Table.Cell>{item.name}</Table.Cell>
-            <Table.Cell>
-              {new Date(item.created).toLocaleDateString()}
-            </Table.Cell>
-            <Table.Cell>
-              {new Date(item.lastModified).toLocaleDateString()}
-            </Table.Cell>
-            <Table.Cell>{item.status}</Table.Cell>
+    <div>
+      <CheckboxField
+        name="yesToShowSubmitted"
+        value="yes"
+        label="SUBMITTED"
+        checked={showSubmitted}
+        onChange={() =>
+          setShowSubmitted(prevShowSubmitted => !prevShowSubmitted)
+        }
+      />
+      <CheckboxField
+        name="yesToShowUnsubmitted"
+        value="yes"
+        label="UNSUBMITTED"
+        checked={showUnsubmitted}
+        onChange={() =>
+          setShowUnsubmitted(prevShowUnsubmitted => !prevShowUnsubmitted)
+        }
+      />
+      <Table responsive data-cy="ltftSummary">
+        <Table.Head>
+          <Table.Row>
+            <Table.Cell>Name</Table.Cell>
+            <Table.Cell>Created date</Table.Cell>
+            <Table.Cell>Last Modified date</Table.Cell>
+            <Table.Cell>Status</Table.Cell>
           </Table.Row>
-        ))}
-      </Table.Body>
-    </Table>
+        </Table.Head>
+        <Table.Body>
+          {sortedLtftSummaries.map((item, index) => (
+            <Table.Row key={index}>
+              <Table.Cell>{item.name}</Table.Cell>
+              <Table.Cell>
+                {new Date(item.created).toLocaleDateString()}
+              </Table.Cell>
+              <Table.Cell data-cy={`lastModified-${index}`}>
+                {new Date(item.lastModified).toLocaleDateString()}
+              </Table.Cell>
+              <Table.Cell>{item.status}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
   );
 };
 

--- a/cypress/component/forms/ltft/LtftSummary.cy.tsx
+++ b/cypress/component/forms/ltft/LtftSummary.cy.tsx
@@ -25,4 +25,9 @@ describe("LtftSummary Component", () => {
       cy.contains("Status").should("exist");
     });
   });
+
+  it("should sort by last modified date desc", () => {
+    cy.get('[data-cy="lastModified-0"]').contains("15/12/2024");
+    cy.get('[data-cy="lastModified-1"]').contains("15/10/2024");
+  });
 });

--- a/cypress/component/forms/ltft/LtftSummary.cy.tsx
+++ b/cypress/component/forms/ltft/LtftSummary.cy.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { mount } from "cypress/react18";
+import LtftSummary from "../../../../components/forms/ltft/LtftSummary";
+import { mockLtftsList1 } from "../../../../mock-data/mock-ltft-data";
+
+describe("LtftSummary Component", () => {
+  beforeEach(() => {
+    mount(<LtftSummary ltftSummaryList={mockLtftsList1} />);
+  });
+
+  it("should render the table", () => {
+    cy.get("[data-cy=ltftSummary]").should("exist");
+  });
+
+  it("should display only non-draft entries", () => {
+    cy.get("tbody tr").should("have.length", 2);
+    cy.contains("Draft User").should("not.exist");
+  });
+
+  it("should display correct table headers", () => {
+    cy.get("thead tr").within(() => {
+      cy.contains("Name").should("exist");
+      cy.contains("Created date").should("exist");
+      cy.contains("Last Modified date").should("exist");
+      cy.contains("Status").should("exist");
+    });
+  });
+});

--- a/cypress/component/forms/ltft/LtftSummary.cy.tsx
+++ b/cypress/component/forms/ltft/LtftSummary.cy.tsx
@@ -2,32 +2,52 @@ import React from "react";
 import { mount } from "cypress/react18";
 import LtftSummary from "../../../../components/forms/ltft/LtftSummary";
 import { mockLtftsList1 } from "../../../../mock-data/mock-ltft-data";
+import { Provider } from "react-redux";
+import store from "../../../../redux/store/store";
+import { MemoryRouter } from "react-router-dom";
 
 describe("LtftSummary Component", () => {
   beforeEach(() => {
-    mount(<LtftSummary ltftSummaryList={mockLtftsList1} />);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/ltft"]}>
+          <LtftSummary ltftSummaryList={mockLtftsList1} />
+        </MemoryRouter>
+      </Provider>
+    );
   });
 
   it("should render the table", () => {
     cy.get("[data-cy=ltftSummary]").should("exist");
   });
 
-  it("should display only non-draft entries", () => {
-    cy.get("tbody tr").should("have.length", 2);
-    cy.contains("Draft User").should("not.exist");
-  });
-
   it("should display correct table headers", () => {
     cy.get("thead tr").within(() => {
       cy.contains("Name").should("exist");
       cy.contains("Created date").should("exist");
-      cy.contains("Last Modified date").should("exist");
+      cy.contains("Status date").should("exist");
       cy.contains("Status").should("exist");
     });
   });
 
-  it("should sort by last modified date desc", () => {
-    cy.get('[data-cy="lastModified-0"]').contains("15/12/2024");
-    cy.get('[data-cy="lastModified-1"]').contains("15/10/2024");
+  it("should hide DRAFT and UNSUBMITTED ltft", () => {
+    cy.get("tbody tr").should("have.length", 4);
+    cy.contains("DRAFT").should("not.exist");
+    cy.contains("UNSUBMITTED").should("not.exist");
+  });
+
+  it("should filter out APPROVED ltft", () => {
+    cy.get("[data-cy=filterApprovedLtft]").click();
+    cy.get('[data-cy="ltftSummary"]').contains("APPROVED").should("not.exist");
+  });
+
+  it("should filter out SUBMITTED ltft", () => {
+    cy.get("[data-cy=filterSubmittedLtft]").click();
+    cy.get('[data-cy="ltftSummary"]').contains("SUBMITTED").should("not.exist");
+  });
+
+  it("should filter out WITHDRAWN ltft", () => {
+    cy.get("[data-cy=filterWithdrawnLtft]").click();
+    cy.get('[data-cy="ltftSummary"]').contains("WITHDRAWN").should("not.exist");
   });
 });

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -6,24 +6,40 @@ export const mockLtftsList1 = [
     name: "GP hours reduction",
     programmeMembershipId: "a6de88b8-de41-48dd-9492-a518f5001176",
     status: "DRAFT",
-    created: "2025-01-15T14:50:36.941Z",
+    created: "2025-01-1T14:50:36.941Z",
     lastModified: "2025-01-15T15:50:36.941Z"
   },
   {
     id: "123e4567-e89b-12d3-a456-426614174000",
-    name: "My last Programme hours reduction",
+    name: "Programme hours reduction 1",
     programmeMembershipId: "2861fb68-6c08-4af5-a3a1-6f561a37b407",
-    status: "SUBMITTED",
+    status: "APPROVED",
     created: "2024-12-15T14:50:36.941Z",
     lastModified: "2024-12-15T15:50:36.941Z"
   },
   {
     id: "123e4567-e89b-12d3-a456-426614174001",
-    name: "My first Programme hours reduction",
+    name: "Programme hours reduction 2",
     programmeMembershipId: "2861fb68-6c08-4af5-a3a1-6f561a37b406",
-    status: "REJECTED",
+    status: "SUBMITTED",
     created: "2024-10-15T14:50:36.941Z",
     lastModified: "2024-10-15T15:50:36.941Z"
+  },
+  {
+    id: "123e4567-e89b-12d3-a456-426614174001",
+    name: "Programme hours reduction 3",
+    programmeMembershipId: "2861fb68-6c08-4af5-a3a1-6f561a37b406",
+    status: "SUBMITTED",
+    created: "2024-09-15T14:50:36.941Z",
+    lastModified: "2024-09-15T15:50:36.941Z"
+  },
+  {
+    id: "123e4567-e89b-12d3-a456-426614174001",
+    name: "Programme hours reduction 4",
+    programmeMembershipId: "2861fb68-6c08-4af5-a3a1-6f561a37b406",
+    status: "WITHDRAWN",
+    created: "2024-08-15T14:50:36.941Z",
+    lastModified: "2024-08-15T15:50:36.941Z"
   }
 ];
 


### PR DESCRIPTION
- LTFT Summary with APPROVED, SUBMITTED, WITHDRAWN status
- Checkbox for filtering LTFT application  by status
- Dummy data for demonstration only (button and rows not clickable yet)

TODO in future's PR: 
- Refactor to use react table
- Refactor state use for ltftSummaryList data
- Row clickable for LTFT details page (when the view page is ready)
- `Unsubmit` and `Withdraw` button (when backend functionality is ready)