### PR TITLE
Save, update, review & delete DRAFT LTFT

### DIFF
--- a/components/forms/AutosaveMessage.tsx
+++ b/components/forms/AutosaveMessage.tsx
@@ -1,31 +1,38 @@
 import { useAppSelector } from "../../redux/hooks/hooks";
+import { RootState } from "../../redux/store/store";
+import { FormName } from "./form-builder/FormBuilder";
 
 export type SaveStatusProps = "idle" | "saving" | "succeeded" | "failed";
 
 type AutoSaveMessageProps = {
-  formName: string;
+  formName: FormName;
+};
+
+const formStateMap = {
+  formA: (state: RootState) => state.formA,
+  formB: (state: RootState) => state.formB,
+  ltft: (state: RootState) => state.ltft
+};
+
+const getFormState = (state: RootState, formName: FormName) => {
+  return formStateMap[formName](state);
 };
 
 export const AutosaveMessage: React.FC<AutoSaveMessageProps> = ({
   formName
 }) => {
-  const autoSaveStatus = useAppSelector(state =>
-    formName === "formA" ? state.formA.saveStatus : state.formB.saveStatus
-  );
-  const latestTimeStamp = useAppSelector(state =>
-    formName === "formA"
-      ? state.formA.saveLatestTimeStamp
-      : state.formB.saveLatestTimeStamp
-  );
+  const formState = useAppSelector(state => getFormState(state, formName));
+  const autoSaveStatus = formState.saveStatus;
+  const latestTimeStamp = formState.saveLatestTimeStamp;
 
-  const statusMessages: { [key in SaveStatusProps]: string } = {
+  const statusMessages = {
     idle: "Waiting for new changes...",
     saving: "In progress...",
     succeeded: `Success - ${latestTimeStamp}`,
     failed: `Fail - Last autosave success: ${latestTimeStamp}`
   };
 
-  const message = statusMessages[autoSaveStatus];
+  const message = statusMessages[autoSaveStatus as SaveStatusProps];
   return (
     <div>
       <p data-cy="autosaveStatusMsg">{`Autosave status: ${message}`}</p>

--- a/components/forms/CreateList.tsx
+++ b/components/forms/CreateList.tsx
@@ -60,7 +60,7 @@ const CreateList = () => {
             <Col width="one-third">
               <StartOverButton
                 formName={formName}
-                isFormButton={false}
+                btnLocation="formsList"
                 formsListDraftId={formIdFromDraftFormProps}
               />
             </Col>

--- a/components/forms/CreateList.tsx
+++ b/components/forms/CreateList.tsx
@@ -43,10 +43,6 @@ const CreateList = () => {
     dispatch(fetchFeatureFlags());
   }, [dispatch]);
 
-  useEffect(() => {
-    dispatch(formName === "formA" ? resetToInitFormA() : resetToInitFormB());
-  }, [dispatch, formName]);
-
   let content: JSX.Element = <></>;
 
   if (formRListStatus === "loading" || featFlagStatus === "loading")

--- a/components/forms/CreateList.tsx
+++ b/components/forms/CreateList.tsx
@@ -15,11 +15,12 @@ import { resetToInitFormA } from "../../redux/slices/formASlice";
 import { resetToInitFormB } from "../../redux/slices/formBSlice";
 import { Col, Container, Row } from "nhsuk-react-components";
 import { StartOverButton } from "./StartOverButton";
+import { FormName } from "./form-builder/FormBuilder";
 
 const CreateList = () => {
   const dispatch = useAppDispatch();
   const pathname = useLocation().pathname;
-  const formName = pathname === "/formr-a" ? "formA" : "formB";
+  const formName: FormName = pathname === "/formr-a" ? "formA" : "formB";
   const submittedListDesc = useAppSelector(selectAllSubmittedforms);
   const latestSubDate = submittedListDesc?.length
     ? submittedListDesc[0].submissionDate
@@ -28,6 +29,9 @@ const CreateList = () => {
   const featFlagStatus = useAppSelector(state => state.featureFlags.status);
   const needFormsRefresh = useAppSelector(
     state => state.forms?.formsRefreshNeeded
+  );
+  const formIdFromDraftFormProps = useAppSelector(
+    state => state.forms?.draftFormProps?.id
   );
 
   useEffect(() => {
@@ -60,7 +64,11 @@ const CreateList = () => {
           </Row>
           <Row>
             <Col width="one-third">
-              <StartOverButton />
+              <StartOverButton
+                formName={formName}
+                isFormButton={false}
+                formsListDraftId={formIdFromDraftFormProps}
+              />
             </Col>
           </Row>
         </Container>

--- a/components/forms/CreateList.tsx
+++ b/components/forms/CreateList.tsx
@@ -11,8 +11,6 @@ import { fetchFeatureFlags } from "../../redux/slices/featureFlagsSlice";
 import FormsListBtn from "../../components/forms/FormsListBtn";
 import { useLocation } from "react-router-dom";
 import SubmittedFormsList from "../../components/forms/SubmittedFormsList";
-import { resetToInitFormA } from "../../redux/slices/formASlice";
-import { resetToInitFormB } from "../../redux/slices/formBSlice";
 import { Col, Container, Row } from "nhsuk-react-components";
 import { StartOverButton } from "./StartOverButton";
 import { FormName } from "./form-builder/FormBuilder";

--- a/components/forms/StartOverButton.tsx
+++ b/components/forms/StartOverButton.tsx
@@ -12,6 +12,7 @@ import history from "../navigation/history";
 import store from "../../redux/store/store";
 import { updatedFormsRefreshNeeded } from "../../redux/slices/formsSlice";
 import { FormName } from "./form-builder/FormBuilder";
+import { updatedLtftFormsRefreshNeeded } from "../../redux/slices/ltftSummaryListSlice";
 
 export type StartOverButtonProps = {
   formName: FormName;
@@ -58,13 +59,14 @@ export const StartOverButton = ({
   ) : null;
 };
 
-// TODO - for ltft forms list refresh
 function checkPush(formName: FormName, isFormButton: boolean) {
   resetForm(formName);
   if (isFormButton) {
     const mappedUrl = mapFormNameToUrl(formName);
     history.push(`/${mappedUrl}`);
   } else {
-    store.dispatch(updatedFormsRefreshNeeded(true));
+    if (formName !== "ltft") {
+      store.dispatch(updatedFormsRefreshNeeded(true));
+    } else store.dispatch(updatedLtftFormsRefreshNeeded(true));
   }
 }

--- a/components/forms/StartOverButton.tsx
+++ b/components/forms/StartOverButton.tsx
@@ -1,31 +1,38 @@
 import React from "react";
 import { useAppSelector } from "../../redux/hooks/hooks";
-import { useLocation } from "react-router-dom";
 import { useConfirm } from "material-ui-confirm";
 import { Button } from "nhsuk-react-components";
-import { isFormDeleted } from "../../utilities/FormBuilderUtilities";
+import {
+  getDraftFormId,
+  isFormDeleted,
+  mapFormNameToUrl
+} from "../../utilities/FormBuilderUtilities";
 import history from "../navigation/history";
 import store from "../../redux/store/store";
 import { updatedFormsRefreshNeeded } from "../../redux/slices/formsSlice";
+import { FormName } from "./form-builder/FormBuilder";
 
-export const StartOverButton = () => {
+export type StartOverButtonProps = {
+  formName: FormName;
+  isFormButton: boolean;
+  formsListDraftId?: string;
+};
+
+export const StartOverButton = ({
+  formName,
+  isFormButton,
+  formsListDraftId
+}: Readonly<StartOverButtonProps>) => {
   const confirm = useConfirm();
-  const pathName = useLocation().pathname;
-  const formName = pathName.split("/")[1];
-
-  // get id from updated form r (when autosaved)
-  const formId = useAppSelector(state =>
-    formName === "formr-a" ? state.formA.newFormId : state.formB.newFormId
-  );
-  // get id from forms draftFormProps when forms are loaded from db
-  const formIdFromDraftFormProps = useAppSelector(
-    state => state.forms?.draftFormProps?.id
-  );
-
-  const autosaveStatus = useAppSelector(state =>
-    formName === "formr-a" ? state.formA.saveStatus : state.formB.saveStatus
-  );
-  const isAutosaving = autosaveStatus === "saving";
+  const formId = isFormButton
+    ? getDraftFormId(
+        useAppSelector(state => state[formName].formData),
+        formName
+      )
+    : formsListDraftId;
+  console.log("formId in startover button", formId);
+  const saveStatus = useAppSelector(state => state[formName].saveStatus);
+  const isSaving = saveStatus === "saving";
 
   const handleBtnClick = async () => {
     confirm({
@@ -33,33 +40,33 @@ export const StartOverButton = () => {
         "This action will delete all the changes you have made to this form. Are you sure you want to continue?"
     })
       .then(async () => {
-        const shouldStartOver = await isFormDeleted(
-          formName,
-          formId,
-          formIdFromDraftFormProps
-        );
+        const shouldStartOver = await isFormDeleted(formName, formId as string);
         shouldStartOver
-          ? checkPush(formName, pathName)
+          ? checkPush(formName, isFormButton)
           : console.log("startover failed");
       })
       .catch(() => console.log("startover cancelled"));
   };
 
-  return formId || formIdFromDraftFormProps ? (
+  return formId ? (
     <Button
       data-cy="startOverButton"
       reverse
       type="button"
       onClick={handleBtnClick}
-      disabled={isAutosaving}
+      disabled={isSaving}
     >
       Start over
     </Button>
   ) : null;
 };
 
-function checkPush(formName: string, path: string) {
-  path.endsWith("create") || path.endsWith("confirm")
-    ? history.push(`/${formName}`)
-    : store.dispatch(updatedFormsRefreshNeeded(true));
+// TODO - for ltft forms list refresh
+function checkPush(formName: FormName, isFormButton: boolean) {
+  if (isFormButton) {
+    const mappedUrl = mapFormNameToUrl(formName);
+    history.push(`/${mappedUrl}`);
+  } else {
+    store.dispatch(updatedFormsRefreshNeeded(true));
+  }
 }

--- a/components/forms/StartOverButton.tsx
+++ b/components/forms/StartOverButton.tsx
@@ -5,7 +5,8 @@ import { Button } from "nhsuk-react-components";
 import {
   getDraftFormId,
   isFormDeleted,
-  mapFormNameToUrl
+  mapFormNameToUrl,
+  resetForm
 } from "../../utilities/FormBuilderUtilities";
 import history from "../navigation/history";
 import store from "../../redux/store/store";
@@ -25,12 +26,8 @@ export const StartOverButton = ({
 }: Readonly<StartOverButtonProps>) => {
   const confirm = useConfirm();
   const formId = isFormButton
-    ? getDraftFormId(
-        useAppSelector(state => state[formName].formData),
-        formName
-      )
+    ? getDraftFormId(store.getState()[formName].formData, formName)
     : formsListDraftId;
-  console.log("formId in startover button", formId);
   const saveStatus = useAppSelector(state => state[formName].saveStatus);
   const isSaving = saveStatus === "saving";
 
@@ -63,6 +60,7 @@ export const StartOverButton = ({
 
 // TODO - for ltft forms list refresh
 function checkPush(formName: FormName, isFormButton: boolean) {
+  resetForm(formName);
   if (isFormButton) {
     const mappedUrl = mapFormNameToUrl(formName);
     history.push(`/${mappedUrl}`);

--- a/components/forms/__test__/StartOverButton.test.tsx
+++ b/components/forms/__test__/StartOverButton.test.tsx
@@ -45,7 +45,7 @@ describe("StartOverButton Component", () => {
   const renderStartOverButton = () => {
     return render(
       <Provider store={store}>
-        <StartOverButton formName="formA" isFormButton={true} />
+        <StartOverButton formName="formA" btnLocation="form" />
       </Provider>
     );
   };

--- a/components/forms/__test__/StartOverButton.test.tsx
+++ b/components/forms/__test__/StartOverButton.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, fireEvent, act } from "@testing-library/react";
 import store from "../../../redux/store/store";
 import { StartOverButton } from "../StartOverButton";
 import { Provider } from "react-redux";
@@ -16,6 +16,7 @@ import { LifeCycleState } from "../../../models/LifeCycleState";
 import { DraftFormProps } from "../../../utilities/FormBuilderUtilities";
 import { useLocation } from "react-router-dom";
 import history from "../../navigation/history";
+import { updatedLtftFormsRefreshNeeded } from "../../../redux/slices/ltftSummaryListSlice";
 
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
@@ -34,7 +35,10 @@ jest.mock("material-ui-confirm", () => ({
 }));
 
 jest.mock("../../../utilities/FormBuilderUtilities", () => ({
-  isFormDeleted: jest.fn()
+  getDraftFormId: jest.fn(),
+  isFormDeleted: jest.fn(),
+  mapFormNameToUrl: jest.fn(),
+  resetForm: jest.fn()
 }));
 
 jest.mock("../../navigation/history", () => ({
@@ -42,19 +46,28 @@ jest.mock("../../navigation/history", () => ({
 }));
 
 describe("StartOverButton Component", () => {
-  const renderStartOverButton = () => {
+  const renderStartOverButton = (props = {}) => {
     return render(
       <Provider store={store}>
-        <StartOverButton formName="formA" btnLocation="form" />
+        <StartOverButton formName="formA" btnLocation="form" {...props} />
       </Provider>
     );
   };
 
   beforeEach(() => {
     (useLocation as jest.Mock).mockReturnValue({ pathname: "/formr-a" });
+    require("../../../utilities/FormBuilderUtilities").getDraftFormId.mockReturnValue(
+      "123"
+    );
+    require("../../../utilities/FormBuilderUtilities").mapFormNameToUrl.mockReturnValue(
+      "formr-a"
+    );
   });
 
   it("should NOT render the StartOver button when NO formId is available and NO autosave success", () => {
+    require("../../../utilities/FormBuilderUtilities").getDraftFormId.mockReturnValue(
+      null
+    );
     const { queryByRole } = renderStartOverButton();
     const startOverButton = queryByRole("button", {
       name: "Start over"
@@ -72,7 +85,7 @@ describe("StartOverButton Component", () => {
     expect(startOverButton).toBeInTheDocument();
   });
 
-  it("should render the StartOver button when formId is available (i.e. from fetched draft form)", () => {
+  it("should render the StartOver button when formId is available (i.e. from fetched draft form)", async () => {
     const draftProps: DraftFormProps = {
       id: "123",
       lifecycleState: LifeCycleState.Draft
@@ -86,22 +99,77 @@ describe("StartOverButton Component", () => {
     expect(startOverButton).toBeInTheDocument();
   });
 
-  it("should call history.push when successful form delete triggered from 'start over' click on forms page (pathname ends with 'create')", async () => {
-    (useLocation as jest.Mock).mockReturnValue({ pathname: "/formr-a/create" });
-    const mockIsFormDeleted = jest.fn().mockResolvedValue(true);
-    require("../../../utilities/FormBuilderUtilities").isFormDeleted.mockImplementationOnce(
-      mockIsFormDeleted
+  it("should render the StartOver button when btnLocation is 'formView' and NO formId is available", async () => {
+    require("../../../utilities/FormBuilderUtilities").getDraftFormId.mockReturnValue(
+      null
+    );
+    const { queryByRole } = renderStartOverButton({ btnLocation: "formView" });
+    const startOverButton = queryByRole("button", {
+      name: "Start over"
+    });
+    expect(startOverButton).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(startOverButton as HTMLElement);
+    });
+
+    expect(
+      require("../../../utilities/FormBuilderUtilities").isFormDeleted
+    ).not.toHaveBeenCalled();
+    expect(history.push).toHaveBeenCalledWith("/formr-a");
+  });
+
+  it("should call isFormDeleted and checkPush when formId is available and form is deleted", async () => {
+    require("../../../utilities/FormBuilderUtilities").isFormDeleted.mockResolvedValue(
+      true
     );
     const { queryByRole } = renderStartOverButton();
     const startOverButton = queryByRole("button", {
       name: "Start over"
     });
+    expect(startOverButton).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(startOverButton as HTMLElement);
     });
-    expect(mockIsFormDeleted).toHaveBeenCalled();
+
+    expect(
+      require("../../../utilities/FormBuilderUtilities").isFormDeleted
+    ).toHaveBeenCalledWith("formA", "123");
     expect(history.push).toHaveBeenCalledWith("/formr-a");
+  });
+
+  it("should log 'startover failed' when formId is available and form is not deleted", async () => {
+    console.log = jest.fn();
+    require("../../../utilities/FormBuilderUtilities").isFormDeleted.mockResolvedValue(
+      false
+    );
+    const { queryByRole } = renderStartOverButton();
+    const startOverButton = queryByRole("button", {
+      name: "Start over"
+    });
+    expect(startOverButton).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(startOverButton as HTMLElement);
+    });
+
+    expect(
+      require("../../../utilities/FormBuilderUtilities").isFormDeleted
+    ).toHaveBeenCalledWith("formA", "123");
+    expect(console.log).toHaveBeenCalledWith("startover failed");
+  });
+
+  it("should call resetForm with the correct formName", () => {
+    const { queryByRole } = renderStartOverButton();
+    const startOverButton = queryByRole("button", {
+      name: "Start over"
+    });
+    fireEvent.click(startOverButton as HTMLElement);
+
+    expect(
+      require("../../../utilities/FormBuilderUtilities").resetForm
+    ).toHaveBeenCalledWith("formA");
   });
 
   it("should call redux dispatch (updatedFormsRefreshNeeded) when successful form delete triggered from 'start over' click on forms list page (CreateList comp)", async () => {
@@ -110,7 +178,10 @@ describe("StartOverButton Component", () => {
       mockIsFormDeleted
     );
     const dispatchSpy = jest.spyOn(store, "dispatch");
-    const { queryByRole } = renderStartOverButton();
+    const { queryByRole } = renderStartOverButton({
+      btnLocation: "formsList",
+      formsListDraftId: "123"
+    });
     const startOverButton = queryByRole("button", {
       name: "Start over"
     });
@@ -121,21 +192,54 @@ describe("StartOverButton Component", () => {
     expect(mockIsFormDeleted).toHaveBeenCalled();
     expect(dispatchSpy).toHaveBeenCalledWith(updatedFormsRefreshNeeded(true));
     mockIsFormDeleted.mockReset();
+    dispatchSpy.mockRestore();
   });
 
-  it('should console.log("startover failed") for an unsuccessful form delete (when isFormDeleted returns false)', async () => {
-    const mockIsFormDeleted = jest.fn().mockResolvedValue(false);
+  it("should call redux dispatch (updatedLtftFormsRefreshNeeded) when btnLocation is 'formsList' and formName is 'ltft'", async () => {
+    const mockIsFormDeleted = jest.fn().mockResolvedValue(true);
     require("../../../utilities/FormBuilderUtilities").isFormDeleted.mockImplementationOnce(
       mockIsFormDeleted
     );
-    const consoleSpy = jest.spyOn(console, "log");
-    const { queryByRole } = renderStartOverButton();
+    const dispatchSpy = jest.spyOn(store, "dispatch");
+    const { queryByRole } = renderStartOverButton({
+      formName: "ltft",
+      btnLocation: "formsList",
+      formsListDraftId: "123"
+    });
     const startOverButton = queryByRole("button", {
       name: "Start over"
     });
+
     await act(async () => {
       fireEvent.click(startOverButton as HTMLElement);
     });
-    expect(consoleSpy).toHaveBeenCalledWith("startover failed");
+    expect(mockIsFormDeleted).toHaveBeenCalled();
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      updatedLtftFormsRefreshNeeded(true)
+    );
+    mockIsFormDeleted.mockReset();
+    dispatchSpy.mockRestore();
+  });
+
+  it("should navigate to the correct URL when btnLocation is not 'formsList'", async () => {
+    const mockIsFormDeleted = jest.fn().mockResolvedValue(true);
+    require("../../../utilities/FormBuilderUtilities").isFormDeleted.mockImplementationOnce(
+      mockIsFormDeleted
+    );
+    const { queryByRole } = renderStartOverButton({
+      formName: "formA",
+      btnLocation: "formView",
+      formsListDraftId: "123"
+    });
+    const startOverButton = queryByRole("button", {
+      name: "Start over"
+    });
+
+    await act(async () => {
+      fireEvent.click(startOverButton as HTMLElement);
+    });
+    expect(mockIsFormDeleted).toHaveBeenCalled();
+    expect(history.push).toHaveBeenCalledWith("/formr-a");
+    mockIsFormDeleted.mockReset();
   });
 });

--- a/components/forms/__test__/StartOverButton.test.tsx
+++ b/components/forms/__test__/StartOverButton.test.tsx
@@ -41,11 +41,11 @@ jest.mock("../../navigation/history", () => ({
   push: jest.fn()
 }));
 
-describe("Startoverbtn Component", () => {
+describe("StartOverButton Component", () => {
   const renderStartOverButton = () => {
     return render(
       <Provider store={store}>
-        <StartOverButton />
+        <StartOverButton formName="formA" isFormButton={true} />
       </Provider>
     );
   };
@@ -54,14 +54,15 @@ describe("Startoverbtn Component", () => {
     (useLocation as jest.Mock).mockReturnValue({ pathname: "/formr-a" });
   });
 
-  it("should NOT render the Startover button when NO formId is available and NO autosave success", () => {
-    const startOverButton = screen.queryByRole("button", {
+  it("should NOT render the StartOver button when NO formId is available and NO autosave success", () => {
+    const { queryByRole } = renderStartOverButton();
+    const startOverButton = queryByRole("button", {
       name: "Start over"
     });
     expect(startOverButton).not.toBeInTheDocument();
   });
 
-  it("Should render the Startover button when initial autosave is successful (i.e. via stored newFormId on successful POST response).", () => {
+  it("should render the StartOver button when initial autosave is successful (i.e. via stored newFormId on successful POST response)", () => {
     store.dispatch(updatedFormA(formANew));
     store.dispatch(updatedNewFormId("123"));
     const { queryByRole } = renderStartOverButton();
@@ -71,7 +72,7 @@ describe("Startoverbtn Component", () => {
     expect(startOverButton).toBeInTheDocument();
   });
 
-  it("Should render the Startover button when formId is available (i.e. from fetched draft form).", () => {
+  it("should render the StartOver button when formId is available (i.e. from fetched draft form)", () => {
     const draftProps: DraftFormProps = {
       id: "123",
       lifecycleState: LifeCycleState.Draft
@@ -85,7 +86,7 @@ describe("Startoverbtn Component", () => {
     expect(startOverButton).toBeInTheDocument();
   });
 
-  it("should call history.push when successful form delete triggered from 'start over' click on forms page (pathname ends with 'create').", async () => {
+  it("should call history.push when successful form delete triggered from 'start over' click on forms page (pathname ends with 'create')", async () => {
     (useLocation as jest.Mock).mockReturnValue({ pathname: "/formr-a/create" });
     const mockIsFormDeleted = jest.fn().mockResolvedValue(true);
     require("../../../utilities/FormBuilderUtilities").isFormDeleted.mockImplementationOnce(
@@ -103,7 +104,7 @@ describe("Startoverbtn Component", () => {
     expect(history.push).toHaveBeenCalledWith("/formr-a");
   });
 
-  it("should call redux dispatch (updatedFormsRefreshNeeded) when successful form delete triggered from 'start over' click on forms list page (CreateList comp).", async () => {
+  it("should call redux dispatch (updatedFormsRefreshNeeded) when successful form delete triggered from 'start over' click on forms list page (CreateList comp)", async () => {
     const mockIsFormDeleted = jest.fn().mockResolvedValue(true);
     require("../../../utilities/FormBuilderUtilities").isFormDeleted.mockImplementationOnce(
       mockIsFormDeleted

--- a/components/forms/cct/CctCalcSummary.tsx
+++ b/components/forms/cct/CctCalcSummary.tsx
@@ -10,7 +10,10 @@ import { handleCctSubmit } from "../../../utilities/CctUtilities";
 import { FormRUtilities } from "../../../utilities/FormRUtilities";
 import { CalcDetails } from "./CctCalcCreate";
 import ErrorPage from "../../common/ErrorPage";
-import { updatedFormSaveStatus } from "../../../redux/slices/cctSlice";
+import {
+  CctCalculation,
+  updatedFormSaveStatus
+} from "../../../redux/slices/cctSlice";
 
 export function CctCalcSummary() {
   const dispatch = useAppDispatch();
@@ -22,19 +25,10 @@ export function CctCalcSummary() {
   const cctFormSaveStatus = useAppSelector(state => state.cct.formSaveStatus);
   const newCalcMade = useAppSelector(state => state.cct.newCalcMade);
   const viewedCalc = useAppSelector(state => state.cct.cctCalc);
-  const {
-    programmeMembership,
-    cctDate,
-    changes,
-    name,
-    id,
-    created,
-    lastModified
-  } = viewedCalc;
 
   const handleSave = () => {
     dispatch(updatedFormSaveStatus("idle"));
-    if (id) {
+    if (viewedCalc?.id) {
       handleCctSubmit(startSubmitting, stopSubmitting, viewedCalc);
     } else {
       setShowCctNameModal(true);
@@ -43,84 +37,7 @@ export function CctCalcSummary() {
 
   return (
     <>
-      <Card className="pdf-visible">
-        <Card.Content>
-          <Card.Heading data-cy="cct-calc-summary-header">
-            CCT Calculation Summary
-          </Card.Heading>
-          <h3 className={style.panelSubHeader}>Linked Programme</h3>
-          <SummaryList noBorder>
-            <SummaryList.Row>
-              <SummaryList.Key>Programme name</SummaryList.Key>
-              <SummaryList.Value>{programmeMembership.name}</SummaryList.Value>
-            </SummaryList.Row>
-            <SummaryList.Row>
-              <SummaryList.Key>Start date</SummaryList.Key>
-              <SummaryList.Value>
-                {dayjs(programmeMembership.startDate).format("DD/MM/YYYY")}
-              </SummaryList.Value>
-            </SummaryList.Row>
-            <SummaryList.Row>
-              <SummaryList.Key>Completion date</SummaryList.Key>
-              <SummaryList.Value>
-                {dayjs(programmeMembership.endDate).format("DD/MM/YYYY")}
-              </SummaryList.Value>
-            </SummaryList.Row>
-          </SummaryList>
-          <h3 className={style.panelSubHeader}>Current WTE percentage</h3>
-          <SummaryList noBorder>
-            <SummaryList.Row>
-              <SummaryList.Key>WTE</SummaryList.Key>
-              <SummaryList.Value>
-                {programmeMembership.wte && programmeMembership.wte * 100}%
-              </SummaryList.Value>
-            </SummaryList.Row>
-          </SummaryList>
-          <h3 className={style.panelSubHeader}>Proposed changes</h3>
-          {changes.map((change, index) => (
-            <div key={index}>
-              <SummaryList noBorder>
-                <SummaryList.Row>
-                  <SummaryList.Key>Change type</SummaryList.Key>
-                  <SummaryList.Value>
-                    {change.type === "LTFT" && "Changing hours (LTFT)"}
-                  </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                  <SummaryList.Key>Change date</SummaryList.Key>
-                  <SummaryList.Value>
-                    {dayjs(change.startDate).format("DD/MM/YYYY")}
-                  </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                  <SummaryList.Key>Proposed WTE</SummaryList.Key>
-                  <SummaryList.Value data-cy="cct-view-new-wte">
-                    {change.wte && change.wte * 100}%
-                  </SummaryList.Value>
-                </SummaryList.Row>
-              </SummaryList>
-            </div>
-          ))}
-          <SummaryList noBorder>
-            <SummaryList.Row>
-              <SummaryList.Key>New completion date</SummaryList.Key>
-              <SummaryList.Value
-                style={{ color: "green", fontWeight: "bold" }}
-                data-cy="saved-cct-date"
-              >
-                {cctDate && dayjs(cctDate).format("DD/MM/YYYY")}
-              </SummaryList.Value>
-            </SummaryList.Row>
-          </SummaryList>
-          {name && created && lastModified && (
-            <CalcDetails
-              created={created}
-              lastModified={lastModified}
-              name={name}
-            />
-          )}
-        </Card.Content>
-      </Card>
+      <CctCalcSummaryDetails viewedCalc={viewedCalc} />
       <Row>
         <Col width="full">
           {cctFormSaveStatus === "failed" && (
@@ -173,5 +90,93 @@ export function CctCalcSummary() {
         viewedCalc={viewedCalc}
       />
     </>
+  );
+}
+
+export function CctCalcSummaryDetails({
+  viewedCalc
+}: Readonly<{ viewedCalc: CctCalculation }>) {
+  const { programmeMembership, cctDate, changes, name, created, lastModified } =
+    viewedCalc;
+
+  return (
+    <Card className="pdf-visible">
+      <Card.Content>
+        <Card.Heading data-cy="cct-calc-summary-header">
+          CCT Calculation Summary
+        </Card.Heading>
+        <h3 className={style.panelSubHeader}>Linked Programme</h3>
+        <SummaryList noBorder>
+          <SummaryList.Row>
+            <SummaryList.Key>Programme name</SummaryList.Key>
+            <SummaryList.Value>{programmeMembership.name}</SummaryList.Value>
+          </SummaryList.Row>
+          <SummaryList.Row>
+            <SummaryList.Key>Start date</SummaryList.Key>
+            <SummaryList.Value>
+              {dayjs(programmeMembership.startDate).format("DD/MM/YYYY")}
+            </SummaryList.Value>
+          </SummaryList.Row>
+          <SummaryList.Row>
+            <SummaryList.Key>Completion date</SummaryList.Key>
+            <SummaryList.Value>
+              {dayjs(programmeMembership.endDate).format("DD/MM/YYYY")}
+            </SummaryList.Value>
+          </SummaryList.Row>
+        </SummaryList>
+        <h3 className={style.panelSubHeader}>Current WTE percentage</h3>
+        <SummaryList noBorder>
+          <SummaryList.Row>
+            <SummaryList.Key>WTE</SummaryList.Key>
+            <SummaryList.Value>
+              {programmeMembership.wte && programmeMembership.wte * 100}%
+            </SummaryList.Value>
+          </SummaryList.Row>
+        </SummaryList>
+        <h3 className={style.panelSubHeader}>Proposed changes</h3>
+        {changes.map((change, index) => (
+          <div key={index}>
+            <SummaryList noBorder>
+              <SummaryList.Row>
+                <SummaryList.Key>Change type</SummaryList.Key>
+                <SummaryList.Value>
+                  {change.type === "LTFT" && "Changing hours (LTFT)"}
+                </SummaryList.Value>
+              </SummaryList.Row>
+              <SummaryList.Row>
+                <SummaryList.Key>Change date</SummaryList.Key>
+                <SummaryList.Value>
+                  {dayjs(change.startDate).format("DD/MM/YYYY")}
+                </SummaryList.Value>
+              </SummaryList.Row>
+              <SummaryList.Row>
+                <SummaryList.Key>Proposed WTE</SummaryList.Key>
+                <SummaryList.Value data-cy="cct-view-new-wte">
+                  {change.wte && change.wte * 100}%
+                </SummaryList.Value>
+              </SummaryList.Row>
+            </SummaryList>
+          </div>
+        ))}
+        <SummaryList noBorder>
+          <SummaryList.Row>
+            <SummaryList.Key>New completion date</SummaryList.Key>
+            <SummaryList.Value
+              style={{ color: "green", fontWeight: "bold" }}
+              data-cy="saved-cct-date"
+            >
+              {cctDate && dayjs(cctDate).format("DD/MM/YYYY")}
+            </SummaryList.Value>
+          </SummaryList.Row>
+        </SummaryList>
+        {name && created && lastModified && (
+          <CalcDetails
+            created={created}
+            lastModified={lastModified}
+            name={name}
+          />
+        )}
+      </Card.Content>
+    </Card>
   );
 }

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -17,7 +17,8 @@ import {
   formatFieldName,
   showFormField,
   continueToConfirm,
-  saveFormR
+  saveDraftForm,
+  FormDataType
 } from "../../../utilities/FormBuilderUtilities";
 import { Link } from "react-router-dom";
 import { ImportantText } from "./form-sections/ImportantText";
@@ -29,8 +30,6 @@ import ScrollToTop from "../../common/ScrollToTop";
 import { ExpanderMsg, ExpanderNameType } from "../../common/ExpanderMsg";
 import { FormFieldBuilder } from "./FormFieldBuilder";
 import { useFormContext } from "./FormContext";
-import { FormRPartA } from "../../../models/FormRPartA";
-import { FormRPartB } from "../../../models/FormRPartB";
 
 type FieldType =
   | "text"
@@ -168,12 +167,7 @@ export default function FormBuilder({
 
   const handleSaveBtnClick = async () => {
     setIsSubmitting(true);
-    await saveFormR(
-      jsonForm,
-      formData as FormRPartA | FormRPartB,
-      false,
-      false
-    );
+    await saveDraftForm(jsonForm, formData as FormDataType, false, false);
     setIsSubmitting(false);
   };
 

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -307,7 +307,7 @@ export default function FormBuilder({
             </Button>
           </Col>
           <Col width="one-quarter">
-            <StartOverButton formName={jsonFormName} isFormButton={true} />
+            <StartOverButton formName={jsonFormName} btnLocation="form" />
           </Col>
         </Row>
       </Container>

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -307,7 +307,7 @@ export default function FormBuilder({
             </Button>
           </Col>
           <Col width="one-quarter">
-            <StartOverButton />
+            <StartOverButton formName={jsonFormName} isFormButton={true} />
           </Col>
         </Row>
       </Container>

--- a/components/forms/form-builder/FormView.tsx
+++ b/components/forms/form-builder/FormView.tsx
@@ -17,7 +17,7 @@ import {
 } from "../../../utilities/FormRUtilities";
 import history from "../../navigation/history";
 import {
-  saveFormR,
+  saveDraftForm,
   createErrorObject,
   validateFields
 } from "../../../utilities/FormBuilderUtilities";
@@ -103,7 +103,7 @@ export const FormView = ({
       programmeMembershipId
     } as FormRPartA | FormRPartB;
     setShowModal(false);
-    saveFormR(formJson, updatedFormData, false, true);
+    saveDraftForm(formJson, updatedFormData, false, true);
     setIsSubmitting(false);
   };
 
@@ -180,7 +180,7 @@ export const FormView = ({
                 secondary
                 onClick={async () => {
                   setIsSubmitting(true);
-                  await saveFormR(
+                  await saveDraftForm(
                     formJson,
                     formData as FormRPartA | FormRPartB,
                     false,

--- a/components/forms/form-builder/FormView.tsx
+++ b/components/forms/form-builder/FormView.tsx
@@ -195,7 +195,7 @@ export const FormView = ({
               </Button>
             </Col>
             <Col width="one-quarter">
-              <StartOverButton />
+              <StartOverButton formName={formJson.name} isFormButton={true} />
             </Col>
           </Row>
         </Container>

--- a/components/forms/form-builder/FormView.tsx
+++ b/components/forms/form-builder/FormView.tsx
@@ -195,7 +195,10 @@ export const FormView = ({
               </Button>
             </Col>
             <Col width="one-quarter">
-              <StartOverButton formName={formJson.name} isFormButton={true} />
+              <StartOverButton
+                formName={formJson.name}
+                btnLocation="formView"
+              />
             </Col>
           </Row>
         </Container>

--- a/components/forms/form-builder/FormViewBuilder.tsx
+++ b/components/forms/form-builder/FormViewBuilder.tsx
@@ -11,7 +11,8 @@ import {
 } from "nhsuk-react-components";
 import {
   formatFieldName,
-  handleEditSection
+  handleEditSection,
+  showFormField
 } from "../../../utilities/FormBuilderUtilities";
 import { DateUtilities } from "../../../utilities/DateUtilities";
 import history from "../../navigation/history";
@@ -28,10 +29,7 @@ function VisibleField({
   formData,
   formErrors
 }: Readonly<VisibleFieldProps>) {
-  const isVisible =
-    field.visible ||
-    field?.visibleIf?.includes(formData[field.parent as string]);
-
+  const isVisible = showFormField(field, formData);
   if (isVisible) {
     if (field.type === "dto") {
       return (

--- a/components/forms/form-builder/FormViewBuilder.tsx
+++ b/components/forms/form-builder/FormViewBuilder.tsx
@@ -118,6 +118,7 @@ export default function FormViewBuilder({
 function displayListValue(fieldVal: any, fieldType?: string) {
   if (fieldVal === null || fieldVal === "") return "Not provided";
   if (fieldType === "array") {
+    if (fieldVal.length === 0) return "Not provided";
     return fieldVal.map((item: any, index: number) => (
       <Card key={index} className="container-form-view">
         <Card.Content>
@@ -143,5 +144,5 @@ function displayListValue(fieldVal: any, fieldType?: string) {
   if (typeof fieldVal === "boolean") {
     return fieldVal ? "Yes" : "No";
   }
-  return fieldVal.toString();
+  return fieldVal?.toString();
 }

--- a/components/forms/ltft/Ltft.tsx
+++ b/components/forms/ltft/Ltft.tsx
@@ -3,6 +3,7 @@ import { Route, Switch } from "react-router-dom";
 import PageNotFound from "../../common/PageNotFound";
 import { LtftHome } from "./LtftHome";
 import { LtftForm } from "./LtftForm";
+import { LtftFormView } from "./LtftFormView";
 
 export function Ltft() {
   return (
@@ -19,6 +20,7 @@ export function Ltft() {
       <Switch>
         <Route exact path="/ltft" render={() => <LtftHome />} />
         <Route exact path="/ltft/create" render={() => <LtftForm />} />
+        <Route exact path="/ltft/confirm" render={() => <LtftFormView />} />
         <Route path="/ltft/*" component={PageNotFound} />
       </Switch>
     </>

--- a/components/forms/ltft/LtftForm.tsx
+++ b/components/forms/ltft/LtftForm.tsx
@@ -46,7 +46,7 @@ export function LtftForm() {
     { value: "Trust Administrator", label: "Trust Administrator" }
   ];
 
-  return formData?.declarations.discussedWithTpd ? (
+  return formData?.declarations?.discussedWithTpd ? (
     <div>
       <h2>Main application form</h2>
       <FormProvider

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -46,7 +46,7 @@ export const LtftFormView = () => {
       <Container>
         <Row>
           <Col width="one-quarter">
-            <StartOverButton formName={formJson.name} isFormButton={true} />
+            <StartOverButton formName={formJson.name} btnLocation="formView" />
           </Col>
         </Row>
       </Container>

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -10,11 +10,16 @@ import { Col, Container, Row, WarningCallout } from "nhsuk-react-components";
 import Declarations from "../form-builder/Declarations";
 import { CctCalcSummaryDetails } from "../cct/CctCalcSummary";
 import { StartOverButton } from "../StartOverButton";
+import { CctCalculation } from "../../../redux/slices/cctSlice";
 
 export const LtftFormView = () => {
   const formData = useSelectFormData(ltftJson.name as FormName) as LtftObj;
   const canEditStatus = useAppSelector(state => state.ltft.canEdit);
-  const cctSnapshot = useAppSelector(state => state.ltft.LtftCctSnapshot);
+  const cctSnapshot: CctCalculation = {
+    cctDate: formData?.change?.cctDate,
+    programmeMembership: formData?.programmeMembership,
+    changes: [formData?.change]
+  };
   const formJson = ltftJson as Form;
   const redirectPath = "/ltft";
   const [canSubmit, setCanSubmit] = useState(false);

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -1,0 +1,45 @@
+import { useAppSelector } from "../../../redux/hooks/hooks";
+import { Redirect } from "react-router-dom";
+import { LtftObj } from "../../../redux/slices/ltftSlice";
+import { useSelectFormData } from "../../../utilities/hooks/useSelectFormData";
+import { Form, FormName } from "../form-builder/FormBuilder";
+import ltftJson from "./ltft.json";
+import FormViewBuilder from "../form-builder/FormViewBuilder";
+import { useState } from "react";
+import { WarningCallout } from "nhsuk-react-components";
+import Declarations from "../form-builder/Declarations";
+import { CctCalcSummaryDetails } from "../cct/CctCalcSummary";
+
+export const LtftFormView = () => {
+  const formData = useSelectFormData(ltftJson.name as FormName) as LtftObj;
+  const canEditStatus = useAppSelector(state => state.ltft.canEdit);
+  const cctSnapshot = useAppSelector(state => state.ltft.LtftCctSnapshot);
+  const formJson = ltftJson as Form;
+  const redirectPath = "/ltft";
+  const [canSubmit, setCanSubmit] = useState(false);
+  return formData?.traineeTisId ? (
+    <>
+      <CctCalcSummaryDetails viewedCalc={cctSnapshot} />
+      <FormViewBuilder
+        jsonForm={formJson}
+        formData={formData}
+        canEdit={canEditStatus}
+        formErrors={{}}
+      />
+      <WarningCallout>
+        <WarningCallout.Label>Declarations</WarningCallout.Label>
+        <form>
+          <Declarations
+            setCanSubmit={setCanSubmit}
+            canEdit={canEditStatus}
+            formJson={formJson}
+          />
+        </form>
+      </WarningCallout>
+      <p>Btns to go here: submit (to open modal), save & exit, start over </p>
+      <p>Modal to name the form etc. to go here</p>
+    </>
+  ) : (
+    <Redirect to={redirectPath} />
+  );
+};

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -6,9 +6,10 @@ import { Form, FormName } from "../form-builder/FormBuilder";
 import ltftJson from "./ltft.json";
 import FormViewBuilder from "../form-builder/FormViewBuilder";
 import { useState } from "react";
-import { WarningCallout } from "nhsuk-react-components";
+import { Col, Container, Row, WarningCallout } from "nhsuk-react-components";
 import Declarations from "../form-builder/Declarations";
 import { CctCalcSummaryDetails } from "../cct/CctCalcSummary";
+import { StartOverButton } from "../StartOverButton";
 
 export const LtftFormView = () => {
   const formData = useSelectFormData(ltftJson.name as FormName) as LtftObj;
@@ -36,8 +37,15 @@ export const LtftFormView = () => {
           />
         </form>
       </WarningCallout>
-      <p>Btns to go here: submit (to open modal), save & exit, start over </p>
-      <p>Modal to name the form etc. to go here</p>
+      {/* Btns to go here: submit (to open modal), save & exit, start over */}
+      <Container>
+        <Row>
+          <Col width="one-quarter">
+            <StartOverButton formName={formJson.name} isFormButton={true} />
+          </Col>
+        </Row>
+      </Container>
+      {/* Modal to name the form etc. to go here */}
     </>
   ) : (
     <Redirect to={redirectPath} />

--- a/components/forms/ltft/LtftHome.tsx
+++ b/components/forms/ltft/LtftHome.tsx
@@ -9,7 +9,6 @@ import {
 import { LtftTracker } from "./LtftTracker";
 import history from "../../navigation/history";
 import {
-  fetchLtftSummaryList,
   LtftSummaryObj,
   updatedLtftFormsRefreshNeeded
 } from "../../../redux/slices/ltftSummaryListSlice";
@@ -17,15 +16,11 @@ import LtftSummary from "./LtftSummary";
 import { mockLtftsList1 } from "../../../mock-data/mock-ltft-data";
 import { DateUtilities } from "../../../utilities/DateUtilities";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks/hooks";
-import useIsBetaTester from "../../../utilities/hooks/useIsBetaTester";
-import { useEffect } from "react";
 import Loading from "../../common/Loading";
 import { StartOverButton } from "../StartOverButton";
-import {
-  loadTheSavedForm,
-  resetForm
-} from "../../../utilities/FormBuilderUtilities";
+import { loadTheSavedForm } from "../../../utilities/FormBuilderUtilities";
 import ErrorPage from "../../common/ErrorPage";
+import { useLtftHomeStartover } from "../../../utilities/hooks/useLtftHomeStartover";
 
 export function LtftHome() {
   const ltftSummary = useAppSelector(
@@ -34,18 +29,7 @@ export function LtftHome() {
   const ltftFormsListStatus = useAppSelector(
     state => state.ltftSummaryList?.status
   );
-  const needLtftFormsRefresh = useAppSelector(
-    state => state.ltftSummaryList?.ltftFormsRefreshNeeded
-  );
-  const dispatch = useAppDispatch();
-  const isBetaTester = useIsBetaTester();
-  useEffect(() => {
-    if (isBetaTester) {
-      dispatch(fetchLtftSummaryList());
-      updatedLtftFormsRefreshNeeded(false);
-      resetForm("ltft");
-    }
-  }, [dispatch, isBetaTester, needLtftFormsRefresh]);
+  useLtftHomeStartover();
 
   // TODO - use real data for Summary Table when submission logic added
   const mockLtftSummary = mockLtftsList1;

--- a/components/forms/ltft/LtftHome.tsx
+++ b/components/forms/ltft/LtftHome.tsx
@@ -29,7 +29,6 @@ export function LtftHome() {
   const ltftFormsListStatus = useAppSelector(
     state => state.ltftSummaryList?.status
   );
-  //TODO - add logic to refresh the list after startover on the home page
   const needLtftFormsRefresh = useAppSelector(
     state => state.ltftSummaryList?.ltftFormsRefreshNeeded
   );
@@ -112,6 +111,7 @@ type TrackerSectionBtnsProps = {
 function TrackerSectionBtns({
   draftOrUnsubmittedLtftSummary
 }: Readonly<TrackerSectionBtnsProps>) {
+  const dispatch = useAppDispatch();
   return (
     <div style={{ marginTop: "2rem" }}>
       {draftOrUnsubmittedLtftSummary ? (
@@ -144,6 +144,7 @@ function TrackerSectionBtns({
               <Button
                 data-cy="choose-cct-btn"
                 onClick={() => {
+                  dispatch(updatedLtftFormsRefreshNeeded(false));
                   history.push("/cct");
                 }}
               >

--- a/components/forms/ltft/LtftHome.tsx
+++ b/components/forms/ltft/LtftHome.tsx
@@ -21,7 +21,10 @@ import useIsBetaTester from "../../../utilities/hooks/useIsBetaTester";
 import { useEffect } from "react";
 import Loading from "../../common/Loading";
 import { StartOverButton } from "../StartOverButton";
-import { loadTheSavedForm } from "../../../utilities/FormBuilderUtilities";
+import {
+  loadTheSavedForm,
+  resetForm
+} from "../../../utilities/FormBuilderUtilities";
 import ErrorPage from "../../common/ErrorPage";
 
 export function LtftHome() {
@@ -40,6 +43,7 @@ export function LtftHome() {
     if (isBetaTester) {
       dispatch(fetchLtftSummaryList());
       updatedLtftFormsRefreshNeeded(false);
+      resetForm("ltft");
     }
   }, [dispatch, isBetaTester, needLtftFormsRefresh]);
 

--- a/components/forms/ltft/LtftHome.tsx
+++ b/components/forms/ltft/LtftHome.tsx
@@ -22,6 +22,7 @@ import { useEffect } from "react";
 import Loading from "../../common/Loading";
 import { StartOverButton } from "../StartOverButton";
 import { loadTheSavedForm } from "../../../utilities/FormBuilderUtilities";
+import ErrorPage from "../../common/ErrorPage";
 
 export function LtftHome() {
   const ltftSummary = useAppSelector(
@@ -59,49 +60,50 @@ export function LtftHome() {
 
   if (ltftFormsListStatus === "loading") return <Loading />;
 
+  if (ltftFormsListStatus === "failed")
+    return <ErrorPage message="There was a problem loading this page." />;
+
   return (
-    ltftFormsListStatus === "succeeded" && (
-      <>
-        <Card>
-          <Card.Content>
-            <>
-              <Card.Heading data-cy="ltft-tracker-header">
-                {draftOrUnsubmittedLtftSummary
-                  ? "In progress application"
-                  : "New application"}
-              </Card.Heading>
-              <LtftTracker
-                draftOrUnsubmittedLtftSummary={draftOrUnsubmittedLtftSummary}
-              />
-              <TrackerSectionBtns
-                draftOrUnsubmittedLtftSummary={draftOrUnsubmittedLtftSummary}
-              />
-            </>
-          </Card.Content>
-        </Card>
-        <Card>
-          <Card.Content>
-            <WarningCallout data-cy="ltftWarning">
-              <WarningCallout.Label visuallyHiddenText={false}>
-                For Demonstration Only
-              </WarningCallout.Label>
-              <p>
-                The table below has <strong>dummy data</strong> and is read only
-                for demonstrating the future layout of the LTFT Applications
-                Summary.
-              </p>
-            </WarningCallout>
-            <Card.Heading data-cy="ltft-summary-header">
-              Previous applications summary
+    <>
+      <Card>
+        <Card.Content>
+          <>
+            <Card.Heading data-cy="ltft-tracker-header">
+              {draftOrUnsubmittedLtftSummary
+                ? "In progress application"
+                : "New application"}
             </Card.Heading>
-            <LtftSummary
-              ltftSummaryStatus={ltftFormsListStatus}
-              ltftSummaryList={previousLtftSummaries}
+            <LtftTracker
+              draftOrUnsubmittedLtftSummary={draftOrUnsubmittedLtftSummary}
             />
-          </Card.Content>
-        </Card>
-      </>
-    )
+            <TrackerSectionBtns
+              draftOrUnsubmittedLtftSummary={draftOrUnsubmittedLtftSummary}
+            />
+          </>
+        </Card.Content>
+      </Card>
+      <Card>
+        <Card.Content>
+          <WarningCallout data-cy="ltftWarning">
+            <WarningCallout.Label visuallyHiddenText={false}>
+              For Demonstration Only
+            </WarningCallout.Label>
+            <p>
+              The table below has <strong>dummy data</strong> and is read only
+              for demonstrating the future layout of the LTFT Applications
+              Summary.
+            </p>
+          </WarningCallout>
+          <Card.Heading data-cy="ltft-summary-header">
+            Previous applications summary
+          </Card.Heading>
+          <LtftSummary
+            ltftSummaryStatus={ltftFormsListStatus}
+            ltftSummaryList={previousLtftSummaries}
+          />
+        </Card.Content>
+      </Card>
+    </>
   );
 }
 

--- a/components/forms/ltft/LtftHome.tsx
+++ b/components/forms/ltft/LtftHome.tsx
@@ -21,6 +21,7 @@ import useIsBetaTester from "../../../utilities/hooks/useIsBetaTester";
 import { useEffect } from "react";
 import Loading from "../../common/Loading";
 import { StartOverButton } from "../StartOverButton";
+import { loadTheSavedForm } from "../../../utilities/FormBuilderUtilities";
 
 export function LtftHome() {
   const ltftSummary = useAppSelector(
@@ -112,13 +113,19 @@ function TrackerSectionBtns({
   draftOrUnsubmittedLtftSummary
 }: Readonly<TrackerSectionBtnsProps>) {
   const dispatch = useAppDispatch();
+  const handleClick = () => {
+    loadTheSavedForm("/ltft", draftOrUnsubmittedLtftSummary?.id ?? "", history);
+  };
   return (
     <div style={{ marginTop: "2rem" }}>
       {draftOrUnsubmittedLtftSummary ? (
         <Container>
           <Row>
             <Col width="two-thirds">
-              <Button data-cy="continue-application-button">
+              <Button
+                data-cy="continue-application-button"
+                onClick={handleClick}
+              >
                 {`Continue ${
                   draftOrUnsubmittedLtftSummary?.status === "DRAFT"
                     ? "draft"

--- a/components/forms/ltft/LtftHome.tsx
+++ b/components/forms/ltft/LtftHome.tsx
@@ -144,7 +144,7 @@ function TrackerSectionBtns({
             <Col width="one-third">
               <StartOverButton
                 formName="ltft"
-                isFormButton={false}
+                btnLocation="formsList"
                 formsListDraftId={draftOrUnsubmittedLtftSummary.id}
               />
             </Col>

--- a/components/forms/ltft/LtftHome.tsx
+++ b/components/forms/ltft/LtftHome.tsx
@@ -20,6 +20,7 @@ import { useAppDispatch, useAppSelector } from "../../../redux/hooks/hooks";
 import useIsBetaTester from "../../../utilities/hooks/useIsBetaTester";
 import { useEffect } from "react";
 import Loading from "../../common/Loading";
+import { StartOverButton } from "../StartOverButton";
 
 export function LtftHome() {
   const ltftSummary = useAppSelector(
@@ -39,7 +40,7 @@ export function LtftHome() {
       dispatch(fetchLtftSummaryList());
       updatedLtftFormsRefreshNeeded(false);
     }
-  }, [dispatch, isBetaTester]);
+  }, [dispatch, isBetaTester, needLtftFormsRefresh]);
 
   // TODO - use real data for Summary Table when submission logic added
   const mockLtftSummary = mockLtftsList1;
@@ -128,9 +129,11 @@ function TrackerSectionBtns({
           </Row>
           <Row>
             <Col width="one-third">
-              <Button secondary data-cy="ltft-startover-btn">
-                Start over
-              </Button>
+              <StartOverButton
+                formName="ltft"
+                isFormButton={false}
+                formsListDraftId={draftOrUnsubmittedLtftSummary.id}
+              />
             </Col>
           </Row>
         </Container>

--- a/components/forms/ltft/ltft.json
+++ b/components/forms/ltft/ltft.json
@@ -31,6 +31,7 @@
             {
               "name": "otherDiscussions",
               "type": "array",
+              "label": "Other Discussions",
               "visible": true,
               "objectFields": [
                 {
@@ -177,5 +178,14 @@
       ]
     }
   ],
-  "declarations": []
+  "declarations": [
+    {
+      "name": "informationIsCorrect",
+      "label": "I confirm that the information I have provided is correct and accurate to the best of my knowledge."
+    },
+    {
+      "name": "notGuaranteed",
+      "label": "I understand that approval of my application is not guaranteed."
+    }
+  ]
 }

--- a/cypress/component/forms/ltft/LtftHome.cy.tsx
+++ b/cypress/component/forms/ltft/LtftHome.cy.tsx
@@ -3,9 +3,12 @@ import { MemoryRouter } from "react-router-dom";
 import { mount } from "cypress/react18";
 import store from "../../../../redux/store/store";
 import { LtftHome } from "../../../../components/forms/ltft/LtftHome";
+import { updatedLtftSummaryList } from "../../../../redux/slices/ltftSummaryListSlice";
+import { mockLtftsList1 } from "../../../../mock-data/mock-ltft-data";
+import * as hooks from "../../../../utilities/hooks/useIsBetaTester";
 
-describe("LtftHome", () => {
-  it("renders the LtftHome component", () => {
+describe("LtftHome - new application", () => {
+  it("renders the LtftHome component with 'new application' tracker", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/ltft"]}>
@@ -15,15 +18,32 @@ describe("LtftHome", () => {
     );
     cy.get('[data-cy="ltft-tracker-header"]')
       .should("exist")
-      .contains("In progress application");
+      .contains("New application");
     cy.get('[data-cy="ltft-summary-header"]')
       .should("exist")
       .contains("Previous applications summary");
-    cy.get('[data-cy="continue-application-button"]')
+    cy.get('[data-cy="choose-cct-btn"]')
       .should("exist")
-      .contains("Continue draft application");
-    cy.get('[data-cy="ltft-startover-btn"]')
-      .should("exist")
-      .contains("Start over");
+      .contains(
+        "Choose a CCT Calculation to begin your Changing hours (LTFT) application"
+      );
+    cy.get('[data-cy="ltft-startover-btn"]').should("not.exist");
+  });
+
+  it("renders the LtftHome component with 'draft' tracker", () => {
+    store.dispatch(updatedLtftSummaryList(mockLtftsList1));
+    cy.stub(hooks, "default").returns(true);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/ltft"]}>
+          <LtftHome />
+        </MemoryRouter>
+      </Provider>
+    );
+    cy.get('[data-cy="ltft-tracker-header"]').contains(
+      "In progress application"
+    );
+    cy.get('[data-cy="continue-application-button"]').should("exist");
+    cy.get('[data-cy="startOverButton"]').should("exist");
   });
 });

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -84,8 +84,18 @@ export const mockLtftDraft0: LtftObj = {
   reasonsSelected: null,
   reasonsOtherDetail: null,
   status: {
-    current: "DRAFT",
-    history: null
+    current: {
+      state: "DRAFT",
+      detail: "",
+      modifiedBy: {
+        name: "",
+        email: "",
+        role: ""
+      },
+      timestamp: "",
+      revision: 0
+    },
+    history: []
   }
 };
 
@@ -131,7 +141,17 @@ export const mockLtftDto1 = {
     otherDetail: "my other reason"
   },
   status: {
-    current: mockLtftDraft1.status.current,
+    current: {
+      state: mockLtftDraft1.status.current,
+      detail: "",
+      modifiedBy: {
+        name: "",
+        email: "",
+        role: ""
+      },
+      timestamp: "",
+      revision: 0
+    },
     history: []
   },
   created: "2025-01-1T14:50:36.941Z",

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -146,7 +146,10 @@ export const mockLtftDto1 = {
   status: {
     current: {
       state: mockLtftDraft1.status.current,
-      detail: "",
+      detail: {
+        reason: "",
+        message: ""
+      },
       modifiedBy: {
         name: "",
         email: "",

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -86,7 +86,10 @@ export const mockLtftDraft0: LtftObj = {
   status: {
     current: {
       state: "DRAFT",
-      detail: "",
+      detail: {
+        reason: "",
+        message: ""
+      },
       modifiedBy: {
         name: "",
         email: "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.111.3",
+  "version": "0.112.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.111.3",
+      "version": "0.112.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",
@@ -14909,10 +14909,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -37074,9 +37077,12 @@
       }
     },
     "dompurify": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "requires": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "dot-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.111.3",
+  "version": "0.112.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/redux/slices/formsSlice.ts
+++ b/redux/slices/formsSlice.ts
@@ -8,7 +8,7 @@ import { toastErrText } from "../../utilities/Constants";
 import { ToastType, showToast } from "../../components/common/ToastMessage";
 import {
   DraftFormProps,
-  setDraftFormProps
+  setDraftFormRProps
 } from "../../utilities/FormBuilderUtilities";
 
 interface IForms {
@@ -68,7 +68,7 @@ const formsSlice = createSlice({
         state.submittedForms = action.payload.filter(
           (form: IFormR) => form.lifecycleState === LifeCycleState.Submitted
         );
-        state.draftFormProps = setDraftFormProps(action.payload);
+        state.draftFormProps = setDraftFormRProps(action.payload);
       })
       .addCase(fetchForms.rejected, (state, { error }) => {
         state.status = "failed";

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -72,6 +72,14 @@ export type StatusType = {
   history: HistoryType[] | null;
 };
 
+export type StatusInfo = {
+  state: LtftFormStatus;
+  detail: string;
+  modifiedBy: LtftDiscussion;
+  timestamp: string;
+  revision: number;
+};
+
 export type LtftObj = {
   traineeTisId?: string;
   id?: string;

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { CctCalculation } from "./cctSlice";
+import { CctCalculation, CctType } from "./cctSlice";
 import { ProfileSType } from "../../utilities/ProfileUtilities";
 import {
   mapLtftDtoToObj,
@@ -22,7 +22,7 @@ export type LtftFormStatus =
 export type LtftCctChange = {
   calculationId: string;
   cctDate: Date | string;
-  type: string;
+  type: CctType;
   startDate: Date | string;
   wte: number;
   changeId: string;

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -181,7 +181,7 @@ const ltftSlice = createSlice({
   name: "ltft",
   initialState,
   reducers: {
-    resetToInit() {
+    resetToInitLtft() {
       return initialState;
     },
     setLtftCctSnapshot(state, action: PayloadAction<CctCalculation>) {
@@ -329,7 +329,7 @@ const ltftSlice = createSlice({
 });
 
 export const {
-  resetToInit,
+  resetToInitLtft,
   setLtftCctSnapshot,
   updatedLtft,
   updatedCanEditLtft,

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -169,6 +169,14 @@ export const updateLtft = createAsyncThunk(
   }
 );
 
+export const deleteLtft = createAsyncThunk(
+  "ltft/deleteLtft",
+  async (formId: string) => {
+    const formsService = new FormsService();
+    return formsService.deleteLtft(formId);
+  }
+);
+
 const ltftSlice = createSlice({
   name: "ltft",
   initialState,
@@ -300,6 +308,22 @@ const ltftSlice = createSlice({
             `${error.code}-${error.message}`
           );
         }
+      })
+      .addCase(deleteLtft.pending, state => {
+        state.status = "deleting";
+      })
+      .addCase(deleteLtft.fulfilled, state => {
+        state.status = "succeeded";
+        showToast(toastSuccessText.deleteLtft, ToastType.SUCCESS);
+      })
+      .addCase(deleteLtft.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.error.message;
+        showToast(
+          toastErrText.deleteLtft,
+          ToastType.ERROR,
+          `${action.error.code}-${action.error.message}`
+        );
       });
   }
 });

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -40,6 +40,11 @@ type LtftDiscussion = {
   role: string;
 };
 
+type LtftStatusDetails = {
+  reason: string;
+  message: string;
+};
+
 type LtftPd = {
   title?: ProfileSType;
   surname: ProfileSType;
@@ -69,7 +74,7 @@ export type StatusLtft = {
 
 export type StatusInfo = {
   state: LtftFormStatus;
-  detail: string;
+  detail: LtftStatusDetails;
   modifiedBy: LtftDiscussion;
   timestamp: string;
   revision: number;

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -177,6 +177,15 @@ export const deleteLtft = createAsyncThunk(
   }
 );
 
+export const loadSavedLtft = createAsyncThunk(
+  "ltft/loadSavedLtft",
+  async (id: string) => {
+    const formsService = new FormsService();
+    const response = await formsService.getLtftFormById(id);
+    return mapLtftDtoToObj(response.data);
+  }
+);
+
 const ltftSlice = createSlice({
   name: "ltft",
   initialState,
@@ -321,6 +330,22 @@ const ltftSlice = createSlice({
         state.error = action.error.message;
         showToast(
           toastErrText.deleteLtft,
+          ToastType.ERROR,
+          `${action.error.code}-${action.error.message}`
+        );
+      })
+      .addCase(loadSavedLtft.pending, state => {
+        state.status = "loading";
+      })
+      .addCase(loadSavedLtft.fulfilled, (state, action) => {
+        state.status = "succeeded";
+        state.formData = action.payload;
+      })
+      .addCase(loadSavedLtft.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.error.message;
+        showToast(
+          toastErrText.loadLtft,
           ToastType.ERROR,
           `${action.error.code}-${action.error.message}`
         );

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -181,6 +181,9 @@ const ltftSlice = createSlice({
     },
     updatedCanEditLtft(state, action: PayloadAction<boolean>) {
       state.canEdit = action.payload;
+    },
+    updatedEditPageNumberLtft(state, action: PayloadAction<number>) {
+      state.editPageNumber = action.payload;
     }
   },
   extraReducers(builder): void {
@@ -302,7 +305,8 @@ export const {
   resetToInit,
   setLtftCctSnapshot,
   updatedLtft,
-  updatedCanEditLtft
+  updatedCanEditLtft,
+  updatedEditPageNumberLtft
 } = ltftSlice.actions;
 
 export default ltftSlice.reducer;

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -62,14 +62,9 @@ type LtftPm = {
   designatedBodyCode: string;
 };
 
-type HistoryType = {
-  status: LtftFormStatus;
-  timestamp: string;
-};
-
-export type StatusType = {
-  current: LtftFormStatus;
-  history: HistoryType[] | null;
+export type StatusLtft = {
+  current: StatusInfo;
+  history: StatusInfo[];
 };
 
 export type StatusInfo = {
@@ -93,7 +88,7 @@ export type LtftObj = {
   programmeMembership: LtftPm;
   reasonsSelected: string[] | null;
   reasonsOtherDetail: string | null;
-  status: StatusType;
+  status: StatusLtft;
   created?: Date | string;
   lastModified?: Date | string;
 };

--- a/redux/slices/ltftSummaryListSlice.ts
+++ b/redux/slices/ltftSummaryListSlice.ts
@@ -16,12 +16,14 @@ type LtftSummaryList = {
   ltftList: LtftSummaryObj[];
   status: string;
   error: any;
+  ltftFormsRefreshNeeded: boolean;
 };
 
 export const initialState: LtftSummaryList = {
   ltftList: [],
   status: "idle",
-  error: ""
+  error: "",
+  ltftFormsRefreshNeeded: false
 };
 
 export const fetchLtftSummaryList = createAsyncThunk(
@@ -45,6 +47,9 @@ export const ltftSummaryListSlice = createSlice({
     },
     updatedLtftSummaryListStatus: (state, action) => {
       state.status = action.payload;
+    },
+    updatedLtftFormsRefreshNeeded: (state, action) => {
+      state.ltftFormsRefreshNeeded = action.payload;
     }
   },
   extraReducers(builder) {
@@ -68,7 +73,10 @@ export const ltftSummaryListSlice = createSlice({
   }
 });
 
-export const { updatedLtftSummaryList, updatedLtftSummaryListStatus } =
-  ltftSummaryListSlice.actions;
+export const {
+  updatedLtftSummaryList,
+  updatedLtftSummaryListStatus,
+  updatedLtftFormsRefreshNeeded
+} = ltftSummaryListSlice.actions;
 
 export default ltftSummaryListSlice.reducer;

--- a/services/FormsService.ts
+++ b/services/FormsService.ts
@@ -96,4 +96,8 @@ export class FormsService extends ApiService {
   async updateLtft(mappedFormData: LtftDto): Promise<AxiosResponse<LtftDto>> {
     return this.put<LtftDto>(`/ltft/${mappedFormData.id}`, mappedFormData);
   }
+
+  async deleteLtft(formId: string): Promise<AxiosResponse> {
+    return this.delete(`/ltft/${formId}`);
+  }
 }

--- a/services/FormsService.ts
+++ b/services/FormsService.ts
@@ -6,6 +6,7 @@ import { FeatureFlags } from "../models/FeatureFlags";
 import { IFormR } from "../models/IFormR";
 import { ProgrammeMembership } from "../models/ProgrammeMembership";
 import { LtftSummaryObj } from "../redux/slices/ltftSummaryListSlice";
+import { LtftDto } from "../utilities/ltftUtilities";
 export class FormsService extends ApiService {
   constructor() {
     super("/api/forms");
@@ -86,5 +87,13 @@ export class FormsService extends ApiService {
 
   async getLtftSummaryList(): Promise<AxiosResponse<LtftSummaryObj[]>> {
     return this.get<LtftSummaryObj[]>("/ltft");
+  }
+
+  async saveLtft(mappedFormData: LtftDto): Promise<AxiosResponse<LtftDto>> {
+    return this.post<LtftDto>("/ltft", mappedFormData);
+  }
+
+  async updateLtft(mappedFormData: LtftDto): Promise<AxiosResponse<LtftDto>> {
+    return this.put<LtftDto>("/ltft", mappedFormData);
   }
 }

--- a/services/FormsService.ts
+++ b/services/FormsService.ts
@@ -100,4 +100,8 @@ export class FormsService extends ApiService {
   async deleteLtft(formId: string): Promise<AxiosResponse> {
     return this.delete(`/ltft/${formId}`);
   }
+
+  async getLtftFormById(id: string): Promise<AxiosResponse<LtftDto>> {
+    return this.get<LtftDto>(`/ltft/${id}`);
+  }
 }

--- a/services/FormsService.ts
+++ b/services/FormsService.ts
@@ -94,6 +94,6 @@ export class FormsService extends ApiService {
   }
 
   async updateLtft(mappedFormData: LtftDto): Promise<AxiosResponse<LtftDto>> {
-    return this.put<LtftDto>("/ltft", mappedFormData);
+    return this.put<LtftDto>(`/ltft/${mappedFormData.id}`, mappedFormData);
   }
 }

--- a/utilities/Constants.tsx
+++ b/utilities/Constants.tsx
@@ -238,23 +238,36 @@ export const PANEL_KEYS: any = {
 };
 
 const dodgyConnection = "Please check your internet connection and try again.";
+const formA = "Form R (Part A)";
+const formB = "Form R (Part B)";
+const ltft = "Changing hours (LTFT) form";
+const noDel = "Couldn't delete your draft ";
+const noLoad = "Couldn't load your saved ";
+const noSave = "Couldn't save your ";
+const noUpdate = "Couldn't update your ";
+const noSubmit = "Couldn't submit your ";
 
 export const toastErrText = {
-  deleteFormA: "Couldn't delete your draft Form R (Part A).",
-  deleteFormB: "Couldn't delete your draft Form R (Part B).",
+  deleteFormA: `${noDel}${formA}.`,
+  deleteFormB: `${noDel}${formB}.`,
+  deleteLtft: `${noDel}${ltft}.`,
   fetchFeatureFlags:
     "Couldn't load some of your new form data (feature flags).",
   fetchForms: " Couldn't load your list of saved forms.",
   fetchReference:
     "Couldn't fetch the data to pre-populate your new form (reference data).",
-  loadSavedFormA: "Couldn't load your saved Form R (Part A).",
-  loadSavedFormB: "Couldn't load your saved Form R (Part B).",
-  saveFormA: "Couldn't save your Form R (Part A).",
-  saveFormB: "Couldn't save your Form R (Part B).",
-  submitFormA: "Couldn't submit your Form R (Part A).",
-  submitFormB: "Couldn't submit your Form R (Part B).",
-  updateFormA: "Couldn't update your Form R (Part A).",
-  updateFormB: "Couldn't update your Form R (Part B).",
+  loadSavedFormA: `${noLoad}${formA}.`,
+  loadSavedFormB: `${noLoad}${formB}.`,
+  loadLtft: `${noLoad}${ltft}.`,
+  saveFormA: `${noSave}${formA}.`,
+  saveFormB: `${noSave}${formB}.`,
+  saveLtft: `${noSave}${ltft}.`,
+  submitFormA: `${noSubmit}${formA}.`,
+  submitFormB: `${noSubmit}${formB}.`,
+  submitLtft: `${noSubmit}${ltft}.`,
+  updateFormA: `${noUpdate}${formA}.`,
+  updateFormB: `${noUpdate}${formB}.`,
+  updateLtft: `${noUpdate}${ltft}.`,
   fetchTraineeProfileData:
     "Couldn't load your personal details (profile data).",
   updateUserAttributes:
@@ -283,15 +296,23 @@ export const toastErrText = {
   loadLtftSummaryListMessage: `Couldn't load your list of saved Changing hours (LTFT) forms. ${dodgyConnection}`
 };
 
+const isDel = "has been deleted.";
+const isSave = "has been saved.";
+const isUpdate = "has been updated.";
+const isSubmit = "has been submitted.";
 export const toastSuccessText = {
-  deleteFormA: "Your draft Form R (Part A) has been deleted.",
-  deleteFormB: "Your draft Form R (Part B) has been deleted.",
-  saveFormA: "Your Form R (Part A) has been saved.",
-  saveFormB: "Your Form R (Part B) has been saved.",
-  updateFormA: "Your Form R (Part A) has been updated.",
-  updateFormB: "Your Form R (Part B) has been updated.",
-  submitFormA: "Your Form R (Part A) has been submitted.",
-  submitFormB: "Your Form R (Part B) has been submitted.",
+  deleteFormA: `Your draft ${formA} ${isDel}`,
+  deleteFormB: `Your draft ${formB} ${isDel}`,
+  deleteLtft: `Your draft ${ltft} ${isDel}`,
+  saveFormA: `Your ${formA} ${isSave}`,
+  saveFormB: `Your ${formB} ${isSave}`,
+  saveLtft: `Your ${ltft} ${isSave}`,
+  updateFormA: `Your ${formA} ${isUpdate}`,
+  updateFormB: `Your ${formB} ${isUpdate}`,
+  updateLtft: `Your ${ltft} ${isUpdate}`,
+  submitFormA: `Your ${formA} ${isSubmit}`,
+  submitFormB: `Your ${formB} ${isSubmit}`,
+  submitLtft: `Your ${ltft} ${isSubmit}`,
   verifyPhone:
     "Your phone has been verified. An SMS code from HEE should arrive soon",
   getPreferredMfaSms:

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -284,7 +284,7 @@ export function setDraftFormProps(forms: IFormR[]): DraftFormProps | null {
   return null;
 }
 // NOTE: This function sets the hidden form fields to null whilst retaining the precious formData for submission
-function setFormRDataForSubmit(
+export function setFormRDataForSubmit(
   jsonForm: Form,
   formData: FormRPartA | FormRPartB
 ): FormRPartA | FormRPartB {

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -36,7 +36,14 @@ import { IFormR } from "../models/IFormR";
 import dayjs from "dayjs";
 import { LinkedFormRDataType } from "../components/forms/form-linker/FormLinkerForm";
 import history from "../components/navigation/history";
-import { LtftObj, saveLtft, updateLtft } from "../redux/slices/ltftSlice";
+import {
+  LtftObj,
+  saveLtft,
+  updatedCanEditLtft,
+  updatedEditPageNumberLtft,
+  updatedLtft,
+  updateLtft
+} from "../redux/slices/ltftSlice";
 
 export function mapItemToNewFormat(item: KeyValue): {
   value: string;
@@ -69,9 +76,12 @@ export async function loadTheSavedForm(
 export function getEditPageNumber(formName: string) {
   if (formName === "formA") {
     return store.getState().formA.editPageNumber;
-  } else {
+  } else if (formName === "formB") {
     return store.getState().formB.editPageNumber;
+  } else if (formName === "ltft") {
+    return store.getState().ltft.editPageNumber;
   }
+  return 0;
 }
 
 // This will be used when reviewing a multi-page form to send the user to the correct page to edit
@@ -117,6 +127,9 @@ export function continueToConfirm(formName: string, formData: FormData) {
   } else if (formName === "formB") {
     store.dispatch(updatedFormB(formData as FormRPartB));
     store.dispatch(updatedCanEditB(true));
+  } else if (formName === "ltft") {
+    store.dispatch(updatedLtft(formData as LtftObj));
+    store.dispatch(updatedCanEditLtft(true));
   }
   history.push(redirectPath);
 }
@@ -126,12 +139,13 @@ export function handleEditSection(
   formName: string,
   history: any
 ) {
-  const redirectPath =
-    formName === "formA" ? "/formr-a/create" : "/formr-b/create";
+  const redirectPath = `${chooseRedirectPath(formName)}/create`;
   if (formName === "formA") {
     store.dispatch(updatedEditPageNumber(pageNum));
-  } else {
+  } else if (formName === "formB") {
     store.dispatch(updatedEditPageNumberB(pageNum));
+  } else if (formName === "ltft") {
+    store.dispatch(updatedEditPageNumberLtft(pageNum));
   }
   history.push(redirectPath);
 }

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -36,7 +36,7 @@ import { IFormR } from "../models/IFormR";
 import dayjs from "dayjs";
 import { LinkedFormRDataType } from "../components/forms/form-linker/FormLinkerForm";
 import history from "../components/navigation/history";
-import { LtftObj, saveLtft } from "../redux/slices/ltftSlice";
+import { LtftObj, saveLtft, updateLtft } from "../redux/slices/ltftSlice";
 
 export function mapItemToNewFormat(item: KeyValue): {
   value: string;
@@ -340,7 +340,6 @@ function prepLtftData(formData: LtftObj, isSubmit: boolean, jsonForm: Form) {
   return formData;
 }
 
-// TODO - need to add ltft logic
 async function updateForm(
   formName: string,
   formData: FormData,
@@ -355,10 +354,18 @@ async function updateForm(
         isSubmit
       })
     );
-  } else {
+  } else if (formName === "formB") {
     await store.dispatch(
       updateFormB({
         formData: formData as FormRPartB,
+        isAutoSave,
+        isSubmit
+      })
+    );
+  } else if (formName === "ltft") {
+    await store.dispatch(
+      updateLtft({
+        formData: formData as LtftObj,
         isAutoSave,
         isSubmit
       })

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -40,6 +40,7 @@ import history from "../components/navigation/history";
 import {
   deleteLtft,
   LtftObj,
+  resetToInitLtft,
   saveLtft,
   updatedCanEditLtft,
   updatedEditPageNumberLtft,
@@ -95,20 +96,13 @@ export function setEditPageNumber(formName: string, pageNumber: number) {
   }
 }
 
-export function resetForm(formName: string, history: any) {
-  const redirectPath = formName === "formA" ? "/formr-a" : "/formr-b";
+export function resetForm(formName: string) {
   if (formName === "formA") {
-    const formAStatus = store.getState().formA.status;
-    if (formAStatus === "succeeded") {
-      store.dispatch(resetToInitFormA());
-      history.push(redirectPath);
-    }
-  } else {
-    const formBStatus = store.getState().formB.status;
-    if (formBStatus === "succeeded") {
-      store.dispatch(resetToInitFormB());
-      history.push(redirectPath);
-    }
+    store.dispatch(resetToInitFormA());
+  } else if (formName === "formB") {
+    store.dispatch(resetToInitFormB());
+  } else if (formName === "ltft") {
+    store.dispatch(resetToInitLtft());
   }
 }
 const chooseRedirectPath = (formName: string, confirm?: boolean) => {

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -12,11 +12,12 @@ import {
   updatedEditPageNumber,
   updatedFormA
 } from "../redux/slices/formASlice";
-import store from "../redux/store/store";
+import store, { RootState } from "../redux/store/store";
 import {
   Field,
   Form,
   FormData,
+  FormName,
   MatcherName
 } from "../components/forms/form-builder/FormBuilder";
 import {
@@ -37,6 +38,7 @@ import dayjs from "dayjs";
 import { LinkedFormRDataType } from "../components/forms/form-linker/FormLinkerForm";
 import history from "../components/navigation/history";
 import {
+  deleteLtft,
   LtftObj,
   saveLtft,
   updatedCanEditLtft,
@@ -151,22 +153,18 @@ export function handleEditSection(
 }
 
 export async function isFormDeleted(
-  formName: string,
-  formId: string | undefined,
-  formIdFromDraftFormProps: string | undefined
-) {
-  if (formName === "formr-a") {
-    await store.dispatch(
-      deleteFormA((formId as string) ?? (formIdFromDraftFormProps as string))
-    );
-    return store.getState().formA.status === "succeeded";
-  } else {
-    await store.dispatch(
-      deleteFormB((formId as string) ?? (formIdFromDraftFormProps as string))
-    );
-
-    return store.getState().formB.status === "succeeded";
+  formName: FormName,
+  formId: string
+): Promise<boolean> {
+  if (formName === "formA") {
+    await store.dispatch(deleteFormA(formId));
+  } else if (formName === "formB") {
+    await store.dispatch(deleteFormB(formId));
+  } else if (formName === "ltft") {
+    await store.dispatch(deleteLtft(formId));
   }
+  const state = store.getState() as RootState;
+  return state[formName].status === "succeeded";
 }
 
 // ----------------------------------------------------------
@@ -252,7 +250,7 @@ export interface DraftFormProps {
   programmeMembershipId?: string | null;
 }
 
-export function setDraftFormProps(forms: IFormR[]): DraftFormProps | null {
+export function setDraftFormRProps(forms: IFormR[]): DraftFormProps | null {
   if (
     forms.length === 0 ||
     forms.every(form => form.lifecycleState === LifeCycleState.Submitted)
@@ -604,6 +602,17 @@ export const determineCurrentValue = (
     return checkedStatus;
   } else {
     return value;
+  }
+};
+
+export const mapFormNameToUrl = (formName: FormName): string => {
+  switch (formName) {
+    case "formA":
+      return "formr-a";
+    case "formB":
+      return "formr-b";
+    case "ltft":
+      return "ltft";
   }
 };
 

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -39,6 +39,7 @@ import { LinkedFormRDataType } from "../components/forms/form-linker/FormLinkerF
 import history from "../components/navigation/history";
 import {
   deleteLtft,
+  loadSavedLtft,
   LtftObj,
   resetToInitLtft,
   saveLtft,
@@ -69,8 +70,10 @@ export async function loadTheSavedForm(
 ) {
   if (pathName === "/formr-a") {
     await store.dispatch(loadSavedFormA({ id, linkedFormRData }));
-  } else {
+  } else if (pathName === "/formr-b") {
     await store.dispatch(loadSavedFormB({ id, linkedFormRData }));
+  } else if (pathName === "/ltft") {
+    await store.dispatch(loadSavedLtft(id));
   }
   history.push(`${pathName}/create`);
 }

--- a/utilities/__test__/FormBuilderUtilities.test.ts
+++ b/utilities/__test__/FormBuilderUtilities.test.ts
@@ -11,7 +11,7 @@ import store from "../../redux/store/store";
 import {
   getDraftFormId,
   handleSaveRedirect,
-  setDraftFormProps,
+  setDraftFormRProps,
   setFormRDataForSubmit,
   transformReferenceData
 } from "../FormBuilderUtilities";
@@ -38,22 +38,22 @@ describe("transformReferenceData", () => {
 describe("Get the latest 'draft' form version to open ", () => {
   // Test the draft form priority logic
   it("should return null if forms list is empty", () => {
-    expect(setDraftFormProps([])).toBe(null);
+    expect(setDraftFormRProps([])).toBe(null);
   });
 
   it("should return null if forms list only contains submitted forms", () => {
-    expect(setDraftFormProps(mockForms.slice(1, 3))).toBe(null);
+    expect(setDraftFormRProps(mockForms.slice(1, 3))).toBe(null);
   });
 
   it("should return the unsubmitted form", () => {
-    expect(setDraftFormProps(mockForms)).toEqual({
+    expect(setDraftFormRProps(mockForms)).toEqual({
       id: "3",
       lifecycleState: LifeCycleState.Unsubmitted
     });
   });
 
   it("should return the single draft form", () => {
-    expect(setDraftFormProps(mockForms.slice(1, 4))).toEqual({
+    expect(setDraftFormRProps(mockForms.slice(1, 4))).toEqual({
       id: "4",
       lifecycleState: LifeCycleState.Draft
     });
@@ -61,7 +61,7 @@ describe("Get the latest 'draft' form version to open ", () => {
 
   it("should return the most recent form between draft and local forms", () => {
     const forms = mockForms.slice(3, 5);
-    expect(setDraftFormProps(forms)).toEqual({
+    expect(setDraftFormRProps(forms)).toEqual({
       id: "4",
       lifecycleState: LifeCycleState.Draft
     });

--- a/utilities/__test__/FormBuilderUtilities.test.ts
+++ b/utilities/__test__/FormBuilderUtilities.test.ts
@@ -12,7 +12,7 @@ import {
   getDraftFormId,
   handleSaveRedirect,
   setDraftFormProps,
-  setFormDataForSubmit,
+  setFormRDataForSubmit,
   transformReferenceData
 } from "../FormBuilderUtilities";
 import formAJson from "../../components/forms/form-builder/form-r/part-a/formA.json";
@@ -70,7 +70,7 @@ describe("Get the latest 'draft' form version to open ", () => {
 
 describe("Set formData for submit", () => {
   it("should set user-input hidden form fields to null before submit", () => {
-    const result = setFormDataForSubmit(
+    const result = setFormRDataForSubmit(
       formAJson as Form,
       formANew as FormRPartA
     );

--- a/utilities/__test__/LtftUtilities.test.ts
+++ b/utilities/__test__/LtftUtilities.test.ts
@@ -29,7 +29,10 @@ const otherDiscussions = [
 const statusData = {
   current: {
     state: "DRAFT",
-    detail: "",
+    detail: {
+      reason: "",
+      message: ""
+    },
     modifiedBy: {
       name: "",
       email: "",
@@ -131,6 +134,14 @@ describe("mapDtoToLtftObj", () => {
       tpdName: "My tpd name",
       tpdEmail: "email@4.tpd",
       other: otherDiscussions
+    },
+    change: {
+      calculationId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      changeId: "fc13458c-5b0b-442f-8907-6f9af8fc0ffb",
+      cctDate: "2028-04-02",
+      type: "LTFT",
+      startDate: "2027-01-01",
+      wte: 0.8
     },
     reasons: {
       selected: ["Unique opportunities", "other"],

--- a/utilities/__test__/LtftUtilities.test.ts
+++ b/utilities/__test__/LtftUtilities.test.ts
@@ -11,6 +11,7 @@ import {
   populateLtftDraft
 } from "../ltftUtilities";
 import { StatusType } from "../../redux/slices/ltftSlice";
+import { date } from "yup";
 
 const otherDiscussions = [
   {
@@ -24,6 +25,9 @@ const otherDiscussions = [
     role: "Educational Supervisor (ES)"
   }
 ];
+
+const dateCreated = "2025-02-01T00:00:00Z";
+const dateModified = "2025-02-02T00:00:00Z";
 
 describe("populateLtftDraft", () => {
   const cctSnapshot = mockCctCalc;
@@ -56,7 +60,9 @@ describe("mapLtftObjToDto", () => {
   const ltftDto = mapLtftObjToDto({
     ...mockLtftDraft1,
     otherDiscussions: otherDiscussions,
-    status: statusData
+    status: statusData,
+    created: dateCreated,
+    lastModified: dateModified
   });
   it("should map discussions correctly", () => {
     expect(ltftDto.discussions).toEqual({
@@ -110,6 +116,8 @@ describe("mapLtftObjToDto", () => {
       designatedBodyCode: "WTF3"
     });
     expect(ltftDto.status).toEqual(statusData);
+    expect(ltftDto.created).toBe(dateCreated);
+    expect(ltftDto.lastModified).toBe(dateModified);
   });
 });
 
@@ -125,7 +133,9 @@ describe("mapDtoToLtftObj", () => {
     reasons: {
       selected: ["Unique opportunities", "other"],
       otherDetail: "my other reason 2"
-    }
+    },
+    created: dateCreated,
+    lastModified: dateModified
   });
   it("should map discussions correctly", () => {
     expect(mockLtftObj.tpdName).toEqual("My tpd name");
@@ -182,5 +192,7 @@ describe("mapDtoToLtftObj", () => {
       current: "DRAFT",
       history: []
     });
+    expect(mockLtftObj.created).toBe(dateCreated);
+    expect(mockLtftObj.lastModified).toBe(dateModified);
   });
 });

--- a/utilities/__test__/LtftUtilities.test.ts
+++ b/utilities/__test__/LtftUtilities.test.ts
@@ -10,7 +10,7 @@ import {
   mapLtftObjToDto,
   populateLtftDraft
 } from "../ltftUtilities";
-import { StatusType } from "../../redux/slices/ltftSlice";
+import { StatusInfo } from "../../redux/slices/ltftSlice";
 import { date } from "yup";
 
 const otherDiscussions = [
@@ -25,6 +25,21 @@ const otherDiscussions = [
     role: "Educational Supervisor (ES)"
   }
 ];
+
+const statusData = {
+  current: {
+    state: "DRAFT",
+    detail: "",
+    modifiedBy: {
+      name: "",
+      email: "",
+      role: ""
+    },
+    timestamp: "",
+    revision: 0
+  } as StatusInfo,
+  history: [] as StatusInfo[]
+};
 
 const dateCreated = "2025-02-01T00:00:00Z";
 const dateModified = "2025-02-02T00:00:00Z";
@@ -44,19 +59,6 @@ describe("populateLtftDraft", () => {
 });
 
 describe("mapLtftObjToDto", () => {
-  const statusData: StatusType = {
-    current: "DRAFT",
-    history: [
-      {
-        status: "DRAFT",
-        timestamp: "2025-02-02T00:00:00Z"
-      },
-      {
-        status: "DRAFT",
-        timestamp: "2025-02-01T00:00:00Z"
-      }
-    ]
-  };
   const ltftDto = mapLtftObjToDto({
     ...mockLtftDraft1,
     otherDiscussions: otherDiscussions,
@@ -134,6 +136,7 @@ describe("mapDtoToLtftObj", () => {
       selected: ["Unique opportunities", "other"],
       otherDetail: "my other reason 2"
     },
+    status: statusData,
     created: dateCreated,
     lastModified: dateModified
   });
@@ -188,11 +191,10 @@ describe("mapDtoToLtftObj", () => {
       wte: 1,
       designatedBodyCode: "WTF3"
     });
-    expect(mockLtftObj.status).toEqual({
-      current: "DRAFT",
-      history: []
-    });
+    expect(mockLtftObj.status).toEqual(statusData);
     expect(mockLtftObj.created).toBe(dateCreated);
     expect(mockLtftObj.lastModified).toBe(dateModified);
   });
 });
+
+//TODO: Add more test for the history when this is implemented

--- a/utilities/hooks/__test__/useLtftHomeStartover.test.tsx
+++ b/utilities/hooks/__test__/useLtftHomeStartover.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { Action, configureStore, EnhancedStore } from "@reduxjs/toolkit";
+import { useLtftHomeStartover } from "../useLtftHomeStartover";
+import {
+  fetchLtftSummaryList,
+  updatedLtftFormsRefreshNeeded
+} from "../../../redux/slices/ltftSummaryListSlice";
+import { resetForm } from "../../FormBuilderUtilities";
+
+jest.mock("../../FormBuilderUtilities", () => ({
+  resetForm: jest.fn()
+}));
+
+// Mock action creators with proper return values
+jest.mock("../../../redux/slices/ltftSummaryListSlice", () => ({
+  fetchLtftSummaryList: jest.fn(() => ({
+    type: "ltftSummaryList/fetchLtftSummaryList"
+  })),
+  updatedLtftFormsRefreshNeeded: jest.fn(() => ({
+    type: "ltftList/updatedLtftFormsRefreshNeeded"
+  }))
+}));
+
+jest.mock("../useIsBetaTester", () => ({
+  __esModule: true,
+  default: jest.fn(() => true)
+}));
+
+//Custom Type for test state to avoid having to use the real RootState type!
+type TestState = {
+  ltftSummaryList: {
+    ltftFormsRefreshNeeded: boolean;
+  };
+};
+
+const testReducer = (
+  state: TestState = { ltftSummaryList: { ltftFormsRefreshNeeded: true } },
+  _action: Action
+) => {
+  return state;
+};
+
+const TestComponent = () => {
+  useLtftHomeStartover();
+  return null;
+};
+
+describe("useLtftHomeStartover", () => {
+  let testStore: EnhancedStore<TestState>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    testStore = configureStore({
+      reducer: testReducer,
+      middleware: getDefaultMiddleware =>
+        getDefaultMiddleware({
+          serializableCheck: false
+        })
+    });
+  });
+
+  it("should dispatch actions and call resetForm when isBetaTester is true", async () => {
+    render(
+      <Provider store={testStore}>
+        <TestComponent />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(fetchLtftSummaryList).toHaveBeenCalled();
+      expect(updatedLtftFormsRefreshNeeded).toHaveBeenCalledWith(false);
+      expect(resetForm).toHaveBeenCalledWith("ltft");
+    });
+  });
+});

--- a/utilities/hooks/useFormAutosave.ts
+++ b/utilities/hooks/useFormAutosave.ts
@@ -1,21 +1,20 @@
 import { useEffect } from "react";
-import { saveFormR } from "../../utilities/FormBuilderUtilities";
+import {
+  FormDataType,
+  saveDraftForm
+} from "../../utilities/FormBuilderUtilities";
 import { Form } from "../../components/forms/form-builder/FormBuilder";
-import { FormRPartA } from "../../models/FormRPartA";
-import { FormRPartB } from "../../models/FormRPartB";
-import { LtftObj } from "../../redux/slices/ltftSlice";
 
 const useFormAutosave = (
   jsonForm: Form,
-  formData: FormRPartA | FormRPartB | LtftObj,
+  formData: FormDataType,
   isFormDirty: boolean
 ) => {
   const formName = jsonForm.name;
   useEffect(() => {
-    // TODO needs ltft implementation
-    if (isFormDirty && formName !== "ltft") {
+    if (isFormDirty) {
       const timeoutId = setTimeout(() => {
-        saveFormR(jsonForm, formData as FormRPartA | FormRPartB, true, false);
+        saveDraftForm(jsonForm, formData, true, false);
       }, 2000);
 
       return () => {

--- a/utilities/hooks/useLtftHomeStartover.ts
+++ b/utilities/hooks/useLtftHomeStartover.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
+import useIsBetaTester from "./useIsBetaTester";
+import {
+  fetchLtftSummaryList,
+  updatedLtftFormsRefreshNeeded
+} from "../../redux/slices/ltftSummaryListSlice";
+import { resetForm } from "../FormBuilderUtilities";
+
+export const useLtftHomeStartover = () => {
+  const dispatch = useAppDispatch();
+  const isBetaTester = useIsBetaTester();
+  const needLtftFormsRefresh = useAppSelector(
+    state => state.ltftSummaryList?.ltftFormsRefreshNeeded
+  );
+
+  useEffect(() => {
+    if (isBetaTester) {
+      dispatch(fetchLtftSummaryList());
+      updatedLtftFormsRefreshNeeded(false);
+      resetForm("ltft");
+    }
+  }, [dispatch, isBetaTester, needLtftFormsRefresh]);
+};

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -3,7 +3,8 @@ import { CctCalculation } from "../redux/slices/cctSlice";
 import {
   LtftCctChange,
   LtftFormStatus,
-  LtftObj
+  LtftObj,
+  StatusInfo
 } from "../redux/slices/ltftSlice";
 import { ProfileSType } from "./ProfileUtilities";
 
@@ -105,13 +106,8 @@ export type LtftDto = {
     otherDetail?: string;
   };
   status: {
-    current: LtftFormStatus;
-    history:
-      | {
-          status: LtftFormStatus;
-          timestamp: string;
-        }[]
-      | [];
+    current: StatusInfo;
+    history: StatusInfo[] | [];
   };
   created: Date | string;
   lastModified: Date | string;
@@ -171,11 +167,29 @@ export const mapLtftObjToDto = (ltftObj: LtftObj): LtftDto => {
       otherDetail: ltftObj.reasonsOtherDetail ?? ""
     },
     status: {
-      current: ltftObj.status.current,
+      // TODO: complate status fields with the correct data when implementing state chagning operations
+      current: {
+        state: ltftObj.status.current,
+        detail: "",
+        modifiedBy: {
+          name: "",
+          email: "",
+          role: ""
+        },
+        timestamp: "",
+        revision: 1
+      },
       history:
         ltftObj.status.history?.map(historyItem => ({
-          status: historyItem.status,
-          timestamp: historyItem.timestamp
+          state: historyItem.status,
+          timestamp: historyItem.timestamp,
+          detail: "",
+          modifiedBy: {
+            name: "",
+            email: "",
+            role: ""
+          },
+          revision: 1
         })) || []
     },
     created: ltftObj.created ?? "",
@@ -231,9 +245,9 @@ export const mapLtftDtoToObj = (ltftDto: LtftDto): LtftObj => {
     reasonsSelected: ltftDto.reasons.selected,
     reasonsOtherDetail: ltftDto.reasons.otherDetail ?? null,
     status: {
-      current: ltftDto.status.current,
+      current: ltftDto.status.current.state,
       history: ltftDto.status.history.map(historyItem => ({
-        status: historyItem.status,
+        status: historyItem.state,
         timestamp: historyItem.timestamp
       }))
     },

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -52,7 +52,10 @@ export function populateLtftDraft(
     status: {
       current: {
         state: "DRAFT",
-        detail: "",
+        detail: {
+          reason: "",
+          message: ""
+        },
         modifiedBy: {
           name: "",
           email: "",
@@ -174,7 +177,10 @@ export const mapLtftObjToDto = (ltftObj: LtftObj): LtftDto => {
     status: {
       current: {
         state: ltftObj.status.current.state,
-        detail: ltftObj.status.current.detail,
+        detail: {
+          reason: ltftObj.status.current.detail.reason,
+          message: ltftObj.status.current.detail.message
+        },
         modifiedBy: {
           name: ltftObj.status.current.modifiedBy.name,
           email: ltftObj.status.current.modifiedBy.email,
@@ -187,7 +193,10 @@ export const mapLtftObjToDto = (ltftObj: LtftObj): LtftDto => {
         ltftObj.status.history?.map(historyItem => ({
           state: historyItem.state,
           timestamp: historyItem.timestamp,
-          detail: historyItem.detail,
+          detail: {
+            reason: historyItem.detail.reason,
+            message: historyItem.detail.message
+          },
           modifiedBy: {
             name: historyItem.modifiedBy.name,
             email: historyItem.modifiedBy.email,
@@ -251,7 +260,10 @@ export const mapLtftDtoToObj = (ltftDto: LtftDto): LtftObj => {
     status: {
       current: {
         state: ltftDto.status.current.state,
-        detail: ltftDto.status.current.detail,
+        detail: {
+          reason: ltftDto.status.current.detail.reason,
+          message: ltftDto.status.current.detail.message
+        },
         modifiedBy: {
           name: ltftDto.status.current.modifiedBy.name,
           email: ltftDto.status.current.modifiedBy.email,
@@ -263,7 +275,10 @@ export const mapLtftDtoToObj = (ltftDto: LtftDto): LtftObj => {
       history: ltftDto.status.history.map(historyItem => ({
         state: historyItem.state,
         timestamp: historyItem.timestamp,
-        detail: historyItem.detail,
+        detail: {
+          reason: historyItem.detail.reason,
+          message: historyItem.detail.message
+        },
         modifiedBy: {
           name: historyItem.modifiedBy.name,
           email: historyItem.modifiedBy.email,

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -236,6 +236,8 @@ export const mapLtftDtoToObj = (ltftDto: LtftDto): LtftObj => {
         status: historyItem.status,
         timestamp: historyItem.timestamp
       }))
-    }
+    },
+    created: ltftDto.created,
+    lastModified: ltftDto.lastModified
   };
 };

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -1,11 +1,6 @@
 import { PersonalDetails } from "../models/PersonalDetails";
 import { CctCalculation } from "../redux/slices/cctSlice";
-import {
-  LtftCctChange,
-  LtftFormStatus,
-  LtftObj,
-  StatusInfo
-} from "../redux/slices/ltftSlice";
+import { LtftCctChange, LtftObj, StatusInfo } from "../redux/slices/ltftSlice";
 import { ProfileSType } from "./ProfileUtilities";
 
 export function populateLtftDraft(
@@ -55,8 +50,18 @@ export function populateLtftDraft(
     reasonsSelected: null,
     reasonsOtherDetail: null,
     status: {
-      current: "DRAFT",
-      history: null
+      current: {
+        state: "DRAFT",
+        detail: "",
+        modifiedBy: {
+          name: "",
+          email: "",
+          role: ""
+        },
+        timestamp: "",
+        revision: 0
+      },
+      history: []
     }
   };
   return draftLtftForm;
@@ -107,7 +112,7 @@ export type LtftDto = {
   };
   status: {
     current: StatusInfo;
-    history: StatusInfo[] | [];
+    history: StatusInfo[];
   };
   created: Date | string;
   lastModified: Date | string;
@@ -167,29 +172,28 @@ export const mapLtftObjToDto = (ltftObj: LtftObj): LtftDto => {
       otherDetail: ltftObj.reasonsOtherDetail ?? ""
     },
     status: {
-      // TODO: complate status fields with the correct data when implementing state chagning operations
       current: {
-        state: ltftObj.status.current,
-        detail: "",
+        state: ltftObj.status.current.state,
+        detail: ltftObj.status.current.detail,
         modifiedBy: {
-          name: "",
-          email: "",
-          role: ""
+          name: ltftObj.status.current.modifiedBy.name,
+          email: ltftObj.status.current.modifiedBy.email,
+          role: ltftObj.status.current.modifiedBy.role
         },
-        timestamp: "",
-        revision: 1
+        timestamp: ltftObj.status.current.timestamp,
+        revision: ltftObj.status.current.revision
       },
       history:
         ltftObj.status.history?.map(historyItem => ({
-          state: historyItem.status,
+          state: historyItem.state,
           timestamp: historyItem.timestamp,
-          detail: "",
+          detail: historyItem.detail,
           modifiedBy: {
-            name: "",
-            email: "",
-            role: ""
+            name: historyItem.modifiedBy.name,
+            email: historyItem.modifiedBy.email,
+            role: historyItem.modifiedBy.role
           },
-          revision: 1
+          revision: historyItem.revision
         })) || []
     },
     created: ltftObj.created ?? "",
@@ -245,10 +249,27 @@ export const mapLtftDtoToObj = (ltftDto: LtftDto): LtftObj => {
     reasonsSelected: ltftDto.reasons.selected,
     reasonsOtherDetail: ltftDto.reasons.otherDetail ?? null,
     status: {
-      current: ltftDto.status.current.state,
+      current: {
+        state: ltftDto.status.current.state,
+        detail: ltftDto.status.current.detail,
+        modifiedBy: {
+          name: ltftDto.status.current.modifiedBy.name,
+          email: ltftDto.status.current.modifiedBy.email,
+          role: ltftDto.status.current.modifiedBy.role
+        },
+        timestamp: ltftDto.status.current.timestamp,
+        revision: ltftDto.status.current.revision
+      },
       history: ltftDto.status.history.map(historyItem => ({
-        status: historyItem.state,
-        timestamp: historyItem.timestamp
+        state: historyItem.state,
+        timestamp: historyItem.timestamp,
+        detail: historyItem.detail,
+        modifiedBy: {
+          name: historyItem.modifiedBy.name,
+          email: historyItem.modifiedBy.email,
+          role: historyItem.modifiedBy.role
+        },
+        revision: historyItem.revision
       }))
     },
     created: ltftDto.created,


### PR DESCRIPTION
Please see https://hee-tis.atlassian.net/browse/TIS21-6974 for ACs .

Hints 'n tips
Probably a good idea to open Redux dev tools in the browser to step through the updates from the very beginning of the LTFT journey... snapshot, initial ltft obj population, updates etc. (the functions for this initial bit and subsequent DTO mapping can be found in ltftUtilities.ts).

Ltft form POST/PUT logic is handled via a generic saveDraftForm function (which has parameters to determine if e.g. autosave, which will in turn determine the thunk call in the redux slice).
NOTE: The redux slice boilerplate is very verbose atm - probably 500 lines just for this! So we can probably refactor this later.

The addition of the newFormId (see ltftSlice) is a bit confusing. It is created after autosave POST success to make sure we have access to the id before the next autosave PUT. (Note: the FormBuilder formData state is the source of truth as the person completes the form and is handled by the FormContext.tsx. It handles the user-input changes i.e. not the id change so that's why we set newFormId).

The StartOverButton.tsx logic probably needs some explaining too! Because it is used across all forms in different parts of the journey, I refactored it so it has a prop to determine where it is used (type BtnLocation). This is particularly useful for:

1. Making sure it is always displayed in the FormView (even if the user has not been able to save the form up until this point e.g. dodgy connection. In this case it just acts as a simple redirect to the LtftHome page). Note: current logic: 'startover' btn only appears after successful POST so if no successful saves the button wouldn't show on the LtftFormView page. (a future ticket could simplify this logic so e.g. dirty form === show startover btn?)

2. On the forms list page e.g LtftHome it will trigger a forms list reload (see useLtftHomeStartover) when the 'startover' btn is clicked on this LtftHome page (see checkPush function) .

I think that's most of the trickier stuff.

In terms of testing, there are still gaps in the FormBuilderUtilities functions (unit tests; which I can cover when I return?) and also the LtftFormView.tsx (which @DorisWongNHS is planning to cover in her current ticket. She promised! 😁)

ps. Please check to see if FormR's still behave themselves!

pps. Apologies in advance for not e.g. updating e2e tests and making them all fail 😆.
  