### PR TITLE
Refactor LTFT submit

### DIFF
--- a/components/forms/AutosaveMessage.tsx
+++ b/components/forms/AutosaveMessage.tsx
@@ -32,7 +32,7 @@ export const AutosaveMessage: React.FC<AutoSaveMessageProps> = ({
     failed: `Fail - Last autosave success: ${latestTimeStamp}`
   };
 
-  const message = statusMessages[autoSaveStatus as SaveStatusProps];
+  const message = statusMessages[autoSaveStatus];
   return (
     <div>
       <p data-cy="autosaveStatusMsg">{`Autosave status: ${message}`}</p>

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -167,7 +167,7 @@ export default function FormBuilder({
 
   const handleSaveBtnClick = async () => {
     setIsSubmitting(true);
-    await saveDraftForm(jsonForm, formData as FormDataType, false, false);
+    await saveDraftForm(jsonForm, formData as FormDataType);
     setIsSubmitting(false);
   };
 

--- a/components/forms/form-builder/FormView.tsx
+++ b/components/forms/form-builder/FormView.tsx
@@ -182,9 +182,7 @@ export const FormView = ({
                   setIsSubmitting(true);
                   await saveDraftForm(
                     formJson,
-                    formData as FormRPartA | FormRPartB,
-                    false,
-                    false
+                    formData as FormRPartA | FormRPartB
                   );
                   setIsSubmitting(false);
                 }}

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -76,7 +76,7 @@ export const LtftFormView = () => {
   const handleModalFormSubmit = async () => {
     setShowModal(false);
     startSubmitting();
-    await saveDraftForm(formJson, formData as LtftObj, false, true);
+    await saveDraftForm(formJson, formData, false, true);
     stopSubmitting();
   };
 
@@ -97,56 +97,61 @@ export const LtftFormView = () => {
           canEdit={canEditStatus}
           formJson={formJson}
         />
-        <Formik initialValues={{ name: "" }} onSubmit={handleSubClick}>
+        <Formik
+          initialValues={{ name: formData.name ?? "" }}
+          onSubmit={handleSubClick}
+        >
           {({ values }) => {
             return (
-              <>
-                <Form>
-                  <TextInputField
-                    name="name"
-                    id="ltftName"
-                    label="Please give your Changing hours (LTFT) application a name"
-                    placeholder="Type name here..."
-                    width="300px"
-                  />
-                  {canEditStatus && (
-                    <Button
-                      type="submit"
-                      disabled={
-                        !values.name.trim() || !canSubmit || isSubmitting
-                      }
-                      data-cy="BtnSubmit"
-                    >
-                      {isSubmitting ? "Saving..." : "Submit"}
-                    </Button>
-                  )}
-                </Form>
-              </>
+              <Form>
+                <TextInputField
+                  name="name"
+                  id="ltftName"
+                  label="Please give your Changing hours (LTFT) application a name"
+                  placeholder="Type name here..."
+                  width="300px"
+                  readOnly={!canEditStatus}
+                />
+                {canEditStatus && (
+                  <Button
+                    type="submit"
+                    disabled={!values.name.trim() || !canSubmit || isSubmitting}
+                    data-cy="BtnSubmit"
+                  >
+                    {isSubmitting ? "Saving..." : "Submit"}
+                  </Button>
+                )}
+              </Form>
             );
           }}
         </Formik>
       </WarningCallout>
-      <Container>
-        <Row>
-          <Col width="one-quarter">
-            <Button
-              secondary
-              onClick={async () => {
-                startSubmitting();
-                await saveDraftForm(formJson, formData as LtftObj);
-                stopSubmitting();
-              }}
-              disabled={isSubmitting}
-              data-cy="BtnSaveDraft"
-            >
-              {"Save & exit"}
-            </Button>
-          </Col>
-          <Col width="one-quarter">
-            <StartOverButton formName={formJson.name} btnLocation="formView" />
-          </Col>
-        </Row>
-      </Container>
+      {canEditStatus && (
+        <Container>
+          <Row>
+            <Col width="one-quarter">
+              <Button
+                secondary
+                onClick={async () => {
+                  startSubmitting();
+                  await saveDraftForm(formJson, formData);
+                  stopSubmitting();
+                }}
+                disabled={isSubmitting}
+                data-cy="BtnSaveDraft"
+              >
+                {"Save & exit"}
+              </Button>
+            </Col>
+            <Col width="one-quarter">
+              <StartOverButton
+                formName={formJson.name}
+                btnLocation="formView"
+              />
+            </Col>
+          </Row>
+        </Container>
+      )}
       <LtftNameModal
         onSubmit={handleModalFormSubmit}
         isOpen={showModal}

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -1,8 +1,11 @@
 import { useAppSelector } from "../../../redux/hooks/hooks";
 import { Redirect } from "react-router-dom";
-import { LtftObj } from "../../../redux/slices/ltftSlice";
+import {
+  LtftObj,
+  updatedLtftSaveStatus
+} from "../../../redux/slices/ltftSlice";
 import { useSelectFormData } from "../../../utilities/hooks/useSelectFormData";
-import { Form, FormName } from "../form-builder/FormBuilder";
+import { Form as FormType, FormName } from "../form-builder/FormBuilder";
 import ltftJson from "./ltft.json";
 import FormViewBuilder from "../form-builder/FormViewBuilder";
 import { useState } from "react";
@@ -20,6 +23,9 @@ import { CctCalculation } from "../../../redux/slices/cctSlice";
 import { LtftNameModal } from "./LtftNameModal";
 import { saveDraftForm } from "../../../utilities/FormBuilderUtilities";
 import { useSubmitting } from "../../../utilities/hooks/useSubmitting";
+import store from "../../../redux/store/store";
+import TextInputField from "../TextInputField";
+import { Form, Formik } from "formik";
 
 export const LtftFormView = () => {
   const { startSubmitting, stopSubmitting, isSubmitting } = useSubmitting();
@@ -30,13 +36,36 @@ export const LtftFormView = () => {
     programmeMembership: formData?.programmeMembership,
     changes: [formData?.change]
   };
-  const formJson = ltftJson as Form;
+  const formJson = ltftJson as FormType;
   const redirectPath = "/ltft";
   const [canSubmit, setCanSubmit] = useState(false);
   const [showModal, setShowModal] = useState(false);
 
-  const handleSubClick = () => {
-    setShowModal(true);
+  const handleSubClick = async (values: { name: string }) => {
+    const updatedDeclarations = {
+      ...formData.declarations,
+      informationIsCorrect: true,
+      notGuaranteed: true
+    };
+    store.dispatch(updatedLtftSaveStatus("idle"));
+    startSubmitting();
+    await saveDraftForm(
+      formJson,
+      {
+        ...formData,
+        name: values.name,
+        declarations: updatedDeclarations
+      } as LtftObj,
+      false,
+      false,
+      true,
+      false
+    );
+    stopSubmitting();
+    const newSaveStatus = store.getState().ltft.saveStatus;
+    if (newSaveStatus === "succeeded") {
+      setShowModal(true);
+    }
   };
 
   const handleModalFormClose = () => {
@@ -44,15 +73,10 @@ export const LtftFormView = () => {
     stopSubmitting();
   };
 
-  const handleModalFormSubmit = async (values: { name: string }) => {
+  const handleModalFormSubmit = async () => {
     setShowModal(false);
     startSubmitting();
-    await saveDraftForm(
-      formJson,
-      { ...formData, name: values.name } as LtftObj,
-      false,
-      true
-    );
+    await saveDraftForm(formJson, formData as LtftObj, false, true);
     stopSubmitting();
   };
 
@@ -67,40 +91,49 @@ export const LtftFormView = () => {
       />
       <WarningCallout>
         <WarningCallout.Label>Declarations</WarningCallout.Label>
-        <form>
-          <Declarations
-            setCanSubmit={setCanSubmit}
-            canEdit={canEditStatus}
-            formJson={formJson}
-          />
-          {canEditStatus && (
-            <Button
-              onClick={(e: { preventDefault: () => void }) => {
-                e.preventDefault();
-                startSubmitting();
-                handleSubClick();
-              }}
-              disabled={!canSubmit || isSubmitting}
-              data-cy="BtnSubmit"
-            >
-              Submit Form
-            </Button>
-          )}
-        </form>
+
+        <Declarations
+          setCanSubmit={setCanSubmit}
+          canEdit={canEditStatus}
+          formJson={formJson}
+        />
+        <Formik initialValues={{ name: "" }} onSubmit={handleSubClick}>
+          {({ values }) => {
+            return (
+              <>
+                <Form>
+                  <TextInputField
+                    name="name"
+                    id="ltftName"
+                    label="Please give your Changing hours (LTFT) application a name"
+                    placeholder="Type name here..."
+                    width="300px"
+                  />
+                  {canEditStatus && (
+                    <Button
+                      type="submit"
+                      disabled={
+                        !values.name.trim() || !canSubmit || isSubmitting
+                      }
+                      data-cy="BtnSubmit"
+                    >
+                      {isSubmitting ? "Saving..." : "Submit"}
+                    </Button>
+                  )}
+                </Form>
+              </>
+            );
+          }}
+        </Formik>
       </WarningCallout>
       <Container>
         <Row>
           <Col width="one-quarter">
             <Button
               secondary
-              onClick={async (e: { preventDefault: () => void }) => {
+              onClick={async () => {
                 startSubmitting();
-                await saveDraftForm(
-                  formJson,
-                  formData as LtftObj,
-                  false,
-                  false
-                );
+                await saveDraftForm(formJson, formData as LtftObj);
                 stopSubmitting();
               }}
               disabled={isSubmitting}

--- a/components/forms/ltft/LtftNameModal.tsx
+++ b/components/forms/ltft/LtftNameModal.tsx
@@ -1,11 +1,9 @@
-import { Form, Formik } from "formik";
 import { Modal } from "../../common/Modal";
-import TextInputField from "../TextInputField";
 import { Button, WarningCallout } from "nhsuk-react-components";
 import { useSubmitting } from "../../../utilities/hooks/useSubmitting";
 
 type LtftNameModalProps = {
-  onSubmit: (values: { name: string }) => void;
+  onSubmit: () => void;
   isOpen: boolean;
   onClose: () => void;
 };
@@ -18,39 +16,25 @@ export function LtftNameModal({
   const { isSubmitting } = useSubmitting();
   return (
     <Modal isOpen={isOpen} onClose={onClose} cancelBtnText="Cancel">
-      <Formik initialValues={{ name: "" }} onSubmit={onSubmit}>
-        {({ values }) => {
-          return (
-            <>
-              <WarningCallout data-cy="ltftModalWarning">
-                <WarningCallout.Label visuallyHiddenText={false}>
-                  Important
-                </WarningCallout.Label>
-                <p>
-                  Please check the details of the form carefully before
-                  submission. Are you sure you want to submit it?
-                </p>
-              </WarningCallout>
-              <Form>
-                <TextInputField
-                  name="name"
-                  id="ltftName"
-                  label="Please give your Changing hours (LTFT) application a name"
-                  placeholder="Type name here..."
-                  width="300px"
-                />
-                <Button
-                  type="submit"
-                  disabled={!values.name.trim() || isSubmitting}
-                  data-cy="ltft-modal-save-btn"
-                >
-                  {isSubmitting ? "Saving..." : "Confirm & Continue"}
-                </Button>
-              </Form>
-            </>
-          );
-        }}
-      </Formik>
+      <form>
+        <WarningCallout data-cy="ltftModalWarning">
+          <WarningCallout.Label visuallyHiddenText={false}>
+            Important
+          </WarningCallout.Label>
+          <p>
+            Please check the details of the form carefully before submission.
+            Are you sure you want to submit it?
+          </p>
+        </WarningCallout>
+        <Button
+          onClick={onSubmit}
+          type="button"
+          disabled={isSubmitting}
+          data-cy="ltft-modal-save-btn"
+        >
+          {isSubmitting ? "Submitting..." : "Confirm & Continue"}
+        </Button>
+      </form>
     </Modal>
   );
 }

--- a/components/forms/ltft/__test__/LtftFormView.test.tsx
+++ b/components/forms/ltft/__test__/LtftFormView.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LtftFormView } from "../LtftFormView";
+import { Provider } from "react-redux";
+import { Router } from "react-router-dom";
+import { createMemoryHistory } from "history";
+import * as FormBuilderUtilities from "../../../../utilities/FormBuilderUtilities";
+import { mockLtftDraft0 } from "../../../../mock-data/mock-ltft-data";
+import { configureStore } from "@reduxjs/toolkit";
+
+jest.mock("../../../../utilities/FormBuilderUtilities");
+jest.mock("../../../../utilities/hooks/useSelectFormData", () => ({
+  useSelectFormData: () => mockLtftDraft0
+}));
+jest.mock("../../../../utilities/hooks/useSubmitting", () => ({
+  useSubmitting: () => ({
+    startSubmitting: jest.fn(),
+    stopSubmitting: jest.fn(),
+    isSubmitting: false
+  })
+}));
+jest.mock("../../cct/CctCalcSummary", () => ({
+  CctCalcSummaryDetails: () => <div>CCT Summary</div>
+}));
+jest.mock("../../form-builder/FormViewBuilder", () => ({
+  __esModule: true,
+  default: () => <div>Form Builder</div>
+}));
+
+// Note: Mock the Declarations via factory to avoid the need to interact with the form to set canSubmit to true
+jest.mock("../../form-builder/Declarations", () => {
+  const React = require("react"); // Import React within the factory
+  const { useEffect } = React;
+
+  // Define the component here inside the factory function
+  const MockDeclarations = ({
+    setCanSubmit
+  }: {
+    setCanSubmit: (value: boolean) => void;
+  }) => {
+    useEffect(() => {
+      setCanSubmit(true);
+    }, [setCanSubmit]);
+
+    return <div>Declarations</div>;
+  };
+
+  return {
+    __esModule: true,
+    default: MockDeclarations
+  };
+});
+
+// Simplified modal mock as we only need to check if it renders or not. (full functionality tested in LtftNameModal.test.tsx)
+jest.mock("../LtftNameModal", () => ({
+  LtftNameModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="ltft-modal">Modal Content</div> : null
+}));
+
+// Mock store setup
+let mockStoreState = {
+  ltft: { canEdit: true, saveStatus: "idle" }
+};
+
+jest.mock("../../../../redux/store/store", () => ({
+  __esModule: true,
+  default: {
+    dispatch: jest.fn(),
+    getState: jest.fn(() => mockStoreState),
+    subscribe: jest.fn(),
+    replaceReducer: jest.fn()
+  }
+}));
+
+// Simple Redux store for Provider
+const testStore = configureStore({
+  reducer: (state = mockStoreState) => state
+});
+
+describe("LtftFormView - Modal Display Tests", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  const setupTest = async () => {
+    const history = createMemoryHistory();
+    user = userEvent.setup();
+
+    render(
+      <Provider store={testStore}>
+        <Router history={history}>
+          <LtftFormView />
+        </Router>
+      </Provider>
+    );
+
+    // Since declarations are auto-approved in our mock via useEffect, just type name and submit
+    await act(async () => {
+      await user.type(
+        screen.getByLabelText(/Please give your Changing hours/),
+        "Test Application"
+      );
+    });
+
+    await act(async () => {
+      await user.click(screen.getByText("Submit"));
+    });
+
+    expect(FormBuilderUtilities.saveDraftForm).toHaveBeenCalled();
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStoreState = {
+      ltft: { canEdit: true, saveStatus: "idle" }
+    };
+  });
+
+  it("should open modal when form submission is successful", async () => {
+    (FormBuilderUtilities.saveDraftForm as jest.Mock).mockImplementation(() => {
+      mockStoreState = {
+        ltft: { canEdit: true, saveStatus: "succeeded" }
+      };
+      return Promise.resolve();
+    });
+
+    await setupTest();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ltft-modal")).toBeInTheDocument();
+    });
+  });
+
+  it("should NOT open modal when form submission fails", async () => {
+    (FormBuilderUtilities.saveDraftForm as jest.Mock).mockImplementation(() => {
+      mockStoreState = {
+        ltft: { canEdit: true, saveStatus: "failed" }
+      };
+      return Promise.resolve();
+    });
+
+    await setupTest();
+
+    await waitFor(() => {
+      expect(mockStoreState.ltft.saveStatus).toBe("failed");
+    });
+
+    // Verify the modal is NOT present
+    expect(screen.queryByTestId("ltft-modal")).not.toBeInTheDocument();
+  });
+});

--- a/components/forms/ltft/__test__/LtftNameModal.test.tsx
+++ b/components/forms/ltft/__test__/LtftNameModal.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { LtftNameModal } from "../LtftNameModal";
 
@@ -7,8 +7,9 @@ import { LtftNameModal } from "../LtftNameModal";
 HTMLDialogElement.prototype.showModal = jest.fn();
 HTMLDialogElement.prototype.close = jest.fn();
 
+const mockUseSubmitting = { isSubmitting: false };
 jest.mock("../../../../utilities/hooks/useSubmitting", () => ({
-  useSubmitting: () => ({ isSubmitting: false })
+  useSubmitting: () => mockUseSubmitting
 }));
 
 describe("LtftNameModal", () => {
@@ -21,30 +22,36 @@ describe("LtftNameModal", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseSubmitting.isSubmitting = false;
   });
 
-  it("calls onSubmit with the correct name data when form is submitted", async () => {
-    const user = userEvent.setup();
+  it("displays the warning confirmation message", () => {
     render(<LtftNameModal {...defaultProps} />);
 
-    const nameInput = screen.getByLabelText(
-      /Please give your Changing hours \(LTFT\) application a name/i
-    );
+    expect(screen.getByText("Important")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Please check the details of the form carefully before submission/i
+      )
+    ).toBeInTheDocument();
+  });
 
-    await act(async () => {
-      await user.type(nameInput, "Test Application");
-    });
+  it("calls onSubmit when Confirm & Continue button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<LtftNameModal {...defaultProps} />);
 
     await act(async () => {
       await user.click(screen.getByText("Confirm & Continue"));
     });
 
-    await waitFor(() => {
-      expect(mockOnSubmit).toHaveBeenCalledTimes(1);
-      expect(mockOnSubmit).toHaveBeenCalledWith(
-        { name: "Test Application" },
-        expect.anything()
-      );
-    });
+    expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows submitting text when form is being submitted", () => {
+    mockUseSubmitting.isSubmitting = true;
+
+    render(<LtftNameModal {...defaultProps} />);
+
+    expect(screen.getByText("Submitting...")).toBeInTheDocument();
   });
 });

--- a/cypress/component/forms/ltft/LtftFormView.cy.tsx
+++ b/cypress/component/forms/ltft/LtftFormView.cy.tsx
@@ -46,29 +46,28 @@ describe("LTFT Form View", () => {
       .should("not.be.disabled");
   });
 
-  it("should enable the submit button when declarations are checked", () => {
+  it("should enable the submit button when declarations are checked and input name text", () => {
+    cy.get('[data-cy="BtnSubmit"]').should("be.disabled");
     cy.get('[data-cy="informationIsCorrect"]').check();
     cy.get('[data-cy="notGuaranteed"]').check();
+    cy.get('[data-cy="BtnSubmit"]').should("be.disabled");
+    cy.get('[data-cy="name"]').type("Test Application");
     cy.get('[data-cy="BtnSubmit"]').should("not.be.disabled");
   });
 
-  it("should open the pre-submit modal when submit button is clicked", () => {
+  it("should open the pre-submit modal when submit button is enabled and clickable", () => {
     cy.get('[data-cy="informationIsCorrect"]').check();
     cy.get('[data-cy="notGuaranteed"]').check();
-    cy.get('[data-cy="BtnSubmit"]').click();
-    cy.get('[data-cy="dialogModal"]').should("exist");
-    cy.get('[data-cy="ltftModalWarning"]').should("exist");
-    cy.get('[data-cy="ltft-modal-save-btn"]')
-      .should("exist")
-      .should("be.disabled");
-    // should keep disable if trim Name is empty
+    cy.get('[data-cy="BtnSubmit"]').should("be.disabled");
     cy.get("#ltftName").type("  ");
-    cy.get('[data-cy="ltft-modal-save-btn"]').should("be.disabled");
+    cy.get('[data-cy="BtnSubmit"]').should("be.disabled");
     // should enable the submit button when Name is inputted
     cy.get("#ltftName").type("Test Application");
-    cy.get('[data-cy="ltft-modal-save-btn"]').should("not.be.disabled");
-    // should close the pre-submit modal when clicking Cancel
-    cy.get('[data-cy="dialogModal"] button').contains("Cancel").click();
-    cy.get('[data-cy="dialogModal"]').should("not.be.visible");
+    cy.get('[data-cy="BtnSubmit"]').should("not.be.disabled").click();
+
+    cy.get('[data-cy="dialogModal"]').should("exist");
+    cy.get('[data-cy="ltftModalWarning"]').should("exist");
+
+    // NOTE - Removed the modal-related tests as the modal will not open as before via the btn click because of the new intermediate saveDraftForm call. AFAIK no easy way to mock this logic in Cypress Component tests, so see RTL (Jest) LtftFormView.test.tsx .
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.112.0",
+  "version": "0.114.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.112.0",
+      "version": "0.114.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.113.0",
+  "version": "0.114.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/redux/slices/__test__/ltftSlice.test.ts
+++ b/redux/slices/__test__/ltftSlice.test.ts
@@ -1,0 +1,469 @@
+import {
+  AnyAction,
+  configureStore,
+  EnhancedStore,
+  ThunkDispatch
+} from "@reduxjs/toolkit";
+import ltftReducer, {
+  saveLtft,
+  LtftObj,
+  updateLtft,
+  deleteLtft,
+  loadSavedLtft,
+  updatedCanEditLtft,
+  updatedEditPageNumberLtft,
+  resetToInitLtft,
+  setLtftCctSnapshot,
+  updatedLtft,
+  updatedLtftSaveStatus,
+  initialState,
+  LtftState
+} from "../ltftSlice";
+import { FormsService } from "../../../services/FormsService";
+import * as ltftUtilities from "../../../utilities/ltftUtilities";
+import * as ToastMessage from "../../../components/common/ToastMessage";
+import { mockLtftDraft1 } from "../../../mock-data/mock-ltft-data";
+import { CctCalculation } from "../cctSlice";
+import { LtftDto, mapLtftObjToDto } from "../../../utilities/ltftUtilities";
+import { AxiosResponse, AxiosRequestHeaders } from "axios";
+
+jest.mock("../../../services/FormsService");
+jest.mock("../../../utilities/ltftUtilities");
+jest.mock("../../../components/common/ToastMessage");
+
+type TestStore = EnhancedStore<{
+  ltft: LtftState;
+}> & {
+  dispatch: ThunkDispatch<{ ltft: LtftState }, unknown, AnyAction>;
+};
+
+// Factory function to create tests for saveLtft and updateLtft thunks
+const createLtftThunkTests = (
+  thunkName: string,
+  thunkAction: typeof saveLtft | typeof updateLtft,
+  serviceMethodName: "saveLtft" | "updateLtft"
+): void => {
+  describe(`ltftSlice - ${thunkName} thunk`, () => {
+    let store: TestStore;
+    const mockFormData: LtftObj = mockLtftDraft1;
+    const mockResponse: AxiosResponse<LtftDto, any> = {
+      status: 200,
+      statusText: "OK",
+      config: {
+        headers: {} as AxiosRequestHeaders
+      },
+      headers: {} as AxiosRequestHeaders,
+      data: {
+        ...mapLtftObjToDto(mockFormData),
+        id: "123updated",
+        lastModified: "2023-01-01T12:30:00"
+      }
+    };
+    const mockMappedResponse: LtftObj = {
+      ...mockFormData,
+      id: "123updated",
+      lastModified: "2023-01-01T12:30:00"
+    };
+
+    beforeEach(() => {
+      store = configureStore({
+        reducer: {
+          ltft: ltftReducer
+        }
+      });
+
+      jest.clearAllMocks();
+
+      (ltftUtilities.mapLtftObjToDto as jest.Mock).mockReturnValue({
+        mockResponse
+      });
+      (ltftUtilities.mapLtftDtoToObj as jest.Mock).mockReturnValue(
+        mockMappedResponse
+      );
+    });
+
+    test("should handle successful save/update", async () => {
+      (
+        FormsService.prototype[serviceMethodName] as jest.Mock
+      ).mockResolvedValue(mockResponse);
+
+      const result = await store.dispatch(
+        thunkAction({
+          formData: mockFormData,
+          isAutoSave: false,
+          isSubmit: false,
+          showFailToastOnly: false
+        })
+      );
+
+      expect(ltftUtilities.mapLtftObjToDto).toHaveBeenCalledWith(mockFormData);
+      expect(FormsService.prototype[serviceMethodName]).toHaveBeenCalled();
+      expect(FormsService.prototype.submitLtft).not.toHaveBeenCalled();
+      expect(ltftUtilities.mapLtftDtoToObj).toHaveBeenCalledWith(
+        mockResponse.data
+      );
+      expect(ToastMessage.showToast).toHaveBeenCalled();
+      expect(result.payload).toEqual({
+        data: mockMappedResponse,
+        isAutoSave: false,
+        isSubmit: false,
+        showFailToastOnly: false
+      });
+      expect(store.getState().ltft.formData).toEqual(mockMappedResponse);
+      expect(store.getState().ltft.saveStatus).toBe("succeeded");
+    });
+
+    test("should handle successful operation with auto-save", async () => {
+      (
+        FormsService.prototype[serviceMethodName] as jest.Mock
+      ).mockResolvedValue(mockResponse);
+
+      await store.dispatch(
+        thunkAction({
+          formData: mockFormData,
+          isAutoSave: true,
+          isSubmit: false,
+          showFailToastOnly: false
+        })
+      );
+
+      expect(FormsService.prototype[serviceMethodName]).toHaveBeenCalled();
+      expect(ToastMessage.showToast).not.toHaveBeenCalled();
+      expect(store.getState().ltft.saveStatus).toBe("succeeded");
+      expect(store.getState().ltft.saveLatestTimeStamp).not.toBe(
+        "none this session"
+      );
+    });
+
+    test("should handle successful submit", async () => {
+      (FormsService.prototype.submitLtft as jest.Mock).mockResolvedValue(
+        mockResponse
+      );
+
+      await store.dispatch(
+        thunkAction({
+          formData: mockFormData,
+          isAutoSave: false,
+          isSubmit: true,
+          showFailToastOnly: false
+        })
+      );
+
+      expect(FormsService.prototype.submitLtft).toHaveBeenCalled();
+      expect(FormsService.prototype[serviceMethodName]).not.toHaveBeenCalled();
+      expect(ToastMessage.showToast).toHaveBeenCalled();
+      expect(store.getState().ltft.saveStatus).toBe("succeeded");
+    });
+
+    test("should handle failure when saving/updating", async () => {
+      const errorType = serviceMethodName === "saveLtft" ? "SAVE" : "UPDATE";
+      const error = {
+        code: `ERR_${errorType}`,
+        message: `Failed to ${
+          serviceMethodName === "saveLtft" ? "save" : "update"
+        }`
+      };
+      (
+        FormsService.prototype[serviceMethodName] as jest.Mock
+      ).mockRejectedValue(error);
+
+      await store.dispatch(
+        thunkAction({
+          formData: mockFormData,
+          isAutoSave: false,
+          isSubmit: false,
+          showFailToastOnly: false
+        })
+      );
+
+      expect(store.getState().ltft.saveStatus).toBe("failed");
+      expect(store.getState().ltft.error).toBe(error.message);
+      expect(ToastMessage.showToast).toHaveBeenCalled();
+    });
+
+    test("should handle failure when submitting", async () => {
+      const error = { code: "ERR_SUBMIT", message: "Failed to submit" };
+      (FormsService.prototype.submitLtft as jest.Mock).mockRejectedValue(error);
+
+      await store.dispatch(
+        thunkAction({
+          formData: mockFormData,
+          isAutoSave: false,
+          isSubmit: true,
+          showFailToastOnly: false
+        })
+      );
+
+      expect(store.getState().ltft.saveStatus).toBe("failed");
+      expect(ToastMessage.showToast).toHaveBeenCalled();
+    });
+
+    test(`should not show toast when auto-${
+      serviceMethodName === "saveLtft" ? "saving" : "updating"
+    } fails`, async () => {
+      const operationName =
+        serviceMethodName === "saveLtft" ? "save" : "update";
+      const error = {
+        code: `ERR_AUTO_${operationName.toUpperCase()}`,
+        message: `Failed to auto-${operationName}`
+      };
+      (
+        FormsService.prototype[serviceMethodName] as jest.Mock
+      ).mockRejectedValue(error);
+
+      await store.dispatch(
+        thunkAction({
+          formData: mockFormData,
+          isAutoSave: true,
+          isSubmit: false,
+          showFailToastOnly: false
+        })
+      );
+
+      expect(store.getState().ltft.saveStatus).toBe("failed");
+      expect(ToastMessage.showToast).not.toHaveBeenCalled();
+    });
+
+    test(`should not show toast when successful ${
+      serviceMethodName === "saveLtft" ? "save" : "update"
+    } (not autosave) and showFailToastOnly is true`, async () => {
+      (
+        FormsService.prototype[serviceMethodName] as jest.Mock
+      ).mockResolvedValue(mockResponse);
+
+      await store.dispatch(
+        thunkAction({
+          formData: mockFormData,
+          isAutoSave: false,
+          isSubmit: false,
+          showFailToastOnly: true
+        })
+      );
+
+      expect(ToastMessage.showToast).not.toHaveBeenCalled();
+    });
+  });
+};
+
+createLtftThunkTests("saveLtft", saveLtft, "saveLtft");
+createLtftThunkTests("updateLtft", updateLtft, "updateLtft");
+
+describe("ltftSlice - deleteLtft thunk", () => {
+  let store: TestStore;
+  const mockFormId = "ltft-123";
+
+  beforeEach(() => {
+    store = configureStore({
+      reducer: {
+        ltft: ltftReducer
+      }
+    });
+
+    jest.clearAllMocks();
+  });
+
+  test("should handle successful deletion", async () => {
+    const mockResponse = { success: true };
+    (FormsService.prototype.deleteLtft as jest.Mock).mockResolvedValue(
+      mockResponse
+    );
+
+    await store.dispatch(deleteLtft(mockFormId));
+
+    expect(FormsService.prototype.deleteLtft).toHaveBeenCalledWith(mockFormId);
+    expect(ToastMessage.showToast).toHaveBeenCalled();
+    expect(store.getState().ltft.status).toBe("succeeded");
+  });
+
+  test("should handle deletion failure", async () => {
+    const error = {
+      code: "ERR_DELETE",
+      message: "Failed to delete LTFT form"
+    };
+    (FormsService.prototype.deleteLtft as jest.Mock).mockRejectedValue(error);
+
+    await store.dispatch(deleteLtft(mockFormId));
+
+    expect(FormsService.prototype.deleteLtft).toHaveBeenCalledWith(mockFormId);
+    expect(store.getState().ltft.status).toBe("failed");
+    expect(store.getState().ltft.error).toBe(error.message);
+    expect(ToastMessage.showToast).toHaveBeenCalledWith(
+      expect.any(String),
+      ToastMessage.ToastType.ERROR,
+      `${error.code}-${error.message}`
+    );
+  });
+
+  test("should set status to 'deleting' when deletion is pending", () => {
+    (FormsService.prototype.deleteLtft as jest.Mock).mockReturnValue(
+      new Promise(() => {}) // Never resolves to keep action in pending state
+    );
+    store.dispatch(deleteLtft(mockFormId));
+    expect(store.getState().ltft.status).toBe("deleting");
+  });
+});
+
+describe("ltftSlice - loadSavedLtft thunk", () => {
+  let store: TestStore;
+  const mockFormId = "ltft-456";
+  let mockResponse: AxiosResponse<LtftDto, any>;
+  let mockMappedLtft: LtftObj;
+
+  beforeEach(() => {
+    store = configureStore({
+      reducer: {
+        ltft: ltftReducer
+      }
+    });
+
+    jest.clearAllMocks();
+
+    mockResponse = {
+      status: 200,
+      statusText: "OK",
+      config: {
+        headers: {} as AxiosRequestHeaders
+      },
+      headers: {} as AxiosRequestHeaders,
+      data: {
+        ...mapLtftObjToDto(mockLtftDraft1),
+        id: mockFormId,
+        lastModified: "2023-01-01T12:30:00"
+      }
+    };
+
+    mockMappedLtft = {
+      ...mockLtftDraft1,
+      id: mockFormId
+    };
+
+    (ltftUtilities.mapLtftDtoToObj as jest.Mock).mockReturnValue(
+      mockMappedLtft
+    );
+  });
+
+  test("should handle successful form loading", async () => {
+    (FormsService.prototype.getLtftFormById as jest.Mock).mockResolvedValue(
+      mockResponse
+    );
+
+    await store.dispatch(loadSavedLtft(mockFormId));
+
+    expect(FormsService.prototype.getLtftFormById).toHaveBeenCalledWith(
+      mockFormId
+    );
+    expect(ltftUtilities.mapLtftDtoToObj).toHaveBeenCalledWith(
+      mockResponse.data
+    );
+    expect(store.getState().ltft.status).toBe("succeeded");
+    expect(store.getState().ltft.formData).toEqual(mockMappedLtft);
+  });
+
+  test("should handle form loading failure", async () => {
+    const error = {
+      code: "ERR_LOAD",
+      message: "Failed to load LTFT form"
+    };
+    (FormsService.prototype.getLtftFormById as jest.Mock).mockRejectedValue(
+      error
+    );
+    await store.dispatch(loadSavedLtft(mockFormId));
+    expect(FormsService.prototype.getLtftFormById).toHaveBeenCalledWith(
+      mockFormId
+    );
+    expect(store.getState().ltft.status).toBe("failed");
+    expect(store.getState().ltft.error).toBe(error.message);
+    expect(ToastMessage.showToast).toHaveBeenCalledWith(
+      expect.any(String),
+      ToastMessage.ToastType.ERROR,
+      `${error.code}-${error.message}`
+    );
+  });
+
+  test("should set status to 'loading' when form loading is pending", () => {
+    (FormsService.prototype.getLtftFormById as jest.Mock).mockReturnValue(
+      new Promise(() => {})
+    );
+
+    store.dispatch(loadSavedLtft(mockFormId));
+
+    expect(store.getState().ltft.status).toBe("loading");
+  });
+});
+
+// reducer tests
+describe("ltftSlice - reducers", () => {
+  let store: TestStore;
+
+  beforeEach(() => {
+    store = configureStore({
+      reducer: {
+        ltft: ltftReducer
+      }
+    });
+
+    jest.clearAllMocks();
+  });
+
+  test("resetToInitLtft should reset state to initial values", () => {
+    store.dispatch(updatedCanEditLtft(true));
+    store.dispatch(updatedEditPageNumberLtft(5));
+
+    expect(store.getState().ltft.canEdit).toBe(true);
+    expect(store.getState().ltft.editPageNumber).toBe(5);
+
+    store.dispatch(resetToInitLtft());
+
+    // Verify state was reset
+    expect(store.getState().ltft).toEqual(initialState);
+  });
+
+  test("setLtftCctSnapshot should update LtftCctSnapshot", () => {
+    const mockCctSnapshot = {
+      id: "cct-123",
+      created: "2024-01-01"
+    } as unknown as CctCalculation;
+
+    store.dispatch(setLtftCctSnapshot(mockCctSnapshot));
+
+    expect(store.getState().ltft.LtftCctSnapshot).toEqual(mockCctSnapshot);
+  });
+
+  test("updatedLtft should update formData", () => {
+    store.dispatch(updatedLtft(mockLtftDraft1));
+    expect(store.getState().ltft.formData).toEqual(mockLtftDraft1);
+  });
+
+  test("updatedCanEditLtft should update canEdit flag", () => {
+    expect(store.getState().ltft.canEdit).toBe(false); // Initial state
+
+    store.dispatch(updatedCanEditLtft(true));
+    expect(store.getState().ltft.canEdit).toBe(true);
+
+    store.dispatch(updatedCanEditLtft(false));
+    expect(store.getState().ltft.canEdit).toBe(false);
+  });
+
+  test("updatedEditPageNumberLtft should update editPageNumber", () => {
+    expect(store.getState().ltft.editPageNumber).toBe(0); // Initial state
+
+    store.dispatch(updatedEditPageNumberLtft(3));
+    expect(store.getState().ltft.editPageNumber).toBe(3);
+
+    store.dispatch(updatedEditPageNumberLtft(1));
+    expect(store.getState().ltft.editPageNumber).toBe(1);
+  });
+
+  test("updatedLtftSaveStatus should update saveStatus", () => {
+    expect(store.getState().ltft.saveStatus).toBe("idle"); // Initial state
+
+    store.dispatch(updatedLtftSaveStatus("saving"));
+    expect(store.getState().ltft.saveStatus).toBe("saving");
+
+    store.dispatch(updatedLtftSaveStatus("succeeded"));
+    expect(store.getState().ltft.saveStatus).toBe("succeeded");
+
+    store.dispatch(updatedLtftSaveStatus("failed"));
+    expect(store.getState().ltft.saveStatus).toBe("failed");
+  });
+});

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -98,7 +98,7 @@ export type LtftObj = {
   lastModified?: Date | string;
 };
 
-type LtftState = {
+export type LtftState = {
   formData: LtftObj;
   LtftCctSnapshot: CctCalculation;
   status: string;
@@ -110,7 +110,7 @@ type LtftState = {
   saveLatestTimeStamp: string;
 };
 
-const initialState: LtftState = {
+export const initialState: LtftState = {
   formData: {} as LtftObj,
   LtftCctSnapshot: {} as CctCalculation,
   status: "idle",

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -128,11 +128,13 @@ export const saveLtft = createAsyncThunk(
     {
       formData,
       isAutoSave,
-      isSubmit
+      isSubmit,
+      showFailToastOnly
     }: {
       formData: LtftObj;
       isAutoSave: boolean;
       isSubmit: boolean;
+      showFailToastOnly: boolean;
     },
     { rejectWithValue }
   ) => {
@@ -143,7 +145,12 @@ export const saveLtft = createAsyncThunk(
         ? await formsService.submitLtft(mappedFormDataDto)
         : await formsService.saveLtft(mappedFormDataDto);
       const mappedResLtftObj = mapLtftDtoToObj(response.data);
-      return { data: mappedResLtftObj, isAutoSave, isSubmit };
+      return {
+        data: mappedResLtftObj,
+        isAutoSave,
+        isSubmit,
+        showFailToastOnly
+      };
     } catch (error) {
       return rejectWithValue({ error, isAutoSave, isSubmit });
     }
@@ -156,11 +163,13 @@ export const updateLtft = createAsyncThunk(
     {
       formData,
       isAutoSave,
-      isSubmit
+      isSubmit,
+      showFailToastOnly
     }: {
       formData: LtftObj;
       isAutoSave: boolean;
       isSubmit: boolean;
+      showFailToastOnly: boolean;
     },
     { rejectWithValue }
   ) => {
@@ -171,7 +180,12 @@ export const updateLtft = createAsyncThunk(
         ? await formsService.submitLtft(mappedFormDataDto)
         : await formsService.updateLtft(mappedFormDataDto);
       const mappedResLtftObj = mapLtftDtoToObj(response.data);
-      return { data: mappedResLtftObj, isAutoSave, isSubmit };
+      return {
+        data: mappedResLtftObj,
+        isAutoSave,
+        isSubmit,
+        showFailToastOnly
+      };
     } catch (error) {
       return rejectWithValue({ error, isAutoSave, isSubmit });
     }
@@ -213,6 +227,9 @@ const ltftSlice = createSlice({
     },
     updatedEditPageNumberLtft(state, action: PayloadAction<number>) {
       state.editPageNumber = action.payload;
+    },
+    updatedLtftSaveStatus(state, action: PayloadAction<SaveStatusProps>) {
+      state.saveStatus = action.payload;
     }
   },
   extraReducers(builder): void {
@@ -232,7 +249,10 @@ const ltftSlice = createSlice({
       )
       .addCase(
         saveLtft.fulfilled,
-        (state, { payload: { data, isAutoSave, isSubmit } }) => {
+        (
+          state,
+          { payload: { data, isAutoSave, isSubmit, showFailToastOnly } }
+        ) => {
           state.saveStatus = "succeeded";
           state.formData = data;
           state.newFormId = data.id;
@@ -244,7 +264,7 @@ const ltftSlice = createSlice({
           if (isSubmit) {
             showToast(toastSuccessText.submitLtft, ToastType.SUCCESS);
           }
-          if (!isAutoSave && !isSubmit) {
+          if (!isAutoSave && !isSubmit && !showFailToastOnly) {
             showToast(toastSuccessText.saveLtft, ToastType.SUCCESS);
           }
         }
@@ -287,7 +307,10 @@ const ltftSlice = createSlice({
       )
       .addCase(
         updateLtft.fulfilled,
-        (state, { payload: { data, isAutoSave, isSubmit } }) => {
+        (
+          state,
+          { payload: { data, isAutoSave, isSubmit, showFailToastOnly } }
+        ) => {
           state.saveStatus = "succeeded";
           state.formData = data;
           state.newFormId = data.id;
@@ -299,7 +322,7 @@ const ltftSlice = createSlice({
           if (isSubmit) {
             showToast(toastSuccessText.submitLtft, ToastType.SUCCESS);
           }
-          if (!isAutoSave && !isSubmit) {
+          if (!isAutoSave && !isSubmit && !showFailToastOnly) {
             showToast(toastSuccessText.updateLtft, ToastType.SUCCESS);
           }
         }
@@ -367,7 +390,8 @@ export const {
   setLtftCctSnapshot,
   updatedLtft,
   updatedCanEditLtft,
-  updatedEditPageNumberLtft
+  updatedEditPageNumberLtft,
+  updatedLtftSaveStatus
 } = ltftSlice.actions;
 
 export default ltftSlice.reducer;

--- a/utilities/__test__/FormBuilderUtilitiesSaveDraftForm.test.ts
+++ b/utilities/__test__/FormBuilderUtilitiesSaveDraftForm.test.ts
@@ -1,0 +1,414 @@
+import { saveDraftForm } from "../FormBuilderUtilities";
+import store from "../../redux/store/store";
+import history from "../../components/navigation/history";
+import { FormRPartA } from "../../models/FormRPartA";
+import { FormRPartB } from "../../models/FormRPartB";
+import { Form } from "../../components/forms/form-builder/FormBuilder";
+import { LtftObj } from "../../redux/slices/ltftSlice";
+import { LifeCycleState } from "../../models/LifeCycleState";
+
+// Mock Redux store
+jest.mock("../../redux/store/store", () => ({
+  dispatch: jest.fn().mockResolvedValue(undefined),
+  getState: jest.fn().mockReturnValue({
+    formA: { saveStatus: "succeeded", newFormId: "new-formA-id" },
+    formB: { saveStatus: "succeeded", newFormId: "new-formB-id" },
+    ltft: { saveStatus: "succeeded", newFormId: "new-ltft-id" }
+  })
+}));
+
+// Mock history
+jest.mock("../../components/navigation/history", () => ({
+  push: jest.fn()
+}));
+
+// Mock Redux actions
+jest.mock("../../redux/slices/formASlice", () => ({
+  updateFormA: jest.fn(),
+  saveFormA: jest.fn()
+}));
+
+jest.mock("../../redux/slices/formBSlice", () => ({
+  updateFormB: jest.fn(),
+  saveFormB: jest.fn()
+}));
+
+jest.mock("../../redux/slices/ltftSlice", () => ({
+  updateLtft: jest.fn(),
+  saveLtft: jest.fn()
+}));
+
+// Import Redux actions after mocking
+import { updateFormA, saveFormA } from "../../redux/slices/formASlice";
+import { updateFormB, saveFormB } from "../../redux/slices/formBSlice";
+import { updateLtft, saveLtft } from "../../redux/slices/ltftSlice";
+
+describe("saveDraftForm integration tests", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Mock form JSON definitions
+  const formAJson: Form = {
+    name: "formA",
+    pages: [],
+    declarations: []
+  } as Form;
+  const formBJson: Form = {
+    name: "formB",
+    pages: [],
+    declarations: []
+  } as Form;
+  const ltftJson: Form = { name: "ltft", pages: [], declarations: [] } as Form;
+
+  describe("Form A tests", () => {
+    it("should call updateFormA when form has an existing ID", async () => {
+      // Setup
+      const formData: Partial<FormRPartA> = {
+        id: "existing-formA-id",
+        traineeTisId: "trainee123",
+        lifecycleState: LifeCycleState.Draft
+      };
+
+      // Execute
+      await saveDraftForm(formAJson, formData as FormRPartA);
+
+      // Assert
+      expect(updateFormA).toHaveBeenCalledWith({
+        formData: expect.objectContaining({
+          id: "existing-formA-id",
+          traineeTisId: "trainee123",
+          lifecycleState: LifeCycleState.Draft,
+          lastModifiedDate: expect.any(Date)
+        }),
+        isAutoSave: false,
+        isSubmit: false
+      });
+      expect(saveFormA).not.toHaveBeenCalled();
+      expect(history.push).toHaveBeenCalledWith("/formr-a");
+    });
+
+    it("should call saveFormA when form has no existing ID", async () => {
+      // Setup
+      const formData: Partial<FormRPartA> = {
+        traineeTisId: "trainee123",
+        lifecycleState: LifeCycleState.Draft
+      };
+
+      (store.getState as jest.Mock).mockReturnValueOnce({
+        formA: { saveStatus: "succeeded", newFormId: null }
+      });
+
+      // Execute
+      await saveDraftForm(formAJson, formData as FormRPartA);
+
+      // Assert
+      expect(saveFormA).toHaveBeenCalledWith({
+        formData: expect.objectContaining({
+          traineeTisId: "trainee123",
+          lifecycleState: LifeCycleState.Draft,
+          lastModifiedDate: expect.any(Date)
+        }),
+        isAutoSave: false,
+        isSubmit: false
+      });
+      expect(updateFormA).not.toHaveBeenCalled();
+      expect(history.push).toHaveBeenCalledWith("/formr-a");
+    });
+
+    it("should prep FormA data differently when isSubmit=true", async () => {
+      // Setup
+      const formData: Partial<FormRPartA> = {
+        id: "existing-formA-id",
+        traineeTisId: "trainee123",
+        lifecycleState: LifeCycleState.Draft
+      };
+
+      // Execute
+      await saveDraftForm(formAJson, formData as FormRPartA, false, true);
+
+      // Assert
+      expect(updateFormA).toHaveBeenCalledWith({
+        formData: expect.objectContaining({
+          id: "existing-formA-id",
+          traineeTisId: "trainee123",
+          lifecycleState: LifeCycleState.Submitted,
+          lastModifiedDate: expect.any(Date),
+          submissionDate: expect.any(Date)
+        }),
+        isAutoSave: false,
+        isSubmit: true
+      });
+    });
+
+    it("should maintain Unsubmitted state when current state is Unsubmitted", async () => {
+      // Setup
+      const formData: Partial<FormRPartA> = {
+        id: "existing-formA-id",
+        traineeTisId: "trainee123",
+        lifecycleState: LifeCycleState.Unsubmitted
+      };
+
+      // Execute
+      await saveDraftForm(formAJson, formData as FormRPartA);
+
+      // Assert
+      expect(updateFormA).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formData: expect.objectContaining({
+            lifecycleState: LifeCycleState.Unsubmitted
+          })
+        })
+      );
+    });
+  });
+
+  describe("Form B tests", () => {
+    it("should call updateFormB when form has an existing ID", async () => {
+      // Setup
+      const formData: Partial<FormRPartB> = {
+        id: "existing-formB-id",
+        traineeTisId: "trainee123",
+        lifecycleState: LifeCycleState.Draft
+      };
+
+      // Execute
+      await saveDraftForm(formBJson, formData as FormRPartB);
+
+      // Assert
+      expect(updateFormB).toHaveBeenCalledWith({
+        formData: expect.objectContaining({
+          id: "existing-formB-id",
+          traineeTisId: "trainee123",
+          lifecycleState: LifeCycleState.Draft,
+          lastModifiedDate: expect.any(Date)
+        }),
+        isAutoSave: false,
+        isSubmit: false
+      });
+      expect(saveFormB).not.toHaveBeenCalled();
+      expect(history.push).toHaveBeenCalledWith("/formr-b");
+    });
+
+    it("should call saveFormB when form has no existing ID", async () => {
+      // Setup
+      const formData: Partial<FormRPartB> = {
+        traineeTisId: "trainee123",
+        lifecycleState: LifeCycleState.Draft
+      };
+
+      (store.getState as jest.Mock).mockReturnValueOnce({
+        formB: { saveStatus: "succeeded", newFormId: null }
+      });
+
+      // Execute
+      await saveDraftForm(formBJson, formData as FormRPartB);
+
+      // Assert
+      expect(saveFormB).toHaveBeenCalledWith({
+        formData: expect.objectContaining({
+          traineeTisId: "trainee123",
+          lifecycleState: LifeCycleState.Draft,
+          lastModifiedDate: expect.any(Date)
+        }),
+        isAutoSave: false,
+        isSubmit: false
+      });
+      expect(updateFormB).not.toHaveBeenCalled();
+      expect(history.push).toHaveBeenCalledWith("/formr-b");
+    });
+  });
+
+  describe("LTFT tests", () => {
+    it("should call updateLtft when form has an existing ID", async () => {
+      // Setup
+      const formData: Partial<LtftObj> = {
+        id: "existing-ltft-id",
+        traineeTisId: "trainee123"
+      };
+
+      // Execute
+      await saveDraftForm(ltftJson, formData as LtftObj);
+
+      // Assert
+      expect(updateLtft).toHaveBeenCalledWith({
+        formData: expect.objectContaining({
+          id: "existing-ltft-id",
+          traineeTisId: "trainee123"
+        }),
+        isAutoSave: false,
+        isSubmit: false,
+        showFailToastOnly: false
+      });
+      expect(saveLtft).not.toHaveBeenCalled();
+      expect(history.push).toHaveBeenCalledWith("/ltft");
+    });
+
+    it("should call saveLtft when form has no existing ID", async () => {
+      // Setup
+      const formData: Partial<LtftObj> = {
+        traineeTisId: "trainee123"
+      };
+
+      (store.getState as jest.Mock).mockReturnValueOnce({
+        ltft: { saveStatus: "succeeded", newFormId: null }
+      });
+
+      // Execute
+      await saveDraftForm(ltftJson, formData as LtftObj);
+
+      // Assert
+      expect(saveLtft).toHaveBeenCalledWith({
+        formData: expect.objectContaining({
+          traineeTisId: "trainee123"
+        }),
+        isAutoSave: false,
+        isSubmit: false,
+        showFailToastOnly: false
+      });
+      expect(updateLtft).not.toHaveBeenCalled();
+      expect(history.push).toHaveBeenCalledWith("/ltft");
+    });
+
+    it("should NOT prep LTFT forms (no FormR-specific processing)", async () => {
+      // Setup
+      const formData: Partial<LtftObj> = {
+        id: "existing-ltft-id",
+        traineeTisId: "trainee123"
+      };
+
+      // Execute
+      await saveDraftForm(ltftJson, formData as LtftObj, false, true);
+
+      // Assert
+      expect(updateLtft).toHaveBeenCalledWith({
+        formData: expect.objectContaining({
+          id: "existing-ltft-id",
+          traineeTisId: "trainee123"
+        }),
+        isAutoSave: false,
+        isSubmit: true,
+        showFailToastOnly: false
+      });
+      // LTFT forms don't set submissionDate or change lifecycleState like FormR forms
+    });
+  });
+
+  describe("Flag parameter tests", () => {
+    it("should pass isAutoSave flag to update function", async () => {
+      const formData: Partial<FormRPartA> = { id: "test-id" };
+      await saveDraftForm(formAJson, formData as FormRPartA, true);
+
+      expect(updateFormA).toHaveBeenCalledWith(
+        expect.objectContaining({ isAutoSave: true })
+      );
+    });
+
+    it("should pass isSubmit flag to update function", async () => {
+      const formData: Partial<FormRPartA> = { id: "test-id" };
+      await saveDraftForm(formAJson, formData as FormRPartA, false, true);
+
+      expect(updateFormA).toHaveBeenCalledWith(
+        expect.objectContaining({ isSubmit: true })
+      );
+    });
+
+    it("should pass showFailToastOnly flag to update function", async () => {
+      const formData: Partial<LtftObj> = { id: "test-id" };
+      await saveDraftForm(ltftJson, formData as LtftObj, false, false, true);
+
+      expect(updateLtft).toHaveBeenCalledWith(
+        expect.objectContaining({ showFailToastOnly: true })
+      );
+    });
+
+    it("should not redirect when shouldRedirect is false", async () => {
+      const formData: Partial<FormRPartA> = { id: "test-id" };
+      await saveDraftForm(
+        formAJson,
+        formData as FormRPartA,
+        false,
+        false,
+        false,
+        false
+      );
+
+      expect(history.push).not.toHaveBeenCalled();
+    });
+
+    it("should not redirect when save status is not 'succeeded'", async () => {
+      const formData: Partial<FormRPartA> = { id: "test-id" };
+
+      // Mock unsuccessful save status
+      (store.getState as jest.Mock).mockReturnValueOnce({
+        formA: { saveStatus: "failed" },
+        formB: { saveStatus: "succeeded" },
+        ltft: { saveStatus: "succeeded" }
+      });
+
+      await saveDraftForm(formAJson, formData as FormRPartA);
+
+      expect(history.push).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Form ID handling tests", () => {
+    it("should get formA ID from store when not in formData", async () => {
+      const formData: Partial<FormRPartA> = { traineeTisId: "trainee123" };
+
+      await saveDraftForm(formAJson, formData as FormRPartA);
+
+      expect(updateFormA).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formData: expect.objectContaining({
+            id: "new-formA-id"
+          })
+        })
+      );
+    });
+
+    it("should get formB ID from store when not in formData", async () => {
+      const formData: Partial<FormRPartB> = { traineeTisId: "trainee123" };
+
+      await saveDraftForm(formBJson, formData as FormRPartB);
+
+      expect(updateFormB).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formData: expect.objectContaining({
+            id: "new-formB-id"
+          })
+        })
+      );
+    });
+
+    it("should get ltft ID from store when not in formData", async () => {
+      const formData: Partial<LtftObj> = { traineeTisId: "trainee123" };
+
+      await saveDraftForm(ltftJson, formData as LtftObj);
+
+      expect(updateLtft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formData: expect.objectContaining({
+            id: "new-ltft-id"
+          })
+        })
+      );
+    });
+
+    it("should call saveForm when no ID is available", async () => {
+      const formData: Partial<FormRPartA> = { traineeTisId: "trainee123" };
+
+      // Mock store to return null for newFormId
+      (store.getState as jest.Mock).mockReturnValueOnce({
+        formA: { saveStatus: "succeeded", newFormId: null },
+        formB: { saveStatus: "succeeded" },
+        ltft: { saveStatus: "succeeded" }
+      });
+
+      await saveDraftForm(formAJson, formData as FormRPartA);
+
+      expect(saveFormA).toHaveBeenCalled();
+      expect(updateFormA).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/utilities/hooks/useFormAutosave.ts
+++ b/utilities/hooks/useFormAutosave.ts
@@ -14,7 +14,7 @@ const useFormAutosave = (
   useEffect(() => {
     if (isFormDirty) {
       const timeoutId = setTimeout(() => {
-        saveDraftForm(jsonForm, formData, true, false);
+        saveDraftForm(jsonForm, formData, true, false, false, false);
       }, 2000);
 
       return () => {


### PR DESCRIPTION
NOTE: Mostly test files. The implementation code changes (~50 lines) is [here](https://github.com/Health-Education-England/tis-trainee-ui/pull/1166/commits/1a3622ca3a9edec8d3c3b6f108c267a5e30fbc2c) and [here](https://github.com/Health-Education-England/tis-trainee-ui/pull/1166/commits/1a3622ca3a9edec8d3c3b6f108c267a5e30fbc2c) .

As agreed Friday: 
1. Add an intermediate POST/PUT `/save /update` step on the `LtftFormView.tsx` submit button.
2. A successful save will open the 'are-you-sure' modal (still named` LtftNameModal.tsx` out of respect/laziness) minus the success Toast so as not to confuse the user (see  
showFailToastOnly in saveDraftForm).
3. A failed save will show error Toast and no modal with the user remaining on `LtftFormView.tsx` .
4. A modal submit will trigger the usual PUT `/submit` logic.
Note: the `name` field has been moved to the `LtftFormView.tsx` so that this data is saved/updated in the intermediate save step.

Update (after @DorisWongNHS 's suggestion):
5. Display the saved Ltft name in LtftFormView text field (when available) for e.g. editing.

NO TICKET
