### PR TITLE
Refactor/summary table1 dw1

### DIFF
--- a/components/forms/ltft/LtftHome.tsx
+++ b/components/forms/ltft/LtftHome.tsx
@@ -1,24 +1,8 @@
-import {
-  ActionLink,
-  Button,
-  Card,
-  Col,
-  Container,
-  Row,
-  WarningCallout
-} from "nhsuk-react-components";
-import { LtftTracker } from "./LtftTracker";
-import history from "../../navigation/history";
-import {
-  LtftSummaryObj,
-  updatedLtftFormsRefreshNeeded
-} from "../../../redux/slices/ltftSummaryListSlice";
+import { ActionLink, Card, Col, Container, Row } from "nhsuk-react-components";
 import LtftSummary from "./LtftSummary";
 import { DateUtilities } from "../../../utilities/DateUtilities";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks/hooks";
 import Loading from "../../common/Loading";
-import { StartOverButton } from "../StartOverButton";
-import { loadTheSavedForm } from "../../../utilities/FormBuilderUtilities";
 import ErrorPage from "../../common/ErrorPage";
 import { useLtftHomeStartover } from "../../../utilities/hooks/useLtftHomeStartover";
 import { Link } from "react-router-dom";
@@ -55,10 +39,8 @@ export function LtftHome() {
       <Card>
         <Card.Content>
           <>
-            <Card.Heading data-cy="ltft-tracker-header">
-              {draftOrUnsubmittedLtftSummary
-                ? "In progress application"
-                : "New application"}
+            <Card.Heading data-cy="ltft-current-summary-header">
+              In progress application
             </Card.Heading>
             <LtftSummary
               ltftSummaryType="CURRENT"
@@ -68,10 +50,12 @@ export function LtftHome() {
             <Container>
               <Row>
                 <Col width="full">
-                  <Link to="/cct" data-cy="cct-link">
-                    Click here to choose a CCT Calculation to begin a new
-                    Changing hours (LTFT) application
-                  </Link>
+                  <ActionLink>
+                    <Link to="/cct" data-cy="cct-link">
+                      Choose a CCT Calculation to begin a new Changing hours
+                      (LTFT) application
+                    </Link>
+                  </ActionLink>
                 </Col>
               </Row>
             </Container>
@@ -80,17 +64,7 @@ export function LtftHome() {
       </Card>
       <Card>
         <Card.Content>
-          <WarningCallout data-cy="ltftWarning">
-            <WarningCallout.Label visuallyHiddenText={false}>
-              For Demonstration Only
-            </WarningCallout.Label>
-            <p>
-              The table below has <strong>dummy data</strong> and is read only
-              for demonstrating the future layout of the LTFT Applications
-              Summary.
-            </p>
-          </WarningCallout>
-          <Card.Heading data-cy="ltft-summary-header">
+          <Card.Heading data-cy="ltft-previous-summary-header">
             Previous applications summary
           </Card.Heading>
           <LtftSummary

--- a/components/forms/ltft/LtftHome.tsx
+++ b/components/forms/ltft/LtftHome.tsx
@@ -1,4 +1,5 @@
 import {
+  ActionLink,
   Button,
   Card,
   Col,
@@ -13,7 +14,6 @@ import {
   updatedLtftFormsRefreshNeeded
 } from "../../../redux/slices/ltftSummaryListSlice";
 import LtftSummary from "./LtftSummary";
-import { mockLtftsList1 } from "../../../mock-data/mock-ltft-data";
 import { DateUtilities } from "../../../utilities/DateUtilities";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks/hooks";
 import Loading from "../../common/Loading";
@@ -21,6 +21,7 @@ import { StartOverButton } from "../StartOverButton";
 import { loadTheSavedForm } from "../../../utilities/FormBuilderUtilities";
 import ErrorPage from "../../common/ErrorPage";
 import { useLtftHomeStartover } from "../../../utilities/hooks/useLtftHomeStartover";
+import { Link } from "react-router-dom";
 
 export function LtftHome() {
   const ltftSummary = useAppSelector(
@@ -40,7 +41,7 @@ export function LtftHome() {
     item => item.status !== "DRAFT" && item.status !== "UNSUBMITTED"
   );
 
-  const draftOrUnsubmittedLtftSummary = ltftSummary.find(
+  const draftOrUnsubmittedLtftSummary = ltftSummary.filter(
     item => item.status === "DRAFT" || item.status === "UNSUBMITTED"
   );
 
@@ -59,12 +60,21 @@ export function LtftHome() {
                 ? "In progress application"
                 : "New application"}
             </Card.Heading>
-            <LtftTracker
-              draftOrUnsubmittedLtftSummary={draftOrUnsubmittedLtftSummary}
+            <LtftSummary
+              ltftSummaryType="CURRENT"
+              ltftSummaryStatus={ltftFormsListStatus}
+              ltftSummaryList={draftOrUnsubmittedLtftSummary}
             />
-            <TrackerSectionBtns
-              draftOrUnsubmittedLtftSummary={draftOrUnsubmittedLtftSummary}
-            />
+            <Container>
+              <Row>
+                <Col width="full">
+                  <Link to="/cct" data-cy="cct-link">
+                    Click here to choose a CCT Calculation to begin a new
+                    Changing hours (LTFT) application
+                  </Link>
+                </Col>
+              </Row>
+            </Container>
           </>
         </Card.Content>
       </Card>
@@ -84,72 +94,12 @@ export function LtftHome() {
             Previous applications summary
           </Card.Heading>
           <LtftSummary
+            ltftSummaryType="PREVIOUS"
             ltftSummaryStatus={ltftFormsListStatus}
             ltftSummaryList={previousLtftSummaries}
           />
         </Card.Content>
       </Card>
     </>
-  );
-}
-
-type TrackerSectionBtnsProps = {
-  draftOrUnsubmittedLtftSummary: LtftSummaryObj | undefined;
-};
-
-function TrackerSectionBtns({
-  draftOrUnsubmittedLtftSummary
-}: Readonly<TrackerSectionBtnsProps>) {
-  const dispatch = useAppDispatch();
-  const handleClick = () => {
-    loadTheSavedForm("/ltft", draftOrUnsubmittedLtftSummary?.id ?? "", history);
-  };
-  return (
-    <div style={{ marginTop: "2rem" }}>
-      {draftOrUnsubmittedLtftSummary ? (
-        <Container>
-          <Row>
-            <Col width="two-thirds">
-              <Button
-                data-cy="continue-application-button"
-                onClick={handleClick}
-              >
-                {`Continue ${
-                  draftOrUnsubmittedLtftSummary?.status === "DRAFT"
-                    ? "draft"
-                    : "unsubmitted"
-                } application`}
-              </Button>
-            </Col>
-          </Row>
-          <Row>
-            <Col width="one-third">
-              <StartOverButton
-                formName="ltft"
-                btnLocation="formsList"
-                formsListDraftId={draftOrUnsubmittedLtftSummary.id}
-              />
-            </Col>
-          </Row>
-        </Container>
-      ) : (
-        <Container>
-          <Row>
-            <Col width="two-thirds">
-              <Button
-                data-cy="choose-cct-btn"
-                onClick={() => {
-                  dispatch(updatedLtftFormsRefreshNeeded(false));
-                  history.push("/cct");
-                }}
-              >
-                Choose a CCT Calculation to begin your Changing hours (LTFT)
-                application
-              </Button>
-            </Col>
-          </Row>
-        </Container>
-      )}
-    </div>
   );
 }

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -17,18 +17,21 @@ import dayjs from "dayjs";
 import Loading from "../../common/Loading";
 import history from "../../navigation/history";
 import { LtftFormStatus } from "../../../redux/slices/ltftSlice";
+import { loadTheSavedForm } from "../../../utilities/FormBuilderUtilities";
 
 type LtftFormStatusSub = Extract<
   LtftFormStatus,
-  "SUBMITTED" | "APPROVED" | "WITHDRAWN"
+  "SUBMITTED" | "APPROVED" | "WITHDRAWN" | "DRAFT" | "UNSUBMITTED"
 >;
 
 type LtftSummaryProps = {
+  ltftSummaryType: string;
   ltftSummaryStatus: string;
   ltftSummaryList?: LtftSummaryObj[];
 };
 
 const LtftSummary = ({
+  ltftSummaryType,
   ltftSummaryStatus,
   ltftSummaryList
 }: Readonly<LtftSummaryProps>) => {
@@ -39,7 +42,9 @@ const LtftSummary = ({
   >({
     SUBMITTED: true,
     APPROVED: true,
-    WITHDRAWN: true
+    WITHDRAWN: true,
+    DRAFT: true,
+    UNSUBMITTED: true
   });
 
   const filteredLtftSummaries = ltftSummaries.filter(
@@ -51,6 +56,14 @@ const LtftSummary = ({
       ...prev,
       [status]: !prev[status]
     }));
+  };
+
+  const handleClick = (id: string) => {
+    if (ltftSummaryType === "CURRENT") {
+      loadTheSavedForm("/ltft", id ?? "", history);
+    } else if (ltftSummaryType === "PREVIOUS") {
+      history.push(`/ltft/${id}`);
+    }
   };
 
   const columnHelper = createColumnHelper<LtftSummaryObj>();
@@ -132,6 +145,12 @@ const LtftSummary = ({
             {renderActionButton("Withdraw", "withdrawLtftBtnLink")}
           </>
         ) : null}
+        {props.row.original.status === "DRAFT" ? (
+          <>{renderActionButton("Delete", "deleteLtftBtnLink")}</>
+        ) : null}
+        {props.row.original.status === "UNSUBMITTED" ? (
+          <>{renderActionButton("Withdraw", "withdrawLtftBtnLink")}</>
+        ) : null}
       </>
     );
   };
@@ -190,68 +209,77 @@ const LtftSummary = ({
     autoResetPageIndex: false
   });
 
-  const statusFilters: LtftFormStatusSub[] = [
-    "APPROVED",
-    "SUBMITTED",
-    "WITHDRAWN"
-  ];
+  let statusFilters: LtftFormStatusSub[] = [];
+  if (ltftSummaryType === "CURRENT") {
+    statusFilters = ["DRAFT", "UNSUBMITTED"];
+  } else if (ltftSummaryType === "PREVIOUS") {
+    statusFilters = ["APPROVED", "SUBMITTED", "WITHDRAWN"];
+  }
 
   let content: JSX.Element = <></>;
   if (ltftSummaryStatus === "loading") content = <Loading />;
   if (ltftSummaryStatus === "succeeded")
     content = (
       <div>
-        {statusFilters.map(status => (
-          <CheckboxField
-            key={status}
-            data-cy={`filter${status}Ltft`}
-            name={`yesToShow${status}`}
-            value="yes"
-            label={status}
-            checked={visibleStatuses[status]}
-            onChange={() => toggleStatus(status)}
-          />
-        ))}
-        <table data-cy="ltft-summary-table">
-          <thead>
-            {table.getHeaderGroups().map(headerGroup => (
-              <tr key={headerGroup.id}>
-                {headerGroup.headers.map(header => (
-                  <th
-                    key={header.id}
-                    data-cy={`ltft-summary-table-${header.id}`}
-                  >
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext()
-                    )}
-                  </th>
-                ))}
-              </tr>
+        {filteredLtftSummaries.length > 0 ? (
+          <>
+            {statusFilters.map(status => (
+              <CheckboxField
+                key={status}
+                data-cy={`filter${status}Ltft`}
+                name={`yesToShow${status}`}
+                value="yes"
+                label={status}
+                checked={visibleStatuses[status]}
+                onChange={() => toggleStatus(status)}
+              />
             ))}
-          </thead>
-          <tbody>
-            {table.getRowModel().rows.map(row => {
-              return (
-                <tr
-                  className="table-row"
-                  onClick={() => history.push(`/ltft/${row.original.id}`)}
-                  key={row.id}
-                  data-cy={`ltft-row-${row.id}`}
-                >
-                  {row.getVisibleCells().map(cell => (
-                    <td key={cell.id} data-cy={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </td>
-                  ))}
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+            <table data-cy="ltft-summary-table">
+              <thead>
+                {table.getHeaderGroups().map(headerGroup => (
+                  <tr key={headerGroup.id}>
+                    {headerGroup.headers.map(header => (
+                      <th
+                        key={header.id}
+                        data-cy={`ltft-summary-table-${header.id}`}
+                      >
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                      </th>
+                    ))}
+                  </tr>
+                ))}
+              </thead>
+              <tbody>
+                {table.getRowModel().rows.map(row => {
+                  return (
+                    <tr
+                      className="table-row"
+                      onClick={() => handleClick(row.original.id)}
+                      key={row.id}
+                      data-cy={`ltft-row-${row.id}`}
+                    >
+                      {row.getVisibleCells().map(cell => (
+                        <td key={cell.id} data-cy={cell.id}>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext()
+                          )}
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </>
+        ) : (
+          <p data-cy="no-saved-drafts">
+            You have no {ltftSummaryType.toLowerCase()} applications.
+          </p>
+        )}
       </div>
     );
   return content;

--- a/cypress/component/forms/ltft/LtftHome.cy.tsx
+++ b/cypress/component/forms/ltft/LtftHome.cy.tsx
@@ -3,12 +3,9 @@ import { MemoryRouter } from "react-router-dom";
 import { mount } from "cypress/react18";
 import store from "../../../../redux/store/store";
 import { LtftHome } from "../../../../components/forms/ltft/LtftHome";
-import { updatedLtftSummaryList } from "../../../../redux/slices/ltftSummaryListSlice";
-import { mockLtftsList1 } from "../../../../mock-data/mock-ltft-data";
-import * as hooks from "../../../../utilities/hooks/useIsBetaTester";
 
-describe("LtftHome - new application", () => {
-  it("renders the LtftHome component with 'new application' tracker", () => {
+describe("LtftHome", () => {
+  it("renders the LtftHome component", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/ltft"]}>
@@ -16,34 +13,16 @@ describe("LtftHome - new application", () => {
         </MemoryRouter>
       </Provider>
     );
-    cy.get('[data-cy="ltft-tracker-header"]')
+    cy.get('[data-cy="ltft-current-summary-header"]')
       .should("exist")
-      .contains("New application");
-    cy.get('[data-cy="ltft-summary-header"]')
-      .should("exist")
-      .contains("Previous applications summary");
-    cy.get('[data-cy="choose-cct-btn"]')
+      .contains("In progress application");
+    cy.get('[data-cy="cct-link"]')
       .should("exist")
       .contains(
-        "Choose a CCT Calculation to begin your Changing hours (LTFT) application"
+        "Choose a CCT Calculation to begin a new Changing hours (LTFT) application"
       );
-    cy.get('[data-cy="ltft-startover-btn"]').should("not.exist");
-  });
-
-  it("renders the LtftHome component with 'draft' tracker", () => {
-    store.dispatch(updatedLtftSummaryList(mockLtftsList1));
-    cy.stub(hooks, "default").returns(true);
-    mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/ltft"]}>
-          <LtftHome />
-        </MemoryRouter>
-      </Provider>
-    );
-    cy.get('[data-cy="ltft-tracker-header"]').contains(
-      "In progress application"
-    );
-    cy.get('[data-cy="continue-application-button"]').should("exist");
-    cy.get('[data-cy="startOverButton"]').should("exist");
+    cy.get('[data-cy="ltft-previous-summary-header"]')
+      .should("exist")
+      .contains("Previous applications summary");
   });
 });

--- a/cypress/component/forms/ltft/LtftSummary.cy.tsx
+++ b/cypress/component/forms/ltft/LtftSummary.cy.tsx
@@ -1,17 +1,112 @@
 import React from "react";
 import { mount } from "cypress/react18";
 import LtftSummary from "../../../../components/forms/ltft/LtftSummary";
-import { mockLtftsList1 } from "../../../../mock-data/mock-ltft-data";
+import {
+  mockLtftDraftList,
+  mockLtftsList1
+} from "../../../../mock-data/mock-ltft-data";
 import { Provider } from "react-redux";
 import store from "../../../../redux/store/store";
 import { MemoryRouter } from "react-router-dom";
 
-describe("LtftSummary Component", () => {
+describe("LtftSummary Component - CURRENT summary", () => {
   beforeEach(() => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/ltft"]}>
           <LtftSummary
+            ltftSummaryType={"CURRENT"}
+            ltftSummaryStatus={"succeeded"}
+            ltftSummaryList={mockLtftDraftList}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+  });
+
+  it("should render the table", () => {
+    cy.get("[data-cy=ltft-summary-table]").should("exist");
+  });
+
+  it("should display correct table headers", () => {
+    cy.get("thead tr").within(() => {
+      cy.contains("Name").should("exist");
+      cy.contains("Created").should("exist");
+      cy.contains("Last modified").should("exist");
+      cy.contains("Status").should("exist");
+    });
+  });
+
+  it("should only show DRAFT and UNSUBMITTED status filters", () => {
+    cy.get('[data-cy="filterDRAFTLtft"]').should("exist");
+    cy.get('[data-cy="filterUNSUBMITTEDLtft"]').should("exist");
+    cy.get('[data-cy="filterAPPROVEDLtft"]').should("not.exist");
+    cy.get('[data-cy="filterSUBMITTEDLtft"]').should("not.exist");
+    cy.get('[data-cy="filterWITHDRAWNLtft"]').should("not.exist");
+  });
+
+  ["DRAFT", "UNSUBMITTED"].forEach(status => {
+    it(`should filter out ${status} ltft`, () => {
+      cy.get(`[data-cy="filter${status}Ltft"]`).should("be.checked");
+      cy.get(`[data-cy="filter${status}Ltft"]`).click();
+      cy.get('[data-cy="ltft-summary-table"]')
+        .contains(status)
+        .should("not.exist");
+    });
+  });
+
+  it("should navigate to correct URL when a row is clicked", () => {
+    cy.get("[data-cy=ltft-summary-table] tbody tr").first().click();
+    cy.url().should("include", "/ltft/create");
+  });
+
+  it("should show Delete button for DRAFT status", () => {
+    cy.get('[data-cy="ltft-summary-table"]')
+      .contains("DRAFT")
+      .parent()
+      .parent()
+      .find('[data-cy="deleteLtftBtnLink"]')
+      .should("exist");
+  });
+
+  it("should show Withdraw button for UNSUBMITTED status", () => {
+    cy.get('[data-cy="ltft-summary-table"]')
+      .contains("UNSUBMITTED")
+      .parent()
+      .parent()
+      .find('[data-cy="withdrawLtftBtnLink"]')
+      .should("exist");
+  });
+});
+
+describe("LtftSummary Component - no CURRENT application", () => {
+  beforeEach(() => {
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/ltft"]}>
+          <LtftSummary
+            ltftSummaryType={"CURRENT"}
+            ltftSummaryStatus={"succeeded"}
+            ltftSummaryList={[]}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+  });
+
+  it("should not render the table", () => {
+    cy.get("[data-cy=ltft-summary-table]").should("not.exist");
+    cy.contains("You have no current applications.").should("exist");
+  });
+});
+
+describe("LtftSummary Component - PREVIOUS summary", () => {
+  beforeEach(() => {
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/ltft"]}>
+          <LtftSummary
+            ltftSummaryType={"PREVIOUS"}
             ltftSummaryStatus={"succeeded"}
             ltftSummaryList={mockLtftsList1}
           />
@@ -33,6 +128,14 @@ describe("LtftSummary Component", () => {
     });
   });
 
+  it("should only show APPROVED, SUBMITTED, and WITHDRAWN status filters", () => {
+    cy.get('[data-cy="filterAPPROVEDLtft"]').should("exist");
+    cy.get('[data-cy="filterSUBMITTEDLtft"]').should("exist");
+    cy.get('[data-cy="filterWITHDRAWNLtft"]').should("exist");
+    cy.get('[data-cy="filterDRAFTLtft"]').should("not.exist");
+    cy.get('[data-cy="filterUNSUBMITTEDLtft"]').should("not.exist");
+  });
+
   ["APPROVED", "SUBMITTED", "WITHDRAWN"].forEach(status => {
     it(`should filter out ${status} ltft`, () => {
       cy.get(`[data-cy="filter${status}Ltft"]`).click();
@@ -45,5 +148,37 @@ describe("LtftSummary Component", () => {
   it("should navigate to correct URL when a row is clicked", () => {
     cy.get("[data-cy=ltft-summary-table] tbody tr").first().click();
     cy.url().should("include", "/ltft/123e4567-e89b-12d3-a456-426614174000");
+  });
+
+  it("should show Unsubmit and Withdraw buttons for SUBMITTED status", () => {
+    cy.get('[data-cy="ltft-summary-table"]')
+      .contains("SUBMITTED")
+      .parent()
+      .parent()
+      .within(() => {
+        cy.get('[data-cy="unsubmitLtftBtnLink"]').should("exist");
+        cy.get('[data-cy="withdrawLtftBtnLink"]').should("exist");
+      });
+  });
+});
+
+describe("LtftSummary Component - no PREVIOUS application", () => {
+  beforeEach(() => {
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/ltft"]}>
+          <LtftSummary
+            ltftSummaryType={"PREVIOUS"}
+            ltftSummaryStatus={"succeeded"}
+            ltftSummaryList={[]}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+  });
+
+  it("should not render the table", () => {
+    cy.get("[data-cy=ltft-summary-table]").should("not.exist");
+    cy.contains("You have no previous applications.").should("exist");
   });
 });

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -1,6 +1,6 @@
 import { LtftObj } from "../redux/slices/ltftSlice";
 
-export const mockLtftsList1 = [
+export const mockLtftDraftList = [
   {
     id: "fc13458c-5b0b-442f-8907-6f9af8fc0ffb",
     name: "GP hours reduction",
@@ -9,6 +9,34 @@ export const mockLtftsList1 = [
     created: "2025-01-1T14:50:36.941Z",
     lastModified: "2025-01-15T15:50:36.941Z"
   },
+  {
+    id: "123e4567-e89b-12d3-a456-426614174000",
+    name: "Programme hours reduction 1",
+    programmeMembershipId: "2861fb68-6c08-4af5-a3a1-6f561a37b407",
+    status: "DRAFT",
+    created: "2024-12-15T14:50:36.941Z",
+    lastModified: "2024-12-15T15:50:36.941Z"
+  },
+  {
+    id: "123e4567-e89b-12d3-a456-426614174001",
+    name: "Programme hours reduction 2",
+    programmeMembershipId: "2861fb68-6c08-4af5-a3a1-6f561a37b406",
+    status: "UNSUBMITTED",
+    created: "2024-10-15T14:50:36.941Z",
+    lastModified: "2024-10-15T15:50:36.941Z"
+  },
+  ,
+  {
+    id: "123e4567-e89b-12d3-a456-426614174002",
+    name: "Programme hours reduction 5",
+    programmeMembershipId: "2861fb68-6c08-4af5-a3a1-6f561a37b406",
+    status: "UNSUBMITTED",
+    created: "2024-08-15T14:50:36.941Z",
+    lastModified: "2024-08-15T15:50:36.941Z"
+  }
+];
+
+export const mockLtftsList1 = [
   {
     id: "123e4567-e89b-12d3-a456-426614174000",
     name: "Programme hours reduction 1",


### PR DESCRIPTION
Add the Draft/Unsubmitted LTFT summary table on the LTFT homepage
- row click to the form edit page for the specific form
- a link to the CCT homepage for new application
- `Delete` button for DRAFT applications and `Withdraw` button for UNSUBMITTED applications (click event not implemented yet)
- "You have no <type> applications" message on CURRENT or PREVIOUS table if no application for the trainee

![image](https://github.com/user-attachments/assets/64836657-86ac-4767-81d0-542098f09d17)
