### PR TITLE
fix: maxLength on TextArea

### DIFF
--- a/components/common/ActionModal.tsx
+++ b/components/common/ActionModal.tsx
@@ -72,8 +72,6 @@ export function ActionModal({
                     placeholder="Enter details here..."
                     width="300px"
                     rows={3}
-                    showCharCount
-                    maxLength={512}
                   />
                 </>
               )}

--- a/components/forms/TextInputField.tsx
+++ b/components/forms/TextInputField.tsx
@@ -27,13 +27,19 @@ interface Props {
 const TextInputField: FunctionComponent<Props> = props => {
   const [field, { error }] = useField(props);
   const FormElement = props.rows ? Textarea : Input;
-  const maxChars = props.maxLength ?? (props.isNumberField ? 4 : 4096);
+  const maxChars = props.maxLength ?? (props.isNumberField ? 4 : 1000);
   const charsRemaining = maxChars - (field.value?.length || 0);
   const setFieldWidth = (valueLength: number | undefined) => {
     return valueLength && valueLength < 20 ? 20 : Math.floor(width / 10) * 10;
   };
-  const { hidelabel, isNumberField, width, isTotal, showCharCount, ...rest } =
-    props;
+  const {
+    hidelabel,
+    isNumberField,
+    width,
+    isTotal,
+    showCharCount = true,
+    ...rest
+  } = props;
   const setCorrectLabelClass = () => {
     if (error) {
       return "nhsuk-form-group nhsuk-form-group--error";

--- a/components/forms/form-builder/form-fields/TextArea.tsx
+++ b/components/forms/form-builder/form-fields/TextArea.tsx
@@ -13,6 +13,8 @@ type TextAreaProps = {
   arrayName?: string;
   rows?: number;
   dtoName?: string;
+  maxLength?: number;
+  showCharCount?: boolean;
 };
 
 export const TextArea: React.FC<TextAreaProps> = ({
@@ -24,9 +26,12 @@ export const TextArea: React.FC<TextAreaProps> = ({
   arrayIndex,
   arrayName,
   rows,
-  dtoName
+  dtoName,
+  maxLength = 1000,
+  showCharCount = true
 }: TextAreaProps) => {
   const { handleBlur, handleChange } = useFormContext();
+  const charsRemaining = maxLength - (value?.length || 0);
   return (
     <>
       <label className="nhsuk-label" htmlFor={name} data-cy={`${name}-label`}>
@@ -51,7 +56,16 @@ export const TextArea: React.FC<TextAreaProps> = ({
         placeholder={placeholder}
         rows={rows ?? 10}
         spellCheck={true}
+        maxLength={maxLength}
       />
+      {showCharCount && (
+        <span
+          className="nhsuk-hint nhsuk-character-count__message"
+          data-cy={`${name}-char-count`}
+        >
+          You have {charsRemaining} characters remaining
+        </span>
+      )}
       {fieldError && (
         <FieldErrorInline fieldError={fieldError} fieldName={name} />
       )}

--- a/components/forms/form-builder/form-fields/__test__/TextArea.test.tsx
+++ b/components/forms/form-builder/form-fields/__test__/TextArea.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { TextArea } from "../TextArea";
+
+// Mock the FormContext
+jest.mock("../../FormContext", () => ({
+  useFormContext: () => ({
+    handleBlur: jest.fn(),
+    handleChange: jest.fn()
+  })
+}));
+
+describe("TextArea Component", () => {
+  const defaultProps = {
+    name: "test-textarea",
+    label: "Test Label",
+    fieldError: "",
+    value: ""
+  };
+
+  test("renders textarea with default maxLength of 1000", () => {
+    render(<TextArea {...defaultProps} />);
+
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveAttribute("maxLength", "1000");
+    expect(
+      screen.getByText("You have 1000 characters remaining")
+    ).toBeInTheDocument();
+  });
+
+  test("applies custom maxLength when provided", () => {
+    render(<TextArea {...defaultProps} maxLength={500} />);
+
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveAttribute("maxLength", "500");
+    expect(
+      screen.getByText("You have 500 characters remaining")
+    ).toBeInTheDocument();
+  });
+
+  test("calculates remaining characters correctly", () => {
+    render(
+      <TextArea {...defaultProps} value="Hello, world!" maxLength={100} />
+    );
+    expect(
+      screen.getByText("You have 87 characters remaining")
+    ).toBeInTheDocument();
+  });
+
+  test("hides character count when showCharCount is false", () => {
+    render(<TextArea {...defaultProps} showCharCount={false} />);
+
+    expect(screen.queryByText(/characters remaining/)).not.toBeInTheDocument();
+  });
+
+  test("shows character count by default (showCharCount=true)", () => {
+    render(<TextArea {...defaultProps} />);
+
+    expect(screen.getByText(/characters remaining/)).toBeInTheDocument();
+  });
+
+  test("shows zero characters remaining when text equals maxLength", () => {
+    const exactLengthText = "A".repeat(50);
+    render(
+      <TextArea {...defaultProps} value={exactLengthText} maxLength={50} />
+    );
+
+    expect(
+      screen.getByText("You have 0 characters remaining")
+    ).toBeInTheDocument();
+  });
+});

--- a/cypress/component/forms/ltft/LtftHome.cy.tsx
+++ b/cypress/component/forms/ltft/LtftHome.cy.tsx
@@ -126,11 +126,11 @@ describe("LtftHome", () => {
           "Please provide any supplementary information if needed"
         );
         cy.get('[data-cy="message-char-count"]').contains(
-          "You have 512 characters remaining"
+          "You have 1000 characters remaining"
         );
         cy.get('[data-cy="message"]').type("Test unsubmit message");
         cy.get('[data-cy="message-char-count"]').contains(
-          "You have 491 characters remaining"
+          "You have 979 characters remaining"
         );
         cy.get('[data-cy="modal-cancel-btn"]')
           .last()

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -930,6 +930,14 @@ Cypress.Commands.add("checkAndFillSection9", () => {
   cy.get(".nhsuk-error-summary").should("not.exist");
 });
 
+Cypress.Commands.add(
+  "fillTextAreaToLimit",
+  (selector: string, char: string, limit: number) => {
+    const text = char.repeat(limit);
+    cy.get(selector).clear().type(text, { delay: 0 });
+  }
+);
+
 // ### SECTION 10: CHECK AND FILL
 Cypress.Commands.add("checkAndFillSection10", () => {
   cy.get(".nhsuk-fieldset__heading").contains("Form R (Part B)");
@@ -938,7 +946,22 @@ Cypress.Commands.add("checkAndFillSection10", () => {
     "Compliments"
   );
   cy.get(".nhsuk-card__heading").contains("Compliments (Not compulsory)");
-  cy.clearAndType('[data-cy="compliments-text-area-input"]', "temp compliment");
+  // Test text area maxLength limit
+  cy.fillTextAreaToLimit('[data-cy="compliments-text-area-input"]', "A", 1000);
+  cy.get('[data-cy="compliments-char-count"]').should(
+    "contain",
+    "You have 0 characters remaining"
+  );
+  cy.get('[data-cy="compliments-text-area-input"]').type("B");
+  cy.get('[data-cy="compliments-char-count"]').should(
+    "contain",
+    "You have 0 characters remaining"
+  );
+  cy.clearAndType('[data-cy="compliments-text-area-input"]', "Test compliment");
+  cy.get('[data-cy="compliments-char-count"]').should(
+    "contain",
+    "You have 985 characters remaining"
+  );
   cy.get(".nhsuk-error-summary").should("not.exist");
   cy.checkElement("BtnSaveDraft");
   cy.get('[data-cy="BtnShortcutToConfirm"]').should("not.exist");

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -54,6 +54,11 @@ declare global {
 
       testDataSourceLink(): Chainable<Element>;
       testData(dataToTest: any, index?: number): Chainable<Element>;
+      fillTextAreaToLimit(
+        selector: string,
+        char: string,
+        limit: number
+      ): Chainable<Element>;
     }
     interface Cypress {
       dayjs(): dayjs.Dayjs;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.116.0",
+  "version": "0.117.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.116.0",
+      "version": "0.117.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.116.0",
+  "version": "0.117.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",


### PR DESCRIPTION
Fix maxLength on FormBuilder `TextArea.tsx` and standalone `TextInput.tsx` comp to 1000 char default. The option is available to set individual maxLengths if required.

NO TICKET