### PR TITLE
Feat/allow CCT snapshot edit

### DIFF
--- a/components/forms/cct/CctCalcCreate.tsx
+++ b/components/forms/cct/CctCalcCreate.tsx
@@ -312,14 +312,7 @@ export function CctCalcCreate() {
                               <div>
                                 {values.changes.map((_, index: number) => (
                                   <Fragment key={index}>
-                                    <div
-                                      style={{
-                                        background: "#D8DDE0",
-                                        border: "solid grey 4px",
-                                        padding: "16px",
-                                        marginBottom: "16px"
-                                      }}
-                                    >
+                                    <div className="cct-calc-container">
                                       <Row>
                                         <Col width="one-quarter">
                                           <SelectInputField

--- a/components/forms/cct/CctCalcSummary.tsx
+++ b/components/forms/cct/CctCalcSummary.tsx
@@ -1,26 +1,14 @@
 import { useState } from "react";
-import {
-  Card,
-  SummaryList,
-  Button,
-  Row,
-  Col,
-  WarningCallout
-} from "nhsuk-react-components";
+import { Button, Row, Col } from "nhsuk-react-components";
 import history from "../../navigation/history";
-import dayjs from "dayjs";
 import { CctNameModal } from "./CctNameModal";
-import style from "../../Common.module.scss";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks/hooks";
 import { useSubmitting } from "../../../utilities/hooks/useSubmitting";
 import { handleCctSubmit } from "../../../utilities/CctUtilities";
 import { FormRUtilities } from "../../../utilities/FormRUtilities";
-import { CalcDetails } from "./CctCalcCreate";
 import ErrorPage from "../../common/ErrorPage";
-import {
-  CctCalculation,
-  updatedFormSaveStatus
-} from "../../../redux/slices/cctSlice";
+import { updatedFormSaveStatus } from "../../../redux/slices/cctSlice";
+import { CctCalcSummaryDetails } from "./CctCalcSummaryDetails";
 
 export function CctCalcSummary() {
   const dispatch = useAppDispatch();
@@ -97,106 +85,5 @@ export function CctCalcSummary() {
         viewedCalc={viewedCalc}
       />
     </>
-  );
-}
-
-export function CctCalcSummaryDetails({
-  viewedCalc
-}: Readonly<{ viewedCalc: CctCalculation }>) {
-  const { programmeMembership, cctDate, changes, name, created, lastModified } =
-    viewedCalc;
-
-  return (
-    <Card className="pdf-visible">
-      <WarningCallout>
-        <WarningCallout.Label data-cy="cct-calc-warning-label">
-          New completion date
-        </WarningCallout.Label>
-        <p data-cy="cct-calc-warning-text1">
-          Please note: the new completion date shown below is indicative and
-          does not take into account your full circumstances (e.g. Out of
-          Programme, Parental Leave).
-        </p>
-        <p data-cy="cct-calc-warning-text2">
-          Your formal completion date will be agreed at ARCP.
-        </p>
-      </WarningCallout>
-      <Card.Content>
-        <Card.Heading data-cy="cct-calc-summary-header">
-          CCT Calculation Summary
-        </Card.Heading>
-        <h3 className={style.panelSubHeader}>Linked Programme</h3>
-        <SummaryList noBorder>
-          <SummaryList.Row>
-            <SummaryList.Key>Programme name</SummaryList.Key>
-            <SummaryList.Value>{programmeMembership.name}</SummaryList.Value>
-          </SummaryList.Row>
-          <SummaryList.Row>
-            <SummaryList.Key>Start date</SummaryList.Key>
-            <SummaryList.Value>
-              {dayjs(programmeMembership.startDate).format("DD/MM/YYYY")}
-            </SummaryList.Value>
-          </SummaryList.Row>
-          <SummaryList.Row>
-            <SummaryList.Key>Completion date</SummaryList.Key>
-            <SummaryList.Value>
-              {dayjs(programmeMembership.endDate).format("DD/MM/YYYY")}
-            </SummaryList.Value>
-          </SummaryList.Row>
-        </SummaryList>
-        <h3 className={style.panelSubHeader}>Current WTE percentage</h3>
-        <SummaryList noBorder>
-          <SummaryList.Row>
-            <SummaryList.Key>WTE</SummaryList.Key>
-            <SummaryList.Value>
-              {programmeMembership.wte && programmeMembership.wte * 100}%
-            </SummaryList.Value>
-          </SummaryList.Row>
-        </SummaryList>
-        <h3 className={style.panelSubHeader}>Proposed changes</h3>
-        {changes.map((change, index) => (
-          <div key={index}>
-            <SummaryList noBorder>
-              <SummaryList.Row>
-                <SummaryList.Key>Change type</SummaryList.Key>
-                <SummaryList.Value>
-                  {change.type === "LTFT" && "Changing hours (LTFT)"}
-                </SummaryList.Value>
-              </SummaryList.Row>
-              <SummaryList.Row>
-                <SummaryList.Key>Change date</SummaryList.Key>
-                <SummaryList.Value>
-                  {dayjs(change.startDate).format("DD/MM/YYYY")}
-                </SummaryList.Value>
-              </SummaryList.Row>
-              <SummaryList.Row>
-                <SummaryList.Key>Proposed WTE</SummaryList.Key>
-                <SummaryList.Value data-cy="cct-view-new-wte">
-                  {change.wte && change.wte * 100}%
-                </SummaryList.Value>
-              </SummaryList.Row>
-            </SummaryList>
-          </div>
-        ))}
-        <SummaryList noBorder>
-          <SummaryList.Row>
-            <SummaryList.Key>New completion date</SummaryList.Key>
-            <SummaryList.Value
-              style={{ color: "green", fontWeight: "bold" }}
-              data-cy="saved-cct-date"
-            >
-              {cctDate && dayjs(cctDate).format("DD/MM/YYYY")}
-            </SummaryList.Value>
-          </SummaryList.Row>
-        </SummaryList>
-        {name && created && lastModified && (
-          <CalcDetails
-            created={created}
-            lastModified={lastModified}
-            name={name}
-          />
-        )}
-      </Card.Content>
-    </Card>
   );
 }

--- a/components/forms/cct/CctCalcSummaryDetails.tsx
+++ b/components/forms/cct/CctCalcSummaryDetails.tsx
@@ -160,8 +160,8 @@ export function CctCalcSummaryDetails({
                 <Row>
                   <Col width="full">
                     {ltftFormStatus === "UNSUBMITTED" && (
-                      <WarningCallout>
-                        <WarningCallout.Label>
+                      <WarningCallout data-cy="cct-recalc-warning-callout">
+                        <WarningCallout.Label data-cy="cct-recalc-warning-label">
                           Recalculating your New completion date
                         </WarningCallout.Label>
                         <p>
@@ -171,8 +171,8 @@ export function CctCalcSummaryDetails({
                           your <strong>New completion date</strong>.
                         </p>
                         <p>
-                          Please note: Any updated values are not saved until
-                          you 're-submit' the application (see below).
+                          {`Please note: Any updated values are not saved until
+                          you 're-submit' the application (see below).`}
                         </p>
                       </WarningCallout>
                     )}
@@ -205,7 +205,9 @@ export function CctCalcSummaryDetails({
                               hidelabel
                             />
                           ) : (
-                            <span>{displayValues.changeDate}</span>
+                            <span data-cy="changeDate-readonly">
+                              {displayValues.changeDate}
+                            </span>
                           )}
                         </SummaryList.Value>
                         {ltftFormStatus === "UNSUBMITTED" && (
@@ -215,6 +217,7 @@ export function CctCalcSummaryDetails({
                               size="small"
                               style={{ minWidth: "9em" }}
                               onClick={() => toggleEditMode("changeDate")}
+                              data-cy="edit-btn_date"
                             >
                               {editableFields.changeDate ? "Revert" : "Edit"}
                             </BtnAmplify>
@@ -246,7 +249,9 @@ export function CctCalcSummaryDetails({
                               </span>
                             </div>
                           ) : (
-                            <span>{displayValues.wte}</span>
+                            <span data-cy="wte-readonly">
+                              {displayValues.wte}
+                            </span>
                           )}
                         </SummaryList.Value>
                         {ltftFormStatus === "UNSUBMITTED" && (
@@ -256,6 +261,7 @@ export function CctCalcSummaryDetails({
                               size="small"
                               style={{ minWidth: "9em" }}
                               onClick={() => toggleEditMode("wte")}
+                              data-cy="edit-btn_wte"
                             >
                               {editableFields.wte ? "Revert" : "Edit"}
                             </BtnAmplify>

--- a/components/forms/cct/CctCalcSummaryDetails.tsx
+++ b/components/forms/cct/CctCalcSummaryDetails.tsx
@@ -1,0 +1,251 @@
+import { Card, SummaryList, WarningCallout } from "nhsuk-react-components";
+import { CctCalculation } from "../../../redux/slices/cctSlice";
+import { LtftFormStatus } from "../../../redux/slices/ltftSlice";
+import style from "../../Common.module.scss";
+import dayjs from "dayjs";
+import { Button as BtnAmplify } from "@aws-amplify/ui-react";
+import { CalcDetails } from "./CctCalcCreate";
+import { useState } from "react";
+import {
+  getStartDateValidationSchema,
+  getWteValidationSchema
+} from "./cctCalcValidationSchema";
+import { recalculateCctDate } from "../../../utilities/ltftUtilities";
+import { Formik, Form, FormikHelpers } from "formik";
+import * as Yup from "yup";
+import TextInputField from "../TextInputField";
+
+export function CctCalcSummaryDetails({
+  viewedCalc,
+  ltftFormStatus
+}: Readonly<{
+  viewedCalc: CctCalculation;
+  ltftFormStatus?: LtftFormStatus;
+}>) {
+  const { programmeMembership, cctDate, changes, name, created, lastModified } =
+    viewedCalc;
+
+  const hasChanges = changes.length > 0;
+  const initChangeDateValue = dayjs(changes[0].startDate);
+  const initWteValue = ((changes[0].wte as number) * 100).toString();
+
+  const [editableFields, setEditableFields] = useState({
+    changeDate: false,
+    wte: false
+  });
+
+  const [displayValues, setDisplayValues] = useState({
+    changeDate: hasChanges ? initChangeDateValue.format("DD/MM/YYYY") : "",
+    wte: hasChanges ? `${initWteValue}%` : ""
+  });
+
+  const isEditMode = editableFields.changeDate || editableFields.wte;
+
+  const toggleEditMode = (field: "changeDate" | "wte") => {
+    setEditableFields(prev => ({
+      ...prev,
+      [field]: !prev[field]
+    }));
+  };
+
+  const validationSchema = Yup.object().shape({
+    changeDate: getStartDateValidationSchema(programmeMembership),
+    wte: getWteValidationSchema(programmeMembership)
+  });
+
+  const handleSubmit = (
+    values: { changeDate: string; wte: string },
+    { setSubmitting }: FormikHelpers<{ changeDate: string; wte: string }>
+  ) => {
+    recalculateCctDate(
+      programmeMembership.endDate,
+      programmeMembership.wte as number,
+      values.changeDate,
+      values.wte
+    );
+    setDisplayValues({
+      changeDate: dayjs(values.changeDate).format("DD/MM/YYYY"),
+      wte: `${values.wte}%`
+    });
+    setEditableFields({
+      changeDate: false,
+      wte: false
+    });
+    setSubmitting(false);
+  };
+
+  return (
+    <Formik
+      initialValues={{
+        changeDate: hasChanges ? initChangeDateValue.format("YYYY-MM-DD") : "",
+        wte: hasChanges ? initWteValue : ""
+      }}
+      validationSchema={validationSchema}
+      onSubmit={handleSubmit}
+    >
+      {({ isValid }) => (
+        <Form>
+          <Card className="pdf-visible">
+            <WarningCallout>
+              <WarningCallout.Label data-cy="cct-calc-warning-label">
+                New completion date
+              </WarningCallout.Label>
+              <p data-cy="cct-calc-warning-text1">
+                Please note: the new completion date shown below is indicative
+                and does not take into account your full circumstances (e.g. Out
+                of Programme, Parental Leave).
+              </p>
+              <p data-cy="cct-calc-warning-text2">
+                Your formal completion date will be agreed at ARCP.
+              </p>
+            </WarningCallout>
+            <Card.Content>
+              <Card.Heading data-cy="cct-calc-summary-header">
+                CCT Calculation Summary
+              </Card.Heading>
+              <SummaryList noBorder>
+                <h3 className={style.panelSubHeader}>Linked Programme</h3>
+                <SummaryList.Row>
+                  <SummaryList.Key>Programme name</SummaryList.Key>
+                  <SummaryList.Value>
+                    {programmeMembership.name}
+                  </SummaryList.Value>
+                </SummaryList.Row>
+                <SummaryList.Row>
+                  <SummaryList.Key>Start date</SummaryList.Key>
+                  <SummaryList.Value>
+                    {dayjs(programmeMembership.startDate).format("DD/MM/YYYY")}
+                  </SummaryList.Value>
+                </SummaryList.Row>
+                <SummaryList.Row>
+                  <SummaryList.Key>Completion date</SummaryList.Key>
+                  <SummaryList.Value>
+                    {dayjs(programmeMembership.endDate).format("DD/MM/YYYY")}
+                  </SummaryList.Value>
+                </SummaryList.Row>
+                <h3 className={style.panelSubHeader}>Current WTE percentage</h3>
+                <SummaryList.Row>
+                  <SummaryList.Key>WTE</SummaryList.Key>
+                  <SummaryList.Value>
+                    {programmeMembership.wte && programmeMembership.wte * 100}%
+                  </SummaryList.Value>
+                </SummaryList.Row>
+                <h3 className={style.panelSubHeader}>Proposed changes</h3>
+
+                <SummaryList.Row>
+                  <SummaryList.Key>Change type</SummaryList.Key>
+                  <SummaryList.Value>
+                    {changes[0].type === "LTFT" && "Changing hours (LTFT)"}
+                  </SummaryList.Value>
+                </SummaryList.Row>
+                <SummaryList.Row>
+                  <SummaryList.Key>Change date</SummaryList.Key>
+                  <SummaryList.Value>
+                    {editableFields.changeDate ? (
+                      <TextInputField
+                        name="changeDate"
+                        label="Change date"
+                        type="date"
+                        data-cy="change-date-input"
+                        hidelabel
+                      />
+                    ) : (
+                      <span>{displayValues.changeDate}</span>
+                    )}
+                  </SummaryList.Value>
+                  {ltftFormStatus === "UNSUBMITTED" && (
+                    <SummaryList.Actions>
+                      <BtnAmplify
+                        type="button"
+                        size="small"
+                        style={{ minWidth: "9em" }}
+                        onClick={() => toggleEditMode("changeDate")}
+                      >
+                        {editableFields.changeDate ? "Revert" : "Edit"}
+                      </BtnAmplify>
+                    </SummaryList.Actions>
+                  )}
+                </SummaryList.Row>
+                <SummaryList.Row>
+                  <SummaryList.Key>Proposed WTE</SummaryList.Key>
+                  <SummaryList.Value data-cy="cct-view-new-wte">
+                    {editableFields.wte ? (
+                      <div style={{ display: "flex", alignItems: "center" }}>
+                        <TextInputField
+                          name="wte"
+                          label="Proposed WTE"
+                          width={2}
+                          data-cy="wte-input"
+                          hidelabel
+                        />
+                        <span
+                          style={{
+                            marginBottom: "auto",
+                            marginTop: "0.5rem",
+                            marginLeft: "0.25rem"
+                          }}
+                        >
+                          %
+                        </span>
+                      </div>
+                    ) : (
+                      <span>{displayValues.wte}</span>
+                    )}
+                  </SummaryList.Value>
+                  {ltftFormStatus === "UNSUBMITTED" && (
+                    <SummaryList.Actions>
+                      <BtnAmplify
+                        type="button"
+                        size="small"
+                        style={{ minWidth: "9em" }}
+                        onClick={() => toggleEditMode("wte")}
+                      >
+                        {editableFields.wte ? "Revert" : "Edit"}
+                      </BtnAmplify>
+                    </SummaryList.Actions>
+                  )}
+                </SummaryList.Row>
+
+                <SummaryList.Row>
+                  <SummaryList.Key>New completion date</SummaryList.Key>
+                  <SummaryList.Value
+                    style={{
+                      color: isEditMode ? "grey" : "teal",
+                      fontWeight: "bold"
+                    }}
+                    data-cy="saved-cct-date"
+                  >
+                    {cctDate && dayjs(cctDate).format("DD/MM/YYYY")}
+                  </SummaryList.Value>
+                  {ltftFormStatus === "UNSUBMITTED" && isEditMode && (
+                    <SummaryList.Actions>
+                      <BtnAmplify
+                        type="submit"
+                        data-cy="cct-recalculate-btn"
+                        style={{
+                          minWidth: "8em",
+                          backgroundColor: "teal",
+                          color: "white"
+                        }}
+                        isDisabled={!isValid}
+                      >
+                        Recalculate
+                      </BtnAmplify>
+                    </SummaryList.Actions>
+                  )}
+                </SummaryList.Row>
+              </SummaryList>
+              {name && created && lastModified && (
+                <CalcDetails
+                  created={created}
+                  lastModified={lastModified}
+                  name={name}
+                />
+              )}
+            </Card.Content>
+          </Card>
+        </Form>
+      )}
+    </Formik>
+  );
+}

--- a/components/forms/cct/CctCalcSummaryDetails.tsx
+++ b/components/forms/cct/CctCalcSummaryDetails.tsx
@@ -1,4 +1,11 @@
-import { Card, SummaryList, WarningCallout } from "nhsuk-react-components";
+import {
+  Card,
+  Col,
+  Container,
+  Row,
+  SummaryList,
+  WarningCallout
+} from "nhsuk-react-components";
 import { CctCalculation } from "../../../redux/slices/cctSlice";
 import { LtftFormStatus } from "../../../redux/slices/ltftSlice";
 import style from "../../Common.module.scss";
@@ -103,138 +110,191 @@ export function CctCalcSummaryDetails({
               <Card.Heading data-cy="cct-calc-summary-header">
                 CCT Calculation Summary
               </Card.Heading>
-              <SummaryList noBorder>
-                <h3 className={style.panelSubHeader}>Linked Programme</h3>
-                <SummaryList.Row>
-                  <SummaryList.Key>Programme name</SummaryList.Key>
-                  <SummaryList.Value>
-                    {programmeMembership.name}
-                  </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                  <SummaryList.Key>Start date</SummaryList.Key>
-                  <SummaryList.Value>
-                    {dayjs(programmeMembership.startDate).format("DD/MM/YYYY")}
-                  </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                  <SummaryList.Key>Completion date</SummaryList.Key>
-                  <SummaryList.Value>
-                    {dayjs(programmeMembership.endDate).format("DD/MM/YYYY")}
-                  </SummaryList.Value>
-                </SummaryList.Row>
-                <h3 className={style.panelSubHeader}>Current WTE percentage</h3>
-                <SummaryList.Row>
-                  <SummaryList.Key>WTE</SummaryList.Key>
-                  <SummaryList.Value>
-                    {programmeMembership.wte && programmeMembership.wte * 100}%
-                  </SummaryList.Value>
-                </SummaryList.Row>
-                <h3 className={style.panelSubHeader}>Proposed changes</h3>
-
-                <SummaryList.Row>
-                  <SummaryList.Key>Change type</SummaryList.Key>
-                  <SummaryList.Value>
-                    {changes[0].type === "LTFT" && "Changing hours (LTFT)"}
-                  </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                  <SummaryList.Key>Change date</SummaryList.Key>
-                  <SummaryList.Value>
-                    {editableFields.changeDate ? (
-                      <TextInputField
-                        name="changeDate"
-                        label="Change date"
-                        type="date"
-                        data-cy="change-date-input"
-                        hidelabel
-                      />
-                    ) : (
-                      <span>{displayValues.changeDate}</span>
-                    )}
-                  </SummaryList.Value>
-                  {ltftFormStatus === "UNSUBMITTED" && (
-                    <SummaryList.Actions>
-                      <BtnAmplify
-                        type="button"
-                        size="small"
-                        style={{ minWidth: "9em" }}
-                        onClick={() => toggleEditMode("changeDate")}
-                      >
-                        {editableFields.changeDate ? "Revert" : "Edit"}
-                      </BtnAmplify>
-                    </SummaryList.Actions>
-                  )}
-                </SummaryList.Row>
-                <SummaryList.Row>
-                  <SummaryList.Key>Proposed WTE</SummaryList.Key>
-                  <SummaryList.Value data-cy="cct-view-new-wte">
-                    {editableFields.wte ? (
-                      <div style={{ display: "flex", alignItems: "center" }}>
-                        <TextInputField
-                          name="wte"
-                          label="Proposed WTE"
-                          width={2}
-                          data-cy="wte-input"
-                          hidelabel
-                        />
-                        <span
-                          style={{
-                            marginBottom: "auto",
-                            marginTop: "0.5rem",
-                            marginLeft: "0.25rem"
-                          }}
-                        >
+              <Container>
+                <Row>
+                  <Col width="three-quarters">
+                    <SummaryList noBorder>
+                      <h3 className={style.panelSubHeader}>Linked Programme</h3>
+                      <SummaryList.Row>
+                        <SummaryList.Key>Programme name</SummaryList.Key>
+                        <SummaryList.Value>
+                          {programmeMembership.name}
+                        </SummaryList.Value>
+                      </SummaryList.Row>
+                      <SummaryList.Row>
+                        <SummaryList.Key>Start date</SummaryList.Key>
+                        <SummaryList.Value>
+                          {dayjs(programmeMembership.startDate).format(
+                            "DD/MM/YYYY"
+                          )}
+                        </SummaryList.Value>
+                      </SummaryList.Row>
+                      <SummaryList.Row>
+                        <SummaryList.Key>Completion date</SummaryList.Key>
+                        <SummaryList.Value>
+                          {dayjs(programmeMembership.endDate).format(
+                            "DD/MM/YYYY"
+                          )}
+                        </SummaryList.Value>
+                      </SummaryList.Row>
+                      <h3 className={style.panelSubHeader}>
+                        Current WTE percentage
+                      </h3>
+                      <SummaryList.Row>
+                        <SummaryList.Key>WTE</SummaryList.Key>
+                        <SummaryList.Value>
+                          {programmeMembership.wte &&
+                            programmeMembership.wte * 100}
                           %
-                        </span>
-                      </div>
-                    ) : (
-                      <span>{displayValues.wte}</span>
+                        </SummaryList.Value>
+                      </SummaryList.Row>
+                    </SummaryList>
+                  </Col>
+                </Row>
+              </Container>
+              <Container
+                className={
+                  ltftFormStatus === "UNSUBMITTED" ? "cct-calc-container" : ""
+                }
+              >
+                <Row>
+                  <Col width="full">
+                    {ltftFormStatus === "UNSUBMITTED" && (
+                      <WarningCallout>
+                        <WarningCallout.Label>
+                          Recalculating your New completion date
+                        </WarningCallout.Label>
+                        <p>
+                          If required, please edit the{" "}
+                          <strong>Change date</strong> and/or{" "}
+                          <strong>Proposed WTE</strong> values to recalculate
+                          your <strong>New completion date</strong>.
+                        </p>
+                        <p>
+                          Please note: Any updated values are not saved until
+                          you 're-submit' the application (see below).
+                        </p>
+                      </WarningCallout>
                     )}
-                  </SummaryList.Value>
-                  {ltftFormStatus === "UNSUBMITTED" && (
-                    <SummaryList.Actions>
-                      <BtnAmplify
-                        type="button"
-                        size="small"
-                        style={{ minWidth: "9em" }}
-                        onClick={() => toggleEditMode("wte")}
-                      >
-                        {editableFields.wte ? "Revert" : "Edit"}
-                      </BtnAmplify>
-                    </SummaryList.Actions>
-                  )}
-                </SummaryList.Row>
-
-                <SummaryList.Row>
-                  <SummaryList.Key>New completion date</SummaryList.Key>
-                  <SummaryList.Value
-                    style={{
-                      color: isEditMode ? "grey" : "teal",
-                      fontWeight: "bold"
-                    }}
-                    data-cy="saved-cct-date"
+                  </Col>
+                </Row>
+                <Row>
+                  <Col
+                    width={
+                      ltftFormStatus === "UNSUBMITTED" ? "two-thirds" : "full"
+                    }
                   >
-                    {cctDate && dayjs(cctDate).format("DD/MM/YYYY")}
-                  </SummaryList.Value>
-                  {ltftFormStatus === "UNSUBMITTED" && isEditMode && (
-                    <SummaryList.Actions>
-                      <BtnAmplify
-                        type="submit"
-                        data-cy="cct-recalculate-btn"
-                        style={{
-                          minWidth: "8em",
-                          backgroundColor: "teal",
-                          color: "white"
-                        }}
-                        isDisabled={!isValid}
-                      >
-                        Recalculate
-                      </BtnAmplify>
-                    </SummaryList.Actions>
-                  )}
-                </SummaryList.Row>
-              </SummaryList>
+                    <h3 className={style.panelSubHeader}>Proposed changes</h3>
+                    <SummaryList noBorder>
+                      <SummaryList.Row>
+                        <SummaryList.Key>Change type</SummaryList.Key>
+                        <SummaryList.Value>
+                          {changes[0].type === "LTFT" &&
+                            "Changing hours (LTFT)"}
+                        </SummaryList.Value>
+                      </SummaryList.Row>
+                      <SummaryList.Row>
+                        <SummaryList.Key>Change date</SummaryList.Key>
+                        <SummaryList.Value>
+                          {editableFields.changeDate ? (
+                            <TextInputField
+                              name="changeDate"
+                              label="Change date"
+                              type="date"
+                              data-cy="change-date-input"
+                              hidelabel
+                            />
+                          ) : (
+                            <span>{displayValues.changeDate}</span>
+                          )}
+                        </SummaryList.Value>
+                        {ltftFormStatus === "UNSUBMITTED" && (
+                          <SummaryList.Actions>
+                            <BtnAmplify
+                              type="button"
+                              size="small"
+                              style={{ minWidth: "9em" }}
+                              onClick={() => toggleEditMode("changeDate")}
+                            >
+                              {editableFields.changeDate ? "Revert" : "Edit"}
+                            </BtnAmplify>
+                          </SummaryList.Actions>
+                        )}
+                      </SummaryList.Row>
+                      <SummaryList.Row>
+                        <SummaryList.Key>Proposed WTE</SummaryList.Key>
+                        <SummaryList.Value data-cy="cct-view-new-wte">
+                          {editableFields.wte ? (
+                            <div
+                              style={{ display: "flex", alignItems: "center" }}
+                            >
+                              <TextInputField
+                                name="wte"
+                                label="Proposed WTE"
+                                width={2}
+                                data-cy="wte-input"
+                                hidelabel
+                              />
+                              <span
+                                style={{
+                                  marginBottom: "auto",
+                                  marginTop: "0.5rem",
+                                  marginLeft: "0.25rem"
+                                }}
+                              >
+                                %
+                              </span>
+                            </div>
+                          ) : (
+                            <span>{displayValues.wte}</span>
+                          )}
+                        </SummaryList.Value>
+                        {ltftFormStatus === "UNSUBMITTED" && (
+                          <SummaryList.Actions>
+                            <BtnAmplify
+                              type="button"
+                              size="small"
+                              style={{ minWidth: "9em" }}
+                              onClick={() => toggleEditMode("wte")}
+                            >
+                              {editableFields.wte ? "Revert" : "Edit"}
+                            </BtnAmplify>
+                          </SummaryList.Actions>
+                        )}
+                      </SummaryList.Row>
+                      <SummaryList.Row>
+                        <SummaryList.Key>New completion date</SummaryList.Key>
+                        <SummaryList.Value
+                          style={{
+                            color: isEditMode ? "grey" : "teal",
+                            fontWeight: "bold"
+                          }}
+                          data-cy="saved-cct-date"
+                        >
+                          {cctDate && dayjs(cctDate).format("DD/MM/YYYY")}
+                        </SummaryList.Value>
+                        {ltftFormStatus === "UNSUBMITTED" && isEditMode && (
+                          <SummaryList.Actions>
+                            <BtnAmplify
+                              type="submit"
+                              data-cy="cct-recalculate-btn"
+                              style={{
+                                minWidth: "8em",
+                                backgroundColor: "teal",
+                                color: "white"
+                              }}
+                              isDisabled={!isValid}
+                            >
+                              Recalculate
+                            </BtnAmplify>
+                          </SummaryList.Actions>
+                        )}
+                      </SummaryList.Row>
+                    </SummaryList>
+                  </Col>
+                </Row>
+              </Container>
+
               {name && created && lastModified && (
                 <CalcDetails
                   created={created}

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -115,9 +115,13 @@ export const LtftFormView = () => {
   if (ltftStatus === "succeeded" || canEditStatus)
     return (
       <LtftViewWrapper>
-        {!canEditStatus && (
+        {(!canEditStatus || ltftFormStatus === "UNSUBMITTED") && (
           <>
-            <h2>Submitted application</h2>
+            <h2>
+              {`${ltftFormStatus.charAt(0)}${ltftFormStatus
+                .slice(1)
+                .toLowerCase()} application`}
+            </h2>
             <SummaryList>
               <SummaryList.Row>
                 <SummaryList.Key>Name</SummaryList.Key>

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -117,7 +117,7 @@ export const LtftFormView = () => {
       <LtftViewWrapper>
         {(!canEditStatus || ltftFormStatus === "UNSUBMITTED") && (
           <>
-            <h2>
+            <h2 data-cy={`${ltftFormStatus}-header`}>
               {`${ltftFormStatus.charAt(0)}${ltftFormStatus
                 .slice(1)
                 .toLowerCase()} application`}

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -20,7 +20,7 @@ import {
   WarningCallout
 } from "nhsuk-react-components";
 import Declarations from "../form-builder/Declarations";
-import { CctCalcSummaryDetails } from "../cct/CctCalcSummary";
+import { CctCalcSummaryDetails } from "../cct/CctCalcSummaryDetails";
 import { StartOverButton } from "../StartOverButton";
 import { CctCalculation } from "../../../redux/slices/cctSlice";
 import { saveDraftForm } from "../../../utilities/FormBuilderUtilities";
@@ -34,6 +34,7 @@ import ErrorPage from "../../common/ErrorPage";
 import dayjs from "dayjs";
 import { ActionModal } from "../../common/ActionModal";
 import { useActionState } from "../../../utilities/hooks/useActionState";
+import ScrollToTop from "../../common/ScrollToTop";
 
 export const LtftFormView = () => {
   const dispatch = useAppDispatch();
@@ -58,6 +59,7 @@ export const LtftFormView = () => {
   const formJson = ltftJson as FormType;
   const [canSubmit, setCanSubmit] = useState(false);
   const [showModal, setShowModal] = useState(false);
+  const ltftFormStatus = formData?.status?.current?.state;
 
   const handleSubClick = async (values: { name: string }) => {
     setAction("Submit", "", formJson.name);
@@ -144,7 +146,10 @@ export const LtftFormView = () => {
             </SummaryList>
           </>
         )}
-        <CctCalcSummaryDetails viewedCalc={cctSnapshot} />
+        <CctCalcSummaryDetails
+          viewedCalc={cctSnapshot}
+          ltftFormStatus={ltftFormStatus}
+        />
         <FormViewBuilder
           jsonForm={formJson}
           formData={formData}
@@ -243,6 +248,7 @@ function LtftViewWrapper({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <>
+      <ScrollToTop />
       <BackLink
         className="back-link"
         data-cy="backLink-to-ltft-home"

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -80,11 +80,15 @@ const LtftSummary = ({
     }));
   };
 
-  const handleClick = (id: string) => {
+  const handleClick = (rowOb: LtftSummaryObj) => {
     if (ltftSummaryType === "CURRENT") {
-      loadTheSavedForm("/ltft", id ?? "", history);
+      loadTheSavedForm(
+        rowOb.status === "UNSUBMITTED" ? "/ltft/confirm" : "/ltft",
+        rowOb.id ?? "",
+        history
+      );
     } else if (ltftSummaryType === "PREVIOUS") {
-      history.push(`/ltft/${id}`);
+      history.push(`/ltft/${rowOb.id}`);
     }
   };
 
@@ -372,7 +376,7 @@ const LtftSummary = ({
                     return (
                       <tr
                         className="table-row"
-                        onClick={() => handleClick(row.original.id)}
+                        onClick={() => handleClick(row.original)}
                         key={row.id}
                         data-cy={`ltft-row-${row.id}`}
                       >

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -92,7 +92,7 @@ const LtftSummary = ({
 
   const renderNameHeader = ({
     column
-  }: HeaderContext<LtftSummaryObj, string>) => (
+  }: HeaderContext<LtftSummaryObj, unknown>) => (
     <TableColumnHeader
       column={column}
       title="Name"
@@ -101,7 +101,7 @@ const LtftSummary = ({
   );
   const renderCreatedHeader = ({
     column
-  }: HeaderContext<LtftSummaryObj, string>) => (
+  }: HeaderContext<LtftSummaryObj, unknown>) => (
     <TableColumnHeader
       column={column}
       title="Created"
@@ -110,7 +110,7 @@ const LtftSummary = ({
   );
   const renderLastModifiedHeader = ({
     column
-  }: HeaderContext<LtftSummaryObj, string>) => (
+  }: HeaderContext<LtftSummaryObj, unknown>) => (
     <TableColumnHeader
       column={column}
       title="Updated"
@@ -119,7 +119,7 @@ const LtftSummary = ({
   );
   const renderFormRefHeader = ({
     column
-  }: HeaderContext<LtftSummaryObj, string>) => (
+  }: HeaderContext<LtftSummaryObj, unknown>) => (
     <TableColumnHeader
       column={column}
       title="Reference"
@@ -128,7 +128,7 @@ const LtftSummary = ({
   );
   const renderStatusHeader = ({
     column
-  }: HeaderContext<LtftSummaryObj, string>) => (
+  }: HeaderContext<LtftSummaryObj, unknown>) => (
     <TableColumnHeader
       column={column}
       title="Status"
@@ -137,7 +137,7 @@ const LtftSummary = ({
   );
   const renderReasonHeader = ({
     column
-  }: HeaderContext<LtftSummaryObj, string>) => (
+  }: HeaderContext<LtftSummaryObj, unknown>) => (
     <TableColumnHeader
       column={column}
       title="Reason"

--- a/cypress/component/forms/ltft/LtftFormView.cy.tsx
+++ b/cypress/component/forms/ltft/LtftFormView.cy.tsx
@@ -123,6 +123,7 @@ describe("LTFT Form View - editable & saved name", () => {
 
   it("should render the saved name in the form", () => {
     cy.get("#ltftName").should("have.value", "My Programme - Hours Reduction");
+    cy.get('[data-cy="cct-recalc-warning-label"]').should("not.exist");
   });
 });
 
@@ -131,7 +132,81 @@ describe("LTFT Form View - unsubmitted", () => {
     mountLtftViewWithMockData(mockLtftUnsubmitted0);
   });
 
-  it("should render the correct buttons", () => {
+  it("should render the editable section and correct buttons", () => {
+    cy.get('[data-cy="UNSUBMITTED-header"]')
+      .should("exist")
+      .contains("Unsubmitted application");
+    cy.get('[data-cy="ltftName"]').contains("my Unsubmitted LTFT");
+    cy.get('[data-cy="ltftRef"]').contains("ltft_4_001");
+
+    // recalc section
+    cy.get('[data-cy="cct-recalc-warning-label"]').contains(
+      "Recalculating your New completion date"
+    );
+    cy.get('[data-cy="cct-recalc-warning-callout"] > p')
+      .first()
+      .should(
+        "include.text",
+        "If required, please edit the Change date and/or Proposed WTE"
+      );
+    cy.get('[data-cy="cct-recalc-warning-callout"] > p')
+      .last()
+      .should(
+        "include.text",
+        "Please note: Any updated values are not saved until"
+      );
+
+    // changeDate field edit
+    cy.get('[data-cy="changeDate-readonly"]').should(
+      "include.text",
+      "01/01/2027"
+    );
+    cy.get('[data-cy="cct-recalculate-btn"]').should("not.exist");
+    cy.get('[data-cy="edit-btn_date"]').should("include.text", "Edit").click();
+    cy.get('[data-cy="cct-recalculate-btn"]').should("exist");
+    cy.get('[data-cy="changeDate-readonly"]').should("not.exist");
+    cy.get('[data-cy="changeDate"]')
+      .should("exist")
+      .should("have.value", "2027-01-01");
+    cy.get('[data-cy="changeDate"]').type("2022-06-30");
+    cy.get("#changeDate--error-message")
+      .should("exist")
+      .should("include.text", "Change date cannot be before today");
+
+    // revert changeDate field
+    cy.get('[data-cy="edit-btn_date"]')
+      .should("include.text", "Revert")
+      .click();
+    cy.get("#changeDate--error-message").should("not.exist");
+    cy.get('[data-cy="changeDate"]').should("not.exist");
+    cy.get('[data-cy="changeDate-readonly"]')
+      .should("exist")
+      .should("include.text", "01/01/2027");
+
+    // edit changeDate again
+    cy.get('[data-cy="edit-btn_date"]').should("include.text", "Edit").click();
+    cy.get('[data-cy="changeDate-readonly"]').should("not.exist");
+    cy.get('[data-cy="changeDate"]')
+      .should("exist")
+      .should("have.value", "2022-06-30");
+    cy.get("#changeDate--error-message").should("exist");
+    cy.get('[data-cy="changeDate"]').type("2027-06-30");
+    cy.get("#changeDate--error-message").should("not.exist");
+
+    // Wte field edit
+    cy.get('[data-cy="wte-readonly"]').should("include.text", "80%");
+    cy.get('[data-cy="edit-btn_wte"]').should("include.text", "Edit").click();
+    cy.get('[data-cy="wte-readonly"]').should("not.exist");
+    cy.get('[data-cy="wte"]').clear().type("100");
+    cy.get("#wte--error-message")
+      .should("exist")
+      .should("include.text", "WTE values must be different");
+    cy.get('[data-cy="cct-recalculate-btn"]').should("be.disabled");
+    cy.get('[data-cy="wte"]').clear().type("60");
+    cy.get("#wte--error-message").should("not.exist");
+    cy.get('[data-cy="cct-recalculate-btn"]').should("not.be.disabled").click();
+    cy.get('[data-cy="saved-cct-date"]').should("include.text", "04/05/2028");
+
     cy.get('[data-cy="BtnSubmit"]').should("exist").contains("Re-submit");
     cy.get('[data-cy="BtnSaveDraft"]').should("exist");
     cy.get('[data-cy="startOverButton"]').should("not.exist");

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -170,6 +170,8 @@ export const mockLtftDraft1: LtftObj = {
 
 export const mockLtftUnsubmitted0: LtftObj = {
   traineeTisId: "4",
+  name: "my Unsubmitted LTFT",
+  formRef: "ltft_4_001",
   change: {
     calculationId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     cctDate: "2028-04-02",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.120.0",
+  "version": "0.121.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.120.0",
+      "version": "0.121.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.120.1",
+  "version": "0.121.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -947,6 +947,14 @@ ol[type="a"] {
   }
 }
 
+// cct proposed changes
+.cct-calc-container {
+  background: #d8dde0;
+  border: solid grey 4px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
 // Dialog component
 dialog {
   max-width: 50%;

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -74,10 +74,13 @@ export async function loadTheSavedForm(
     await store.dispatch(loadSavedFormA({ id, linkedFormRData }));
   } else if (pathName === "/formr-b") {
     await store.dispatch(loadSavedFormB({ id, linkedFormRData }));
-  } else if (pathName === "/ltft") {
+  } else if (pathName === "/ltft" || pathName === "/ltft/confirm") {
     await store.dispatch(loadSavedLtft(id));
   }
-  history.push(`${pathName}/create`);
+  if (pathName === "/ltft/confirm") {
+    store.dispatch(updatedCanEditLtft(true));
+    history.push(pathName);
+  } else history.push(`${pathName}/create`);
 }
 
 // This is used in FormBuilder to set the initial page value (needed because when reviewing/editing mutli-page form needs to take user to the correct page)

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -1,14 +1,16 @@
 import { ReasonMsgObj } from "../components/common/ActionModal";
 import { PersonalDetails } from "../models/PersonalDetails";
-import { CctCalculation } from "../redux/slices/cctSlice";
+import { CctCalculation, CctChangeType } from "../redux/slices/cctSlice";
 import {
   LtftCctChange,
   LtftObj,
   StatusInfo,
   unsubmitLtftForm,
+  updatedLtft,
   withdrawLtftForm
 } from "../redux/slices/ltftSlice";
 import store from "../redux/store/store";
+import { calcLtftChange } from "./CctUtilities";
 import { isFormDeleted } from "./FormBuilderUtilities";
 import { ActionState } from "./hooks/useActionState";
 import { ProfileSType } from "./ProfileUtilities";
@@ -334,3 +336,29 @@ export async function handleLtftSummaryModalSub(
   }
   return false;
 }
+
+export const recalculateCctDate = (
+  endDate: Date | string,
+  currentWte: number,
+  changeDateValue: string,
+  wteValue: string
+): void => {
+  const updatedCompletionDate = calcLtftChange(endDate, currentWte, {
+    type: "LTFT",
+    startDate: changeDateValue,
+    wte: Number(wteValue) / 100
+  } as CctChangeType);
+
+  const currentLtftData = store.getState().ltft.formData;
+  const updatedLtftData = {
+    ...currentLtftData,
+    change: {
+      ...currentLtftData.change,
+      startDate: changeDateValue,
+      wte: Number(wteValue) / 100,
+      cctDate: updatedCompletionDate
+    }
+  };
+
+  store.dispatch(updatedLtft(updatedLtftData));
+};


### PR DESCRIPTION
For `UNSUBMITTED` forms: 
1. allow CCT Calc snapshot editing (`changeDate` and Proposed `WTE`) and recalculation of the `cctDate` in FormView.
2. Direct users straight to FormView via summary table click so they can view/edit CCT etc. without having to navigate through the main form first.

[TIS21-7186](https://hee-tis.atlassian.net/browse/TIS21-7186)