### PR TITLE
feat: add status details in Form View

### DIFF
--- a/components/forms/ltft/LtftForm.tsx
+++ b/components/forms/ltft/LtftForm.tsx
@@ -4,6 +4,7 @@ import ErrorPage from "../../common/ErrorPage";
 import FormBuilder, { Form, FormName } from "../form-builder/FormBuilder";
 import { FormProvider } from "../form-builder/FormContext";
 import ltftJson from "./ltft.json";
+import { LtftStatusDetails } from "./LtftStatusDetails";
 import { ltftValidationSchema } from "./ltftValidationSchema";
 
 export function LtftForm() {
@@ -49,6 +50,7 @@ export function LtftForm() {
   return formData?.declarations?.discussedWithTpd ? (
     <div>
       <h2>Main application form</h2>
+      <LtftStatusDetails {...formData}></LtftStatusDetails>
       <FormProvider
         initialData={formData}
         initialPageFields={initialPageFields}

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -16,7 +16,6 @@ import {
   Col,
   Container,
   Row,
-  SummaryList,
   WarningCallout
 } from "nhsuk-react-components";
 import Declarations from "../form-builder/Declarations";
@@ -31,7 +30,6 @@ import { Form, Formik } from "formik";
 import history from "../../navigation/history";
 import Loading from "../../common/Loading";
 import ErrorPage from "../../common/ErrorPage";
-import dayjs from "dayjs";
 import { ActionModal } from "../../common/ActionModal";
 import { useActionState } from "../../../utilities/hooks/useActionState";
 import ScrollToTop from "../../common/ScrollToTop";

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -35,6 +35,7 @@ import dayjs from "dayjs";
 import { ActionModal } from "../../common/ActionModal";
 import { useActionState } from "../../../utilities/hooks/useActionState";
 import ScrollToTop from "../../common/ScrollToTop";
+import { LtftStatusDetails } from "./LtftStatusDetails";
 
 export const LtftFormView = () => {
   const dispatch = useAppDispatch();
@@ -115,41 +116,7 @@ export const LtftFormView = () => {
   if (ltftStatus === "succeeded" || canEditStatus)
     return (
       <LtftViewWrapper>
-        {(!canEditStatus || ltftFormStatus === "UNSUBMITTED") && (
-          <>
-            <h2 data-cy={`${ltftFormStatus}-header`}>
-              {`${ltftFormStatus.charAt(0)}${ltftFormStatus
-                .slice(1)
-                .toLowerCase()} application`}
-            </h2>
-            <SummaryList>
-              <SummaryList.Row>
-                <SummaryList.Key>Name</SummaryList.Key>
-                <SummaryList.Value data-cy="ltftName">
-                  {formData.name}
-                </SummaryList.Value>
-              </SummaryList.Row>
-              <SummaryList.Row>
-                <SummaryList.Key>Created</SummaryList.Key>
-                <SummaryList.Value data-cy="ltftCreated">
-                  {dayjs(formData.created).toString()}
-                </SummaryList.Value>
-              </SummaryList.Row>
-              <SummaryList.Row>
-                <SummaryList.Key>Submitted</SummaryList.Key>
-                <SummaryList.Value data-cy="ltftSubmitted">
-                  {dayjs(formData.lastModified).toString()}
-                </SummaryList.Value>
-              </SummaryList.Row>
-              <SummaryList.Row>
-                <SummaryList.Key>Reference</SummaryList.Key>
-                <SummaryList.Value data-cy="ltftRef">
-                  {formData.formRef}
-                </SummaryList.Value>
-              </SummaryList.Row>
-            </SummaryList>
-          </>
-        )}
+        <LtftStatusDetails {...formData}></LtftStatusDetails>
         <CctCalcSummaryDetails
           viewedCalc={cctSnapshot}
           ltftFormStatus={ltftFormStatus}

--- a/components/forms/ltft/LtftStatusDetails.tsx
+++ b/components/forms/ltft/LtftStatusDetails.tsx
@@ -1,0 +1,94 @@
+import { SummaryList } from "nhsuk-react-components";
+import { LtftObj } from "../../../redux/slices/ltftSlice";
+import dayjs from "dayjs";
+import { getStatusReasonLabel } from "../../../utilities/ltftUtilities";
+import { StringUtilities } from "../../../utilities/StringUtilities";
+
+export const LtftStatusDetails = (formData: LtftObj) => {
+  return (
+    <>
+      {formData.status?.current?.state != "DRAFT" && (
+        <>
+          <h3>
+            {StringUtilities.capitalize(formData.status?.current?.state)}{" "}
+            application
+          </h3>
+          <SummaryList>
+            <SummaryList.Row>
+              <SummaryList.Key>Name</SummaryList.Key>
+              <SummaryList.Value data-cy="ltftName">
+                {formData.name}
+              </SummaryList.Value>
+            </SummaryList.Row>
+            <SummaryList.Row>
+              <SummaryList.Key>Created</SummaryList.Key>
+              <SummaryList.Value data-cy="ltftCreated">
+                {dayjs(formData.created).toString()}
+              </SummaryList.Value>
+            </SummaryList.Row>
+            <SummaryList.Row>
+              <SummaryList.Key>
+                {StringUtilities.capitalize(formData.status?.current?.state)}
+              </SummaryList.Key>
+              <SummaryList.Value data-cy="ltftSubmitted">
+                {dayjs(formData.lastModified).toString()}
+              </SummaryList.Value>
+            </SummaryList.Row>
+            {(formData.status?.current?.state === "UNSUBMITTED" ||
+              formData.status?.current?.state === "WITHDRAWN") && (
+              <>
+                <SummaryList.Row>
+                  <SummaryList.Key>
+                    {StringUtilities.capitalize(
+                      formData.status?.current?.state
+                    )}{" "}
+                    by
+                  </SummaryList.Key>
+                  <SummaryList.Value data-cy="ltftRef">
+                    {formData.status.current.modifiedBy.role && (
+                      <>
+                        {StringUtilities.capitalize(
+                          formData.status.current.modifiedBy.role
+                        )}
+                        :{" "}
+                      </>
+                    )}
+                    {formData.status.current.modifiedBy.name && (
+                      <>{formData.status.current.modifiedBy.name}</>
+                    )}
+                    {formData.status.current.modifiedBy.email && (
+                      <> ({formData.status.current.modifiedBy.email})</>
+                    )}
+                  </SummaryList.Value>
+                </SummaryList.Row>
+                <SummaryList.Row>
+                  <SummaryList.Key>Reason</SummaryList.Key>
+                  <SummaryList.Value data-cy="ltftRef">
+                    {getStatusReasonLabel(
+                      formData.status?.current?.state,
+                      formData.status.current.detail.reason
+                    )}
+                  </SummaryList.Value>
+                </SummaryList.Row>
+                {formData.status.current.detail.message && (
+                  <SummaryList.Row>
+                    <SummaryList.Key>Message</SummaryList.Key>
+                    <SummaryList.Value data-cy="ltftRef">
+                      {formData.status.current.detail.message}
+                    </SummaryList.Value>
+                  </SummaryList.Row>
+                )}
+              </>
+            )}
+            <SummaryList.Row>
+              <SummaryList.Key>Reference</SummaryList.Key>
+              <SummaryList.Value data-cy="ltftRef">
+                {formData.formRef}
+              </SummaryList.Value>
+            </SummaryList.Row>
+          </SummaryList>
+        </>
+      )}
+    </>
+  );
+};

--- a/components/forms/ltft/LtftStatusDetails.tsx
+++ b/components/forms/ltft/LtftStatusDetails.tsx
@@ -7,9 +7,9 @@ import { StringUtilities } from "../../../utilities/StringUtilities";
 export const LtftStatusDetails = (formData: LtftObj) => {
   return (
     <>
-      {formData.status?.current?.state != "DRAFT" && (
+      {formData.status?.current?.state !== "DRAFT" && (
         <>
-          <h3>
+          <h3 data-cy={`${formData.status?.current?.state}-header`}>
             {StringUtilities.capitalize(formData.status?.current?.state)}{" "}
             application
           </h3>
@@ -30,7 +30,7 @@ export const LtftStatusDetails = (formData: LtftObj) => {
               <SummaryList.Key>
                 {StringUtilities.capitalize(formData.status?.current?.state)}
               </SummaryList.Key>
-              <SummaryList.Value data-cy="ltftSubmitted">
+              <SummaryList.Value data-cy="ltftModified">
                 {dayjs(formData.lastModified).toString()}
               </SummaryList.Value>
             </SummaryList.Row>
@@ -44,7 +44,7 @@ export const LtftStatusDetails = (formData: LtftObj) => {
                     )}{" "}
                     by
                   </SummaryList.Key>
-                  <SummaryList.Value data-cy="ltftRef">
+                  <SummaryList.Value data-cy="ltftModifiedBy">
                     {formData.status.current.modifiedBy.role && (
                       <>
                         {StringUtilities.capitalize(
@@ -63,7 +63,7 @@ export const LtftStatusDetails = (formData: LtftObj) => {
                 </SummaryList.Row>
                 <SummaryList.Row>
                   <SummaryList.Key>Reason</SummaryList.Key>
-                  <SummaryList.Value data-cy="ltftRef">
+                  <SummaryList.Value data-cy="ltfReason">
                     {getStatusReasonLabel(
                       formData.status?.current?.state,
                       formData.status.current.detail.reason
@@ -73,7 +73,7 @@ export const LtftStatusDetails = (formData: LtftObj) => {
                 {formData.status.current.detail.message && (
                   <SummaryList.Row>
                     <SummaryList.Key>Message</SummaryList.Key>
-                    <SummaryList.Value data-cy="ltftRef">
+                    <SummaryList.Value data-cy="ltftMessage">
                       {formData.status.current.detail.message}
                     </SummaryList.Value>
                   </SummaryList.Row>

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -36,7 +36,6 @@ import {
   getStatusReasonLabel,
   handleLtftSummaryModalSub
 } from "../../../utilities/ltftUtilities";
-import { ACTION_REASONS } from "../../../utilities/Constants";
 import { Label } from "nhsuk-react-components";
 import InfoTooltip from "../../common/InfoTooltip";
 

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -32,7 +32,10 @@ import {
 } from "../../common/ActionModal";
 import { useSubmitting } from "../../../utilities/hooks/useSubmitting";
 import { useActionState } from "../../../utilities/hooks/useActionState";
-import { handleLtftSummaryModalSub } from "../../../utilities/ltftUtilities";
+import {
+  getStatusReasonLabel,
+  handleLtftSummaryModalSub
+} from "../../../utilities/ltftUtilities";
 import { ACTION_REASONS } from "../../../utilities/Constants";
 import { Label } from "nhsuk-react-components";
 import InfoTooltip from "../../common/InfoTooltip";
@@ -186,23 +189,12 @@ const LtftSummary = ({
     };
     return (
       <>
-        {props.row.original.status === "UNSUBMITTED" &&
-        props.row.original.statusReason ? (
-          <>
-            {ACTION_REASONS.UNSUBMIT.find(
-              reason => reason.value === props.row.original.statusReason
-            )?.label ?? "Other reason"}
-          </>
-        ) : null}
-        {props.row.original.status === "WITHDRAWN" &&
-        props.row.original.statusReason ? (
-          <>
-            {ACTION_REASONS.WITHDRAW.find(
-              reason => reason.value === props.row.original.statusReason
-            )?.label ?? "Other reason"}
-          </>
-        ) : null}
-        {props.row.original.status === "UNSUBMITTED" &&
+        {getStatusReasonLabel(
+          props.row.original.status,
+          props.row.original.statusReason
+        )}
+        {(props.row.original.status === "UNSUBMITTED" ||
+          props.row.original.status === "WITHDRAWN") &&
         props.row.original.statusMessage ? (
           <Label size="s" onClick={handleTooltipClick}>
             <InfoTooltip

--- a/cypress/component/forms/ltft/LtftFormView.cy.tsx
+++ b/cypress/component/forms/ltft/LtftFormView.cy.tsx
@@ -56,14 +56,15 @@ describe("LTFT Form View - not editable", () => {
     cy.get('[data-cy="notGuaranteed"]')
       .should("be.checked")
       .should("have.attr", "readonly");
+    cy.get('[data-cy="supportingInformation-value"]').contains("Not provided");
     cy.get('[data-cy="BtnSubmit"]').should("not.exist");
     cy.get('[data-cy="BtnSaveDraft"]').should("not.exist");
     cy.get('[data-cy="startOverButton"]').should("not.exist");
-    cy.get('[data-cy="ltftName"]').contains("My Programme - Hours Reduction");
-    cy.get('[data-cy="ltftCreated"]').should("exist");
-    cy.get('[data-cy="ltftSubmitted"]').should("exist");
-    cy.get('[data-cy="ltftRef"]').contains("ltft_-1_001");
-    cy.get('[data-cy="supportingInformation-value"]').contains("Not provided");
+    // status details section should not exist in DRAFT
+    cy.get('[data-cy="ltftName"]').should("not.exist");
+    cy.get('[data-cy="ltftCreated"]').should("not.exist");
+    cy.get('[data-cy="ltftModified"]').should("not.exist");
+    cy.get('[data-cy="ltftRef"]').should("not.exist");
   });
 });
 
@@ -133,11 +134,20 @@ describe("LTFT Form View - unsubmitted", () => {
   });
 
   it("should render the editable section and correct buttons", () => {
+    // status details section
     cy.get('[data-cy="UNSUBMITTED-header"]')
       .should("exist")
       .contains("Unsubmitted application");
     cy.get('[data-cy="ltftName"]').contains("my Unsubmitted LTFT");
+    cy.get('[data-cy="ltftCreated"]').should("exist");
+    cy.get('[data-cy="ltftModified"]').should("exist");
+    cy.get('[data-cy="ltftModifiedBy"]').contains(
+      "Admin: Admin Name (admin@nhs.net)"
+    );
+    cy.get('[data-cy="ltfReason"]').contains("Change WTE percentage");
+    cy.get('[data-cy="ltftMessage"]').contains("status reason message");
     cy.get('[data-cy="ltftRef"]').contains("ltft_4_001");
+    cy.get('[data-cy="supportingInformation-value"]').contains("Not provided");
 
     // recalc section
     cy.get('[data-cy="cct-recalc-warning-label"]').contains(

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -215,13 +215,13 @@ export const mockLtftUnsubmitted0: LtftObj = {
     current: {
       state: "UNSUBMITTED",
       detail: {
-        reason: "",
-        message: ""
+        reason: "changePercentage",
+        message: "status reason message"
       },
       modifiedBy: {
-        name: "",
-        email: "",
-        role: ""
+        name: "Admin Name",
+        email: "admin@nhs.net",
+        role: "ADMIN"
       },
       timestamp: "",
       revision: 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.121.0",
+  "version": "0.121.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/StringUtilities.ts
+++ b/utilities/StringUtilities.ts
@@ -28,4 +28,9 @@ export class StringUtilities {
   public static truncateString(str: string, length: number) {
     return str.length > length ? `${str.substring(0, length)}...` : str;
   }
+
+  public static capitalize(str: string): string {
+    if (!str) return str;
+    return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+  }
 }

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -11,6 +11,7 @@ import {
 } from "../redux/slices/ltftSlice";
 import store from "../redux/store/store";
 import { calcLtftChange } from "./CctUtilities";
+import { ACTION_REASONS } from "./Constants";
 import { isFormDeleted } from "./FormBuilderUtilities";
 import { ActionState } from "./hooks/useActionState";
 import { ProfileSType } from "./ProfileUtilities";
@@ -362,3 +363,24 @@ export const recalculateCctDate = (
 
   store.dispatch(updatedLtft(updatedLtftData));
 };
+
+export function getStatusReasonLabel(
+  status: string,
+  statusReason: string
+): string {
+  if (status === "UNSUBMITTED" && statusReason) {
+    return (
+      ACTION_REASONS.UNSUBMIT.find(reason => reason.value === statusReason)
+        ?.label ?? "Other reason"
+    );
+  }
+
+  if (status === "WITHDRAWN" && statusReason) {
+    return (
+      ACTION_REASONS.WITHDRAW.find(reason => reason.value === statusReason)
+        ?.label ?? "Other reason"
+    );
+  }
+
+  return "";
+}


### PR DESCRIPTION
The Status Details section is added in the Form and FormView for any non-DRAFT applications.
- new component for the Status Details section
- the `modifiedBy`, `reason`, and `message` fiels will only displayed in UNSUBMITTED or WITHDRAWN applications when they are not empty
- `capitalize` function in stringUtilities
- `getStatusReasonLabel` function in ltftUtilities

SUBMITTED:
![image](https://github.com/user-attachments/assets/42e37c22-1cf2-42bf-8557-1570bb32462f)

UNSUBMITTED / WITHDRAWN:
![image](https://github.com/user-attachments/assets/45172de1-d6bc-47fe-a598-77d2852300bc)


TIS21-6706
TIS21-7145