### PR TITLE
Refactor/main service calls and state

### DIFF
--- a/components/common/Loading.tsx
+++ b/components/common/Loading.tsx
@@ -1,13 +1,36 @@
 import React from "react";
-import ReactLoading from "react-loading";
+import ReactLoading, { LoadingType } from "react-loading";
 
-export default function Loading() {
+type LoadingProps = {
+  color?: string;
+  height?: any;
+  width?: any;
+  delay?: number;
+  type?: LoadingType;
+  className?: string;
+};
+
+export default function Loading({
+  color = "#005eb8",
+  height = 100,
+  width = 100,
+  delay = 0,
+  type = "bubbles",
+  className = ""
+}: LoadingProps) {
+  const loadingType: LoadingType = type;
+
   return (
-    <ReactLoading
-      data-cy="loading"
-      type={"bars"}
-      color={"black"}
-      aria-label="loading-bars"
-    ></ReactLoading>
+    <div className={`loading ${className}`}>
+      <ReactLoading
+        data-cy="loading"
+        type={loadingType}
+        color={color}
+        height={height}
+        width={width}
+        delay={delay}
+        aria-label="loading-icon"
+      />
+    </div>
   );
 }

--- a/components/common/Loading.tsx
+++ b/components/common/Loading.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import ReactLoading, { LoadingType } from "react-loading";
 
-type LoadingProps = {
+type LoadingProps = Readonly<{
   color?: string;
   height?: any;
   width?: any;
   delay?: number;
   type?: LoadingType;
   className?: string;
-};
+}>;
 
 export default function Loading({
   color = "#005eb8",

--- a/components/forms/CreateList.tsx
+++ b/components/forms/CreateList.tsx
@@ -7,13 +7,13 @@ import {
   selectAllSubmittedforms,
   updatedFormsRefreshNeeded
 } from "../../redux/slices/formsSlice";
-import { fetchFeatureFlags } from "../../redux/slices/featureFlagsSlice";
 import FormsListBtn from "../../components/forms/FormsListBtn";
 import { useLocation } from "react-router-dom";
 import SubmittedFormsList from "../../components/forms/SubmittedFormsList";
 import { Col, Container, Row } from "nhsuk-react-components";
 import { StartOverButton } from "./StartOverButton";
 import { FormName } from "./form-builder/FormBuilder";
+import ErrorPage from "../common/ErrorPage";
 
 const CreateList = () => {
   const dispatch = useAppDispatch();
@@ -24,7 +24,7 @@ const CreateList = () => {
     ? submittedListDesc[0].submissionDate
     : null;
   const formRListStatus = useAppSelector(state => state.forms?.status);
-  const featFlagStatus = useAppSelector(state => state.featureFlags.status);
+
   const needFormsRefresh = useAppSelector(
     state => state.forms?.formsRefreshNeeded
   );
@@ -37,16 +37,13 @@ const CreateList = () => {
     dispatch(updatedFormsRefreshNeeded(false));
   }, [dispatch, pathname, needFormsRefresh]);
 
-  useEffect(() => {
-    dispatch(fetchFeatureFlags());
-  }, [dispatch]);
-
-  let content: JSX.Element = <></>;
-
-  if (formRListStatus === "loading" || featFlagStatus === "loading")
-    content = <Loading />;
-  if (formRListStatus === "succeeded" && featFlagStatus === "succeeded")
-    content = (
+  if (formRListStatus === "loading") return <Loading />;
+  if (formRListStatus === "failed")
+    return (
+      <ErrorPage message="There was a problem loading your saved forms. Please try reloading them by refreshing the page." />
+    );
+  if (formRListStatus === "succeeded")
+    return (
       <>
         <ScrollTo />
         <br />
@@ -73,7 +70,7 @@ const CreateList = () => {
         />
       </>
     );
-  return content;
+  return null;
 };
 
 export default CreateList;

--- a/components/main/GlobalAlert.tsx
+++ b/components/main/GlobalAlert.tsx
@@ -35,7 +35,7 @@ export const GlobalAlert = () => {
 
   const hasAlerts = Object.values(alerts).some(alert => alert.status);
 
-  if (isActionsAndAlertLoading) {
+  if (isActionsAndAlertLoading && preferredMfa !== "NOMFA") {
     return <Loading />;
   }
 
@@ -49,7 +49,7 @@ export const GlobalAlert = () => {
         {isActionsAndAlertError && preferredMfa !== "NOMFA" && (
           <>
             <p className="nhsuk-error-summary__title">
-              There was a problem loading any outstanding actions relating to
+              There was a problem loading any outstanding actions to confirm
               your Programmes and Placements. Please try again by refreshing the
               page.
             </p>

--- a/components/main/GlobalAlert.tsx
+++ b/components/main/GlobalAlert.tsx
@@ -36,7 +36,7 @@ export const GlobalAlert = () => {
   const hasAlerts = Object.values(alerts).some(alert => alert.status);
 
   if (isActionsAndAlertLoading && preferredMfa !== "NOMFA") {
-    return <Loading />;
+    return null;
   }
 
   return hasAlerts ? (
@@ -47,13 +47,10 @@ export const GlobalAlert = () => {
     >
       <div className="nhsuk-width-container">
         {isActionsAndAlertError && preferredMfa !== "NOMFA" && (
-          <>
-            <p className="nhsuk-error-summary__title">
-              There was a problem loading any outstanding actions to confirm
-              your Programmes and Placements. Please try again by refreshing the
-              page.
-            </p>
-          </>
+          <p className="nhsuk-error-summary__title">
+            There was a problem loading any outstanding actions to confirm your
+            Programmes and Placements. Please try again by refreshing the page.
+          </p>
         )}
         {alerts.actionSummary.status && alerts.actionSummary.component}
         {alerts.bookmark.status && alerts.bookmark.component}

--- a/components/main/GlobalAlert.tsx
+++ b/components/main/GlobalAlert.tsx
@@ -1,9 +1,7 @@
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import React from "react";
 import { useAppSelector } from "../../redux/hooks/hooks";
-import { useOutstandingActions } from "../../utilities/hooks/action-summary/useOutstandingActions";
-import { useInfoActions } from "../../utilities/hooks/action-summary/useInfoActions";
-import { useInProgressActions } from "../../utilities/hooks/action-summary/useInProgressActions";
+import { useActionsAndAlertsDataLoader } from "../../utilities/hooks/useActionsAndAlertDataLoader";
 import { Fieldset } from "nhsuk-react-components";
 import {
   faClock,
@@ -11,60 +9,35 @@ import {
   faExclamationTriangle
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useAlertStatusData } from "../../utilities/hooks/useAlertStatusData";
+import Loading from "../common/Loading";
 
-const GlobalAlert = () => {
-  // Don't show the Global alert if the user has not set their MFA
+export const GlobalAlert = () => {
+  const { isActionsAndAlertLoading, isActionsAndAlertError } =
+    useActionsAndAlertsDataLoader();
+
   const preferredMfa = useAppSelector(state => state.user.preferredMfa);
-  // BOOKMARK
   const showBookmarkAlert = useAppSelector(state => state.user.redirected);
-  // ACTION SUMMARY
-  const draftFormProps = !!useAppSelector(state => state.forms?.draftFormProps);
-  const { unsignedCojCount, programmeActions, placementActions } =
-    useOutstandingActions();
-  const unsignedCoJ = unsignedCojCount > 0;
-  const unreviewedProgramme = programmeActions.length > 0;
-  const unreviewedPlacement = placementActions.length > 0;
-  const { isInProgressFormA, isInProgressFormB } = useInProgressActions();
-  const inProgressFormR =
-    isInProgressFormA || isInProgressFormB || draftFormProps;
-  const { noSubFormRA, noSubFormRB, infoActionsA, infoActionsB } =
-    useInfoActions();
-  const importantInfo: boolean =
-    !!infoActionsA.isForInfoYearPlusSubForm ||
-    !!infoActionsB.isForInfoYearPlusSubForm ||
-    noSubFormRA ||
-    noSubFormRB;
 
-  const showActionsSummaryAlert =
-    (unsignedCoJ ||
-      inProgressFormR ||
-      draftFormProps ||
-      importantInfo ||
-      unreviewedProgramme ||
-      unreviewedPlacement) &&
-    preferredMfa !== "NOMFA";
+  const alertStatusData = useAlertStatusData();
+  const { showActionsSummaryAlert } = alertStatusData;
 
   const alerts = {
+    actionSummary: {
+      status: showActionsSummaryAlert && preferredMfa !== "NOMFA",
+      component: <ActionsSummaryAlert {...alertStatusData} />
+    },
     bookmark: {
       status: showBookmarkAlert,
       component: <BookmarkAlert />
-    },
-    outstandingActions: {
-      status: showActionsSummaryAlert,
-      component: (
-        <ActionsSummaryAlert
-          unsignedCoJ={unsignedCoJ}
-          inProgressFormR={inProgressFormR}
-          importantInfo={importantInfo}
-          unreviewedProgramme={unreviewedProgramme}
-          unreviewedPlacement={unreviewedPlacement}
-        />
-      )
     }
   };
 
   const hasAlerts = Object.values(alerts).some(alert => alert.status);
-  const { bookmark, outstandingActions } = alerts;
+
+  if (isActionsAndAlertLoading) {
+    return <Loading />;
+  }
 
   return hasAlerts ? (
     <aside
@@ -73,21 +46,21 @@ const GlobalAlert = () => {
       data-cy="globalAlert"
     >
       <div className="nhsuk-width-container">
-        {outstandingActions.status && (
-          <ActionsSummaryAlert
-            unsignedCoJ={unsignedCoJ}
-            inProgressFormR={inProgressFormR}
-            importantInfo={importantInfo}
-            unreviewedProgramme={unreviewedProgramme}
-            unreviewedPlacement={unreviewedPlacement}
-          />
+        {isActionsAndAlertError && preferredMfa !== "NOMFA" && (
+          <>
+            <p className="nhsuk-error-summary__title">
+              There was a problem loading any outstanding actions relating to
+              your Programmes and Placements. Please try again by refreshing the
+              page.
+            </p>
+          </>
         )}
-        {bookmark.status && <BookmarkAlert />}
+        {alerts.actionSummary.status && alerts.actionSummary.component}
+        {alerts.bookmark.status && alerts.bookmark.component}
       </div>
     </aside>
   ) : null;
 };
-export default GlobalAlert;
 
 function BookmarkAlert() {
   return (
@@ -122,39 +95,48 @@ function ActionsSummaryAlert({
   unreviewedProgramme,
   unreviewedPlacement
 }: Readonly<ActionsAlertProps>) {
-  const conditions = [
-    {
-      check: () =>
-        (unsignedCoJ || unreviewedProgramme || unreviewedPlacement) &&
-        !inProgressFormR,
-      body: (
+  const pathname = useLocation().pathname;
+  const isActionSummaryPage = pathname === "/action-summary";
+  const alertMessage = getActionAlertMessage(
+    unsignedCoJ,
+    inProgressFormR,
+    unreviewedProgramme,
+    unreviewedPlacement
+  );
+
+  return (
+    <div data-cy="actionsSummaryAlert">
+      {alertMessage.body && (
+        <span data-cy={alertMessage.cyTag}>{alertMessage.body}</span>
+      )}
+      {importantInfo && (
+        <span data-cy={"checkFormRSubs"}>
+          <p>
+            <FontAwesomeIcon icon={faInfoCircle} size="lg" color="#005eb8" />{" "}
+            Please review your Form R submissions.
+          </p>
+        </span>
+      )}
+      {isActionSummaryPage ? null : (
         <p>
-          <FontAwesomeIcon
-            icon={faExclamationTriangle}
-            size="lg"
-            color="#d5281b"
-          />
-          You have outstanding actions to complete.
+          <Link to="/action-summary">View action summary</Link> for details.
         </p>
-      ),
-      cyTag: "outstandingAction"
-    },
-    {
-      check: () =>
-        !(unsignedCoJ || unreviewedProgramme || unreviewedPlacement) &&
-        inProgressFormR,
-      body: (
-        <p>
-          <FontAwesomeIcon icon={faClock} size="lg" color="#E45245" /> You have
-          in progress actions to complete.
-        </p>
-      ),
-      cyTag: "inProgressFormR"
-    },
-    {
-      check: () =>
-        (unsignedCoJ || unreviewedProgramme || unreviewedPlacement) &&
-        inProgressFormR,
+      )}
+    </div>
+  );
+}
+
+function getActionAlertMessage(
+  unsignedCoJ: boolean,
+  inProgressFormR: boolean,
+  unreviewedProgramme: boolean,
+  unreviewedPlacement: boolean
+) {
+  const hasOutstandingActions =
+    unsignedCoJ || unreviewedProgramme || unreviewedPlacement;
+
+  if (hasOutstandingActions && inProgressFormR) {
+    return {
       body: (
         <p>
           <FontAwesomeIcon
@@ -166,27 +148,36 @@ function ActionsSummaryAlert({
         </p>
       ),
       cyTag: "unsignedCoJAndInProgressFormR"
-    }
-  ];
+    };
+  }
 
-  const { body, cyTag } = conditions.find(({ check }) => check()) ?? {
-    body: null
-  };
+  if (hasOutstandingActions) {
+    return {
+      body: (
+        <p>
+          <FontAwesomeIcon
+            icon={faExclamationTriangle}
+            size="lg"
+            color="#d5281b"
+          />
+          You have outstanding actions to complete.
+        </p>
+      ),
+      cyTag: "outstandingAction"
+    };
+  }
 
-  return (
-    <div data-cy="actionsSummaryAlert">
-      <span data-cy={cyTag}>{body}</span>
-      {importantInfo && (
-        <span data-cy={"checkFormRSubs"}>
-          <p>
-            <FontAwesomeIcon icon={faInfoCircle} size="lg" color="#005eb8" />{" "}
-            Please review your Form R submissions.
-          </p>
-        </span>
-      )}
-      <p>
-        See <Link to="/action-summary">Action Summary</Link> for details.
-      </p>
-    </div>
-  );
+  if (inProgressFormR) {
+    return {
+      body: (
+        <p>
+          <FontAwesomeIcon icon={faClock} size="lg" color="#E45245" /> You have
+          in progress actions to complete.
+        </p>
+      ),
+      cyTag: "inProgressFormR"
+    };
+  }
+
+  return { body: null, cyTag: null };
 }

--- a/components/main/Main.tsx
+++ b/components/main/Main.tsx
@@ -1,4 +1,4 @@
-import { Switch, Route, Redirect, useLocation } from "react-router-dom";
+import { Switch, Route, Redirect } from "react-router-dom";
 import Profile from "../profile/Profile";
 import FormRPartA from "../forms/form-builder/form-r/part-a/FormRPartA";
 import FormRPartB from "../forms/form-builder/form-r/part-b/FormRPartB";
@@ -13,7 +13,7 @@ import Home from "../home/Home";
 import { Placements } from "../placements/Placements";
 import { Programmes } from "../programmes/Programmes";
 import Breadcrumbs from "../breadcrumbs/Breadcrumbs";
-import GlobalAlert from "./GlobalAlert";
+import { GlobalAlert } from "./GlobalAlert";
 import CojView from "../forms/conditionOfJoining/CojView";
 import TSSHeader from "../navigation/TSSHeader";
 import packageJson from "../../package.json";
@@ -26,17 +26,14 @@ import useIsBetaTester from "../../utilities/hooks/useIsBetaTester";
 import { useRedirectHandler } from "../../utilities/hooks/useRedirectHandler";
 import { useCriticalDataLoader } from "../../utilities/hooks/useCriticalDataLoader";
 import ErrorPage from "../common/ErrorPage";
-import { useActionsAndAlertsDataLoader } from "../../utilities/hooks/useActionsAndAlertDataLoader";
 
 const appVersion = packageJson.version;
 
 export const Main = () => {
   const isBetaTester = useIsBetaTester();
-  const pathname = useLocation().pathname;
   const { isCriticalLoading, isCriticalSuccess, hasCriticalError } =
     useCriticalDataLoader();
   useRedirectHandler();
-  useActionsAndAlertsDataLoader();
 
   if (isCriticalLoading)
     return (
@@ -52,7 +49,7 @@ export const Main = () => {
   if (isCriticalSuccess)
     return (
       <ConfirmProvider>
-        {pathname !== "/action-summary" ? <GlobalAlert /> : null}
+        <GlobalAlert />
         <PageTitle />
         <TSSHeader />
         <Breadcrumbs />

--- a/components/main/__test__/GlobalAlert.test.tsx
+++ b/components/main/__test__/GlobalAlert.test.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { GlobalAlert } from "../GlobalAlert";
+import { BrowserRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+
+// Create mock hooks that return values we control
+let mockActionsData = {
+  isActionsAndAlertLoading: false,
+  isActionsAndAlertSuccess: true,
+  isActionsAndAlertError: false
+};
+
+let mockAlertData = {
+  unsignedCoJ: false,
+  inProgressFormR: false,
+  importantInfo: false,
+  unreviewedProgramme: false,
+  unreviewedPlacement: false,
+  showActionsSummaryAlert: false
+};
+
+// Mock the hooks
+jest.mock("../../../utilities/hooks/useActionsAndAlertDataLoader", () => ({
+  useActionsAndAlertsDataLoader: () => mockActionsData
+}));
+
+jest.mock("../../../utilities/hooks/useAlertStatusData", () => ({
+  useAlertStatusData: () => mockAlertData
+}));
+
+describe("GlobalAlert Error States", () => {
+  beforeEach(() => {
+    // Reset mocks to default values before each test
+    mockActionsData = {
+      isActionsAndAlertLoading: false,
+      isActionsAndAlertSuccess: true,
+      isActionsAndAlertError: false
+    };
+
+    mockAlertData = {
+      unsignedCoJ: false,
+      inProgressFormR: false,
+      importantInfo: false,
+      unreviewedProgramme: false,
+      unreviewedPlacement: false,
+      showActionsSummaryAlert: false
+    };
+  });
+
+  const renderWithStore = (customState = {}) => {
+    const defaultState = {
+      user: {
+        preferredMfa: "SMS",
+        redirected: false
+      }
+    };
+
+    const mergedState = {
+      ...defaultState,
+      ...customState
+    };
+
+    const store = configureStore({
+      reducer: () => mergedState
+    });
+
+    return render(
+      <Provider store={store}>
+        <BrowserRouter>
+          <GlobalAlert />
+        </BrowserRouter>
+      </Provider>
+    );
+  };
+
+  it("should display error message when isActionsAndAlertError is true and preferredMfa is not NOMFA", () => {
+    mockActionsData.isActionsAndAlertError = true;
+    mockAlertData.showActionsSummaryAlert = true;
+
+    renderWithStore();
+
+    expect(
+      screen.getByText(/There was a problem loading any outstanding actions/i)
+    ).toBeInTheDocument();
+  });
+
+  it("should not display error message when isActionsAndAlertError is false", () => {
+    renderWithStore();
+
+    expect(
+      screen.queryByText(/There was a problem loading any outstanding actions/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("should not display error message when isActionsAndAlertError is true but preferredMfa is NOMFA", () => {
+    mockActionsData.isActionsAndAlertError = true;
+
+    renderWithStore({
+      user: { preferredMfa: "NOMFA", redirected: false }
+    });
+
+    expect(
+      screen.queryByText(/There was a problem loading any outstanding actions/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render nothing when isActionsAndAlertLoading is true and preferredMfa is not NOMFA", () => {
+    mockActionsData.isActionsAndAlertLoading = true;
+
+    renderWithStore();
+
+    expect(document.body.textContent).toBe("");
+  });
+});

--- a/cypress/component/main/GlobalAlert.cy.tsx
+++ b/cypress/component/main/GlobalAlert.cy.tsx
@@ -1,7 +1,7 @@
 import { mount } from "cypress/react18";
 import { Provider } from "react-redux";
 import { Router } from "react-router-dom";
-import GlobalAlert from "../../../components/main/GlobalAlert";
+import { GlobalAlert } from "../../../components/main/GlobalAlert";
 import history from "../../../components/navigation/history";
 import {
   mockOutstandingActions,
@@ -25,31 +25,21 @@ import { updatedActionsData } from "../../../redux/slices/traineeActionsSlice";
 
 describe("GlobalAlert", () => {
   const mountComponent = (
-    redirected: boolean,
-    preferredMfa?: string,
-    formAList?: IFormR[],
-    formBList?: IFormR[],
-    unsignedCojs?: ProgrammeMembership[],
-    unreviewedActions?: TraineeAction[]
+    redirected: boolean = false,
+    preferredMfa: string = "NOMFA",
+    formAList: IFormR[] = [],
+    formBList: IFormR[] = [],
+    unsignedCojs: ProgrammeMembership[] = [],
+    unreviewedActions: TraineeAction[] = []
   ) => {
     const MockedGlobalAlert: React.FC = () => {
       const dispatch = useAppDispatch();
       dispatch(updatedRedirected(redirected));
-      if (preferredMfa) {
-        dispatch(updatedPreferredMfa(preferredMfa));
-      }
-      if (formAList) {
-        dispatch(updatedFormAList(formAList));
-      }
-      if (formBList) {
-        dispatch(updatedFormBList(formBList));
-      }
-      if (unsignedCojs) {
-        dispatch(updatedUnsignedCojs(unsignedCojs));
-      }
-      if (unreviewedActions) {
-        dispatch(updatedActionsData(unreviewedActions));
-      }
+      dispatch(updatedPreferredMfa(preferredMfa));
+      dispatch(updatedFormAList(formAList));
+      dispatch(updatedFormBList(formBList));
+      dispatch(updatedUnsignedCojs(unsignedCojs));
+      dispatch(updatedActionsData(unreviewedActions));
       return <GlobalAlert />;
     };
 
@@ -63,7 +53,7 @@ describe("GlobalAlert", () => {
   };
 
   it("should not render the Global Action Summary Alert if the user has not set their MFA", () => {
-    mountComponent(false);
+    mountComponent();
     cy.get("[data-cy=globalAlert]").should("not.exist");
     cy.get("[data-cy=actionsSummaryAlert]").should("not.exist");
     cy.get("[data-cy=bookmarkAlert]").should("not.exist");
@@ -93,7 +83,7 @@ describe("GlobalAlert", () => {
   });
 
   it("should render Global Bookmark alert (redirect is true) but no Action Summary (recent submitted Form R, no unsigned CoJ)", () => {
-    mountComponent(true, "SMS", [mockFormList[0]], [mockFormList[1]]);
+    mountComponent(true, "SMS", [mockFormList[0]], [mockFormList[1]], [], []);
     cy.get("[data-cy=globalAlert]").should("exist");
     cy.get("[data-cy=bookmarkAlert]").should("exist");
     cy.get("[data-cy=actionsSummaryAlert]").should("not.exist");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.121.0",
+  "version": "0.121.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.121.0",
+      "version": "0.121.2",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.121.1",
+  "version": "0.121.2",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/redux/slices/formBSlice.ts
+++ b/redux/slices/formBSlice.ts
@@ -10,7 +10,7 @@ import { toastErrText, toastSuccessText } from "../../utilities/Constants";
 import { ToastType, showToast } from "../../components/common/ToastMessage";
 import { SaveStatusProps } from "../../components/forms/AutosaveMessage";
 import { DateUtilities } from "../../utilities/DateUtilities";
-import store from "../store/store";
+import { RootState } from "../store/store";
 import { LinkedFormRDataType } from "../../components/forms/form-linker/FormLinkerForm";
 interface IFormB {
   formBList: IFormR[];
@@ -77,14 +77,17 @@ type ReturnedLoadSavedFormB = {
 
 export const loadSavedFormB = createAsyncThunk(
   "formB/fetchFormB",
-  async ({
-    id,
-    linkedFormRData
-  }: {
-    id: string;
-    linkedFormRData?: LinkedFormRDataType;
-  }): Promise<ReturnedLoadSavedFormB> => {
-    const state = store.getState();
+  async (
+    {
+      id,
+      linkedFormRData
+    }: {
+      id: string;
+      linkedFormRData?: LinkedFormRDataType;
+    },
+    { getState }
+  ): Promise<ReturnedLoadSavedFormB> => {
+    const state = getState() as RootState;
     const covidFlagStatus =
       state.featureFlags.featureFlags.formRPartB.covidDeclaration;
     const formsService = new FormsService();

--- a/utilities/ActionSummaryUtilities.ts
+++ b/utilities/ActionSummaryUtilities.ts
@@ -107,6 +107,9 @@ export function noSubmittedForms(formList: IFormR[]) {
 }
 
 function isAnyFormInProgress(formList: IFormR[]): boolean {
+  if (!formList || formList.length < 1) {
+    return false;
+  }
   return (
     formList.filter(
       form =>

--- a/utilities/hooks/useActionsAndAlertDataLoader.ts
+++ b/utilities/hooks/useActionsAndAlertDataLoader.ts
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
+import { loadFormAList } from "../../redux/slices/formASlice";
+import { loadFormBList } from "../../redux/slices/formBSlice";
+import { fetchTraineeActionsData } from "../../redux/slices/traineeActionsSlice";
+
+export const useActionsAndAlertsDataLoader = () => {
+  const dispatch = useAppDispatch();
+  const formAListStatus = useAppSelector(state => state.formA.status);
+  const formBListStatus = useAppSelector(state => state.formB.status);
+  const traineeActionsDataStatus = useAppSelector(
+    state => state.traineeActions.status
+  );
+
+  useEffect(() => {
+    if (formAListStatus === "idle") {
+      dispatch(loadFormAList());
+    }
+  }, [dispatch, formAListStatus]);
+
+  useEffect(() => {
+    if (formBListStatus === "idle") {
+      dispatch(loadFormBList());
+    }
+  }, [dispatch, formBListStatus]);
+
+  useEffect(() => {
+    if (traineeActionsDataStatus === "idle") {
+      dispatch(fetchTraineeActionsData());
+    }
+  }, [dispatch, traineeActionsDataStatus]);
+
+  // Determine overall loading state
+  const isActionsAndAlertLoading =
+    formAListStatus === "loading" ||
+    formBListStatus === "loading" ||
+    traineeActionsDataStatus === "loading";
+  // Determine if all non-critical data has loaded successfully
+  const isActionsAndAlertSuccess =
+    formAListStatus === "succeeded" &&
+    formBListStatus === "succeeded" &&
+    traineeActionsDataStatus === "succeeded";
+  // Check for any errors
+  const isActionsAndAlertError =
+    formAListStatus === "failed" ||
+    formBListStatus === "failed" ||
+    traineeActionsDataStatus === "failed";
+
+  return {
+    isActionsAndAlertLoading,
+    isActionsAndAlertSuccess,
+    isActionsAndAlertError
+  };
+};

--- a/utilities/hooks/useAlertStatusData.ts
+++ b/utilities/hooks/useAlertStatusData.ts
@@ -1,0 +1,52 @@
+import { useAppSelector } from "../../redux/hooks/hooks";
+import { useInfoActions } from "./action-summary/useInfoActions";
+import { useInProgressActions } from "./action-summary/useInProgressActions";
+import { useOutstandingActions } from "./action-summary/useOutstandingActions";
+
+export interface AlertStatusData {
+  unsignedCoJ: boolean;
+  inProgressFormR: boolean;
+  importantInfo: boolean;
+  unreviewedProgramme: boolean;
+  unreviewedPlacement: boolean;
+  showActionsSummaryAlert: boolean;
+}
+
+export function useAlertStatusData(): AlertStatusData {
+  // ACTION SUMMARY
+  const draftFormProps = !!useAppSelector(state => state.forms?.draftFormProps);
+  const { unsignedCojCount, programmeActions, placementActions } =
+    useOutstandingActions();
+  const unsignedCoJ = unsignedCojCount > 0;
+  const unreviewedProgramme = programmeActions.length > 0;
+  const unreviewedPlacement = placementActions.length > 0;
+
+  const { isInProgressFormA, isInProgressFormB } = useInProgressActions();
+  const inProgressFormR =
+    isInProgressFormA || isInProgressFormB || draftFormProps;
+
+  const { noSubFormRA, noSubFormRB, infoActionsA, infoActionsB } =
+    useInfoActions();
+  const importantInfo: boolean =
+    !!infoActionsA.isForInfoYearPlusSubForm ||
+    !!infoActionsB.isForInfoYearPlusSubForm ||
+    noSubFormRA ||
+    noSubFormRB;
+
+  const showActionsSummaryAlert =
+    unsignedCoJ ||
+    inProgressFormR ||
+    draftFormProps ||
+    importantInfo ||
+    unreviewedProgramme ||
+    unreviewedPlacement;
+
+  return {
+    unsignedCoJ,
+    inProgressFormR,
+    importantInfo,
+    unreviewedProgramme,
+    unreviewedPlacement,
+    showActionsSummaryAlert
+  };
+}

--- a/utilities/hooks/useCriticalDataLoader.ts
+++ b/utilities/hooks/useCriticalDataLoader.ts
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { useAppSelector, useAppDispatch } from "../../redux/hooks/hooks";
+import { fetchTraineeProfileData } from "../../redux/slices/traineeProfileSlice";
+import { fetchReference } from "../../redux/slices/referenceSlice";
+import { fetchFeatureFlags } from "../../redux/slices/featureFlagsSlice";
+import {
+  getCognitoGroups,
+  getPreferredMfa
+} from "../../redux/slices/userSlice";
+
+export const useCriticalDataLoader = () => {
+  const dispatch = useAppDispatch();
+  const [authActionsDispatched, setAuthActionsDispatched] = useState(false);
+
+  // Get all critical data statuses
+  const traineeProfileStatus = useAppSelector(
+    state => state.traineeProfile.status
+  );
+  const referenceStatus = useAppSelector(state => state.reference.status);
+  const featureFlagsStatus = useAppSelector(state => state.featureFlags.status);
+  const userStatus = useAppSelector(state => state.user.status);
+
+  useEffect(() => {
+    if (traineeProfileStatus === "idle") {
+      dispatch(fetchTraineeProfileData());
+    }
+  }, [traineeProfileStatus, dispatch]);
+
+  useEffect(() => {
+    if (referenceStatus === "idle") {
+      dispatch(fetchReference());
+    }
+  }, [referenceStatus, dispatch]);
+
+  useEffect(() => {
+    if (featureFlagsStatus === "idle") {
+      dispatch(fetchFeatureFlags());
+    }
+  }, [featureFlagsStatus, dispatch]);
+
+  // Fetch user auth data if not already dispatched
+  useEffect(() => {
+    if (!authActionsDispatched) {
+      dispatch(getPreferredMfa());
+      dispatch(getCognitoGroups());
+      setAuthActionsDispatched(true);
+    }
+  }, [authActionsDispatched, dispatch]);
+
+  const isCriticalLoading =
+    traineeProfileStatus === "loading" ||
+    referenceStatus === "loading" ||
+    featureFlagsStatus === "loading" ||
+    userStatus === "loading";
+
+  const isCriticalSuccess =
+    traineeProfileStatus === "succeeded" &&
+    referenceStatus === "succeeded" &&
+    featureFlagsStatus === "succeeded" &&
+    (userStatus === "succeeded" || userStatus === "idle");
+
+  const hasCriticalError =
+    traineeProfileStatus === "failed" ||
+    referenceStatus === "failed" ||
+    featureFlagsStatus === "failed" ||
+    userStatus === "failed";
+
+  return {
+    isCriticalLoading,
+    isCriticalSuccess,
+    hasCriticalError
+  };
+};

--- a/utilities/hooks/useRedirectHandler.ts
+++ b/utilities/hooks/useRedirectHandler.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { useAppSelector, useAppDispatch } from "../../redux/hooks/hooks";
+import { updatedRedirected } from "../../redux/slices/userSlice";
+
+export const useRedirectHandler = () => {
+  const dispatch = useAppDispatch();
+  const redirected = useAppSelector(state => state.user.redirected);
+  const location = useLocation();
+  const isMatchedQueryParamsRedirect =
+    new URLSearchParams(location.search).get("redirected") === "1";
+
+  // Update the redirected state in Redux if needed
+  useEffect(() => {
+    if (isMatchedQueryParamsRedirect && !redirected) {
+      dispatch(updatedRedirected(true));
+    }
+  }, [isMatchedQueryParamsRedirect, redirected, dispatch]);
+
+  // Clean up URL params to avoid it being bookmarked
+  useEffect(() => {
+    if (redirected || isMatchedQueryParamsRedirect) {
+      const params = new URLSearchParams(location.search);
+      params.delete("redirected");
+
+      window.history.pushState(
+        null,
+        "",
+        location.pathname + (params.toString() ? "?" + params.toString() : "")
+      );
+    }
+  }, [
+    redirected,
+    isMatchedQueryParamsRedirect,
+    location.pathname,
+    location.search
+  ]);
+};


### PR DESCRIPTION
Long overdue Spring clean and as a base for any new feature flag work...

The `Main.tsx `comp is a mess making it difficult to read and maintain.
1. Move and group `useEffects` from `Main.tsx` to custom hooks:
- `useCriticalDataLoader` for critical `Profile`, `Reference`, `user` data - without which TSS is unusable.
- `useActionsAndAlertsDataLoader` for non-critical action summary and alerts.
- `useRedirectHandler` for app redirect logic
And add an error message when critical data fails to load (rather than blank screen)

2. Refactor Global Alert
- Move the `useActionsAndAlertsDataLoader` hook from Main 
- Refactor `GlobalAlert` to simplify logic e.g. create `useAlertStatusData` hook to manage all the actions hooks.
- Add error message to `GlobalAlert` when actions fail to load.

3. refactor `Loading` comp to make more customisable and make it look a bit less 💩.

4. fix: circular dependency in `formB` slice.


JFDI
