### PR TITLE
feat(ltft): include managing deanery in LTFT

### DIFF
--- a/components/forms/cct/CctCalcCreate.tsx
+++ b/components/forms/cct/CctCalcCreate.tsx
@@ -197,6 +197,11 @@ export function CctCalcCreate() {
                                     selectedProgramme.designatedBodyCode,
                                     false
                                   );
+                                  setFieldValue(
+                                    "programmeMembership.managingDeanery",
+                                    selectedProgramme.managingDeanery,
+                                    false
+                                  );
                                 }
                               } else {
                                 resetForm({ values: defaultCctCalc });

--- a/mock-data/mock-cct-data.ts
+++ b/mock-data/mock-cct-data.ts
@@ -13,7 +13,8 @@ export const mockCctList: CctCalculation[] = [
       startDate: "2020-01-01",
       endDate: "2028-01-01",
       wte: 1.0,
-      designatedBodyCode: "WTF"
+      designatedBodyCode: "WTF",
+      managingDeanery: "North West"
     },
     changes: [
       {
@@ -35,7 +36,8 @@ export const mockCctList: CctCalculation[] = [
       startDate: "2024-08-07",
       endDate: "2029-07-31",
       wte: 1.0,
-      designatedBodyCode: "WTF2"
+      designatedBodyCode: "WTF2",
+      managingDeanery: "North East"
     },
     changes: [
       {
@@ -59,7 +61,8 @@ export const mockCctCalc: CctCalculation = {
     startDate: "2020-01-01",
     endDate: "2028-01-01",
     wte: 1.0,
-    designatedBodyCode: "WTF3"
+    designatedBodyCode: "WTF3",
+    managingDeanery: "North North West"
   },
   changes: [
     {

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -128,7 +128,8 @@ export const mockLtftDraft0: LtftObj = {
     startDate: "2020-01-01",
     endDate: "2028-01-01",
     wte: 1,
-    designatedBodyCode: "WTF3"
+    designatedBodyCode: "WTF3",
+    managingDeanery: "North North West"
   },
   reasonsSelected: null,
   reasonsOtherDetail: null,
@@ -206,7 +207,8 @@ export const mockLtftUnsubmitted0: LtftObj = {
     startDate: "2020-01-01",
     endDate: "2028-01-01",
     wte: 1,
-    designatedBodyCode: "WTF3"
+    designatedBodyCode: "WTF3",
+    managingDeanery: "North North West"
   },
   reasonsSelected: null,
   reasonsOtherDetail: null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.121.2",
+  "version": "0.122.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.121.2",
+      "version": "0.122.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.121.2",
+  "version": "0.122.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/redux/slices/cctSlice.ts
+++ b/redux/slices/cctSlice.ts
@@ -20,6 +20,7 @@ export type PmType = {
   endDate: Date | string;
   wte: number | null;
   designatedBodyCode: string | null;
+  managingDeanery: string | null;
 };
 
 export type CctCalculation = {
@@ -40,7 +41,8 @@ export const defaultCctCalc: CctCalculation = {
     startDate: "",
     endDate: "",
     wte: null,
-    designatedBodyCode: null
+    designatedBodyCode: null,
+    managingDeanery: null
   },
   changes: [
     {

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -66,6 +66,7 @@ type LtftPm = {
   endDate: Date | string;
   wte: number;
   designatedBodyCode: string;
+  managingDeanery: string;
 };
 
 export type StatusLtft = {

--- a/utilities/__test__/LtftUtilities.test.ts
+++ b/utilities/__test__/LtftUtilities.test.ts
@@ -117,7 +117,8 @@ describe("mapLtftObjToDto", () => {
       startDate: "2020-01-01",
       endDate: "2028-01-01",
       wte: 1,
-      designatedBodyCode: "WTF3"
+      designatedBodyCode: "WTF3",
+      managingDeanery: "North North West"
     });
     expect(ltftDto.status).toEqual(statusData);
     expect(ltftDto.created).toBe(dateCreated);
@@ -202,7 +203,8 @@ describe("mapDtoToLtftObj", () => {
       startDate: "2020-01-01",
       endDate: "2028-01-01",
       wte: 1,
-      designatedBodyCode: "WTF3"
+      designatedBodyCode: "WTF3",
+      managingDeanery: "North North West"
     });
     expect(mockLtftObj.status).toEqual(statusData);
     expect(mockLtftObj.created).toBe(dateCreated);

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -58,7 +58,8 @@ export function populateLtftDraft(
       endDate: cctSnapshot?.programmeMembership.endDate ?? "",
       wte: cctSnapshot?.programmeMembership.wte ?? 0,
       designatedBodyCode:
-        cctSnapshot?.programmeMembership.designatedBodyCode ?? ""
+        cctSnapshot?.programmeMembership.designatedBodyCode ?? "",
+      managingDeanery: cctSnapshot?.programmeMembership.managingDeanery ?? ""
     },
     reasonsSelected: null,
     reasonsOtherDetail: null,
@@ -123,6 +124,7 @@ export type LtftDto = {
     endDate?: Date | string;
     wte: number;
     designatedBodyCode?: string;
+    managingDeanery?: string;
   };
   reasons: {
     selected: string[];
@@ -185,7 +187,8 @@ export const mapLtftObjToDto = (ltftObj: LtftObj): LtftDto => {
       startDate: ltftObj.programmeMembership.startDate,
       endDate: ltftObj.programmeMembership.endDate,
       wte: ltftObj.programmeMembership.wte,
-      designatedBodyCode: ltftObj.programmeMembership.designatedBodyCode ?? null
+      designatedBodyCode: ltftObj.programmeMembership.designatedBodyCode ?? null,
+      managingDeanery: ltftObj.programmeMembership.managingDeanery ?? null
     },
     reasons: {
       selected: ltftObj.reasonsSelected || [],
@@ -272,7 +275,8 @@ export const mapLtftDtoToObj = (ltftDto: LtftDto): LtftObj => {
       startDate: ltftDto.programmeMembership.startDate,
       endDate: ltftDto.programmeMembership.endDate ?? "",
       wte: ltftDto.programmeMembership.wte,
-      designatedBodyCode: ltftDto.programmeMembership.designatedBodyCode ?? ""
+      designatedBodyCode: ltftDto.programmeMembership.designatedBodyCode ?? "",
+      managingDeanery: ltftDto.programmeMembership.managingDeanery ?? ""
     },
     reasonsSelected: ltftDto.reasons.selected,
     reasonsOtherDetail: ltftDto.reasons.otherDetail ?? null,


### PR DESCRIPTION
The LTFT notifications require the managing deanery name to determine which contacts/links to include in the notification. The details and forms services have been updated to include the managing deanery in the CCT calculation and LTFT dtos respectively.

Update the frontend models to include the managing deanery and populate the LTFT form's value based on the value taken from the CCT calculation.

TIS21-6596
TIS21-6594