### PR TITLE
Feature Flag - Show LTFT to pilot regions (and beta tester club members)

### DIFF
--- a/components/forms/cct/CctHome.tsx
+++ b/components/forms/cct/CctHome.tsx
@@ -9,16 +9,16 @@ import { useEffect } from "react";
 import { loadCctList } from "../../../redux/slices/cctListSlice";
 import { CctProgrammesList } from "./CctProgrammesList";
 import { fetchLtftSummaryList } from "../../../redux/slices/ltftSummaryListSlice";
-import useIsBetaTester from "../../../utilities/hooks/useIsBetaTester";
+import { useIsLtftPilot } from "../../../utilities/hooks/useIsLtftPilot";
 
 export function CctHome() {
   const dispatch = useAppDispatch();
-  const isBetaTester = useIsBetaTester();
+  const isLtftPilot = useIsLtftPilot();
 
   useEffect(() => {
     dispatch(loadCctList());
-    if (isBetaTester) dispatch(fetchLtftSummaryList());
-  }, [dispatch, isBetaTester]);
+    if (isLtftPilot) dispatch(fetchLtftSummaryList());
+  }, [dispatch, isLtftPilot]);
 
   return (
     <>

--- a/components/forms/cct/CctSavedDrafts.tsx
+++ b/components/forms/cct/CctSavedDrafts.tsx
@@ -1,11 +1,11 @@
 import { useAppSelector } from "../../../redux/hooks/hooks";
-import useIsBetaTester from "../../../utilities/hooks/useIsBetaTester";
+import { useIsLtftPilot } from "../../../utilities/hooks/useIsLtftPilot";
 import ErrorPage from "../../common/ErrorPage";
 import Loading from "../../common/Loading";
 import { CctSavedDraftsTable } from "./CctSavedDraftsTable";
 
 export function CctSavedDrafts() {
-  const isBetaTester = useIsBetaTester();
+  const isLtftPilot = useIsLtftPilot();
   const cctListStatus = useAppSelector(state => state.cctList.status);
   const ltftSummaryListStatus = useAppSelector(
     state => state.ltftSummaryList.status
@@ -22,7 +22,7 @@ export function CctSavedDrafts() {
   }
 
   if (
-    (isBetaTester &&
+    (isLtftPilot &&
       cctListStatus === "succeeded" &&
       ltftSummaryListStatus === "succeeded") ||
     cctListStatus === "succeeded"

--- a/components/forms/cct/CctSavedDraftsTable.tsx
+++ b/components/forms/cct/CctSavedDraftsTable.tsx
@@ -22,7 +22,7 @@ import {
   setLtftCctSnapshot,
   updatedLtft
 } from "../../../redux/slices/ltftSlice";
-import useIsBetaTester from "../../../utilities/hooks/useIsBetaTester";
+import { useIsLtftPilot } from "../../../utilities/hooks/useIsLtftPilot";
 import { LtftDeclarationsModal } from "../ltft/LtftDeclarationsModal";
 import { populateLtftDraft } from "../../../utilities/ltftUtilities";
 import { Button } from "@aws-amplify/ui-react";
@@ -192,13 +192,13 @@ function RowLtftActions({
   row,
   setIsModalOpen
 }: Readonly<RowLtftActionsProps>) {
-  const isBetaTester = useIsBetaTester();
+  const isLtftPilot = useIsLtftPilot();
   const makeLtftBtnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     store.dispatch(setLtftCctSnapshot(row));
     setIsModalOpen(true);
   };
-  return isBetaTester ? (
+  return isLtftPilot ? (
     <Button
       onClick={makeLtftBtnClick}
       data-cy={`make-ltft-btn-${row.id}`}

--- a/components/home/Home.tsx
+++ b/components/home/Home.tsx
@@ -3,7 +3,7 @@ import { Redirect } from "react-router-dom";
 import { useAppSelector } from "../../redux/hooks/hooks";
 import history from "../navigation/history";
 import style from "../Common.module.scss";
-import useIsBetaTester from "../../utilities/hooks/useIsBetaTester";
+import { useIsLtftPilot } from "../../utilities/hooks/useIsLtftPilot";
 
 const handleClick = (route: string) => history.push(route);
 
@@ -16,7 +16,7 @@ interface HomeCardProps {
 
 const Home = () => {
   const preferredMfa = useAppSelector(state => state.user.preferredMfa);
-  const isBetaTester = useIsBetaTester();
+  const isLtftPilot = useIsLtftPilot();
 
   if (preferredMfa === "NOMFA") {
     return <Redirect to="/mfa" />;
@@ -135,7 +135,7 @@ const Home = () => {
           </PageCard>
         </Card.GroupItem>
       </Card.Group>
-      {isBetaTester && (
+      {isLtftPilot && (
         <Card.Group>
           <Card.GroupItem width="one-third">
             <PageCard

--- a/components/main/GlobalAlert.tsx
+++ b/components/main/GlobalAlert.tsx
@@ -10,7 +10,6 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useAlertStatusData } from "../../utilities/hooks/useAlertStatusData";
-import Loading from "../common/Loading";
 
 export const GlobalAlert = () => {
   const { isActionsAndAlertLoading, isActionsAndAlertError } =

--- a/components/main/Main.tsx
+++ b/components/main/Main.tsx
@@ -22,7 +22,7 @@ import ActionSummary from "../actionSummary/ActionSummary";
 import { OnboardingTracker } from "../programmes/trackers/OnboardingTracker";
 import { Cct } from "../forms/cct/Cct";
 import { Ltft } from "../forms/ltft/Ltft";
-import useIsBetaTester from "../../utilities/hooks/useIsBetaTester";
+import { useIsLtftPilot } from "../../utilities/hooks/useIsLtftPilot";
 import { useRedirectHandler } from "../../utilities/hooks/useRedirectHandler";
 import { useCriticalDataLoader } from "../../utilities/hooks/useCriticalDataLoader";
 import ErrorPage from "../common/ErrorPage";
@@ -30,7 +30,7 @@ import ErrorPage from "../common/ErrorPage";
 const appVersion = packageJson.version;
 
 export const Main = () => {
-  const isBetaTester = useIsBetaTester();
+  const isLtftPilot = useIsLtftPilot();
   const { isCriticalLoading, isCriticalSuccess, hasCriticalError } =
     useCriticalDataLoader();
   useRedirectHandler();
@@ -72,7 +72,7 @@ export const Main = () => {
             <Route path="/mfa" component={MFA} />
             <Route path="/notifications" component={Notifications} />
             <Route path="/cct" component={Cct} />
-            {isBetaTester ? <Route path="/ltft" component={Ltft} /> : null}
+            {isLtftPilot ? <Route path="/ltft" component={Ltft} /> : null}
             <Redirect exact path="/" to="/home" />
             <Route path="/*" component={PageNotFound} />
           </Switch>

--- a/components/navigation/TSSHeader.tsx
+++ b/components/navigation/TSSHeader.tsx
@@ -6,7 +6,7 @@ import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
 import { useEffect } from "react";
 import { getNotifications } from "../../redux/slices/notificationsSlice";
 import { NotificationsBtn } from "../notifications/NotificationsBtn";
-import useIsBetaTester from "../../utilities/hooks/useIsBetaTester";
+import { useIsLtftPilot } from "../../utilities/hooks/useIsLtftPilot";
 
 const TSSHeader = () => {
   const dispatch = useAppDispatch();
@@ -17,7 +17,7 @@ const TSSHeader = () => {
     state => state.notifications.status
   );
   const preferredMfa = useAppSelector(state => state.user.preferredMfa);
-  const isBetaTester = useIsBetaTester();
+  const isLtftPilot = useIsLtftPilot();
 
   useEffect(() => {
     if (notificationsStatus === "idle") {
@@ -84,7 +84,7 @@ const TSSHeader = () => {
         </span>
       </div>
       <Header.Nav className="header-nav">
-        {makeTSSHeaderLinks(preferredMfa, isBetaTester)}
+        {makeTSSHeaderLinks(preferredMfa, isLtftPilot)}
         <div className="nhsuk-header__navigation-item mobile-only-nav">
           <SignOutBtn />
         </div>
@@ -94,7 +94,7 @@ const TSSHeader = () => {
 };
 export default TSSHeader;
 
-function makeTSSHeaderLinks(preferredMfa: string, isBetaTester: boolean) {
+function makeTSSHeaderLinks(preferredMfa: string, isLtftPilot: boolean) {
   const paths = [
     {
       path: "action-summary",
@@ -145,7 +145,7 @@ function makeTSSHeaderLinks(preferredMfa: string, isBetaTester: boolean) {
       name: "Changing hours (LTFT)",
       mobileOnly: false,
       showWithNoMfa: false,
-      showForBetaTesters: true
+      showForLtftPilot: true
     }
   ];
 
@@ -154,7 +154,7 @@ function makeTSSHeaderLinks(preferredMfa: string, isBetaTester: boolean) {
     name: string;
     mobileOnly: boolean;
     showWithNoMfa: boolean;
-    showForBetaTesters?: boolean;
+    showForLtftPilot?: boolean;
   }) => (
     <div
       key={pathObj.name}
@@ -163,7 +163,7 @@ function makeTSSHeaderLinks(preferredMfa: string, isBetaTester: boolean) {
       }`}
       hidden={
         (preferredMfa === "NOMFA" && !pathObj.showWithNoMfa) ||
-        (pathObj.showForBetaTesters && !isBetaTester)
+        (pathObj?.showForLtftPilot && !isLtftPilot)
       }
     >
       <NavLink

--- a/cypress/component/forms/cct/CctSavedDrafts.cy.tsx
+++ b/cypress/component/forms/cct/CctSavedDrafts.cy.tsx
@@ -12,12 +12,12 @@ import {
   updatedLtftSummaryList,
   updatedLtftSummaryListStatus
 } from "../../../../redux/slices/ltftSummaryListSlice";
-import { updatedCognitoGroups } from "../../../../redux/slices/userSlice";
+import { updatedLtftPilot } from "../../../../redux/slices/userSlice";
 import { mockLtftsList1 } from "../../../../mock-data/mock-ltft-data";
 
 describe("CctSavedDrafts", () => {
   beforeEach(() => {
-    store.dispatch(updatedCognitoGroups(["beta-participant"]));
+    store.dispatch(updatedLtftPilot(true));
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/cct"]}>
@@ -70,9 +70,9 @@ describe("CctSavedDrafts", () => {
   });
 });
 
-describe("CctSavedDrafts - beta tester", () => {
+describe("CctSavedDrafts - ltft pilot", () => {
   beforeEach(() => {
-    store.dispatch(updatedCognitoGroups(["beta-participant"]));
+    store.dispatch(updatedLtftPilot(true));
     store.dispatch(updatedCctList(mockCctList));
     store.dispatch(updatedCctListStatus("succeeded"));
     store.dispatch(updatedLtftSummaryListStatus("succeeded"));
@@ -85,7 +85,7 @@ describe("CctSavedDrafts - beta tester", () => {
     );
   });
 
-  it("Renders the 'ltft button' when user is a beta tester and they have no in progress ltfts", () => {
+  it("Renders the 'ltft button' when user is in the ltft pilot and they have no in progress ltfts", () => {
     store.dispatch(updatedLtftSummaryList(mockLtftsList1.slice(1)));
     cy.get('[data-cy="make-ltft-btn-c96468cc-075c-4ac8-a5a2-1b53220a807e"]')
       .should("exist")
@@ -108,7 +108,7 @@ describe("CctSavedDrafts - beta tester", () => {
     cy.url().should("include", "/ltft/create");
   });
 
-  it("Doesn't render the 'ltft button' when user is a beta tester and they have an in progress ltft", () => {
+  it("Doesn't render the 'ltft button' when user is in the ltft pilot and they have an in progress ltft", () => {
     store.dispatch(updatedLtftSummaryList(mockLtftsList1));
     cy.get('[data-cy="make-ltft-btn-6756c2b57ee98643d6f3dd8b"]').should(
       "exist"
@@ -116,9 +116,8 @@ describe("CctSavedDrafts - beta tester", () => {
   });
 });
 
-describe("CctSavedDrafts - not a beta tester", () => {
+describe("CctSavedDrafts - not in the ltft pilot", () => {
   before(() => {
-    store.dispatch(updatedCognitoGroups(["other-consultants"]));
     store.dispatch(updatedCctList(mockCctList));
     store.dispatch(updatedCctListStatus("succeeded"));
     store.dispatch(updatedLtftSummaryListStatus("succeeded"));
@@ -132,7 +131,7 @@ describe("CctSavedDrafts - not a beta tester", () => {
     );
   });
 
-  it("doesn't render the 'ltft button' when user is not a beta tester", () => {
+  it("doesn't render the 'ltft button' when user is not in the ltft pilot", () => {
     cy.get('[data-cy="make-ltft-btn-6756c2b57ee98643d6f3dd8b]').should(
       "not.exist"
     );

--- a/cypress/component/home/Home.cy.tsx
+++ b/cypress/component/home/Home.cy.tsx
@@ -4,7 +4,7 @@ import { Router } from "react-router-dom";
 import store from "../../../redux/store/store";
 import Home from "../../../components/home/Home";
 import {
-  updatedCognitoGroups,
+  updatedLtftPilot,
   updatedPreferredMfa
 } from "../../../redux/slices/userSlice";
 import history from "../../../components/navigation/history";
@@ -42,7 +42,7 @@ describe("Home with no MFA set up", () => {
 describe("Home with MFA set up", () => {
   beforeEach(() => {
     store.dispatch(updatedPreferredMfa("SMS"));
-    store.dispatch(updatedCognitoGroups(["beta-participant"]));
+    store.dispatch(updatedLtftPilot(true));
     mount(
       <Provider store={store}>
         <Router history={history}>

--- a/cypress/component/navigation/TSSHeader.cy.tsx
+++ b/cypress/component/navigation/TSSHeader.cy.tsx
@@ -4,7 +4,7 @@ import history from "../../../components/navigation/history";
 import { Provider } from "react-redux";
 import store from "../../../redux/store/store";
 import {
-  updatedCognitoGroups,
+  updatedLtftPilot,
   updatedPreferredMfa
 } from "../../../redux/slices/userSlice";
 import { Authenticator } from "@aws-amplify/ui-react";
@@ -36,7 +36,7 @@ const comp = (
 describe("Header with MFA set up", () => {
   beforeEach(() => {
     store.dispatch(updatedPreferredMfa("SMS"));
-    store.dispatch(updatedCognitoGroups(["beta-participant"]));
+    store.dispatch(updatedLtftPilot(true));
     mount(comp);
   });
 
@@ -121,7 +121,7 @@ describe("Header with NOMFA", () => {
 describe("Desktop Header with MFA set up", () => {
   beforeEach(() => {
     store.dispatch(updatedPreferredMfa("SMS"));
-    store.dispatch(updatedCognitoGroups(["beta-participant"]));
+    store.dispatch(updatedLtftPilot(true));
     mount(comp);
     cy.viewport(1024, 768);
   });

--- a/cypress/component/programmes/Programmes.cy.tsx
+++ b/cypress/component/programmes/Programmes.cy.tsx
@@ -19,7 +19,7 @@ import {
 import history from "../../../components/navigation/history";
 import React from "react";
 import {
-  updatedCognitoGroups,
+  updatedLtftPilot,
   updatedPreferredMfa
 } from "../../../redux/slices/userSlice";
 import {
@@ -38,7 +38,6 @@ const mountProgrammesWithMockData = (
   profileStatus: string = "idle",
   programmeMemberships: ProgrammeMembership[] = mockProgrammeMemberships,
   actionsData: any[] = [],
-  cognitoGroups: any[] = [],
   formAList: any = mockFormList,
   formBList: any = mockFormList
 ) => {
@@ -55,9 +54,7 @@ const mountProgrammesWithMockData = (
     );
     dispatch(updatedTraineeProfileStatus(profileStatus));
     dispatch(updatedActionsData(actionsData));
-    if (cognitoGroups.length > 0) {
-      dispatch(updatedCognitoGroups(cognitoGroups));
-    }
+    dispatch(updatedLtftPilot(true));
     dispatch(updatedFormAList(formAList));
     dispatch(updatedFormBList(formBList));
     return <Programmes />;

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -52,7 +52,10 @@ export const mockLtftsList1 = [
     status: "DRAFT",
     created: "2025-01-01T14:50:36.941Z",
     lastModified: "2025-01-15T15:50:36.941Z",
-    formRef: ""
+    formRef: "",
+    statusReason: "",
+    statusMessage: "",
+    modifiedByRole: ""
   },
   {
     id: "123e4567-e89b-12d3-a456-426614174000",
@@ -61,7 +64,10 @@ export const mockLtftsList1 = [
     status: "APPROVED",
     created: "2024-12-15T14:50:36.941Z",
     lastModified: "2024-12-15T15:50:36.941Z",
-    formRef: "ltft_-1_002"
+    formRef: "ltft_-1_002",
+    statusReason: "",
+    statusMessage: "",
+    modifiedByRole: ""
   },
   {
     id: "123e4567-e89b-12d3-a456-426614174001",
@@ -70,7 +76,10 @@ export const mockLtftsList1 = [
     status: "SUBMITTED",
     created: "2024-10-15T14:50:36.941Z",
     lastModified: "2024-10-15T15:50:36.941Z",
-    formRef: "ltft_-1_003"
+    formRef: "ltft_-1_003",
+    statusReason: "",
+    statusMessage: "",
+    modifiedByRole: ""
   },
   {
     id: "123e4567-e89b-12d3-a456-426614174001",
@@ -79,7 +88,10 @@ export const mockLtftsList1 = [
     status: "SUBMITTED",
     created: "2024-09-15T14:50:36.941Z",
     lastModified: "2024-09-15T15:50:36.941Z",
-    formRef: "ltft_-1_004"
+    formRef: "ltft_-1_004",
+    statusReason: "",
+    statusMessage: "",
+    modifiedByRole: ""
   },
   {
     id: "123e4567-e89b-12d3-a456-426614174001",
@@ -88,7 +100,10 @@ export const mockLtftsList1 = [
     status: "WITHDRAWN",
     created: "2024-08-15T14:50:36.941Z",
     lastModified: "2024-08-15T15:50:36.941Z",
-    formRef: "ltft_-1_005"
+    formRef: "ltft_-1_005",
+    statusReason: "",
+    statusMessage: "",
+    modifiedByRole: ""
   }
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.122.0",
+  "version": "0.122.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.122.0",
+      "version": "0.122.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.122.0",
+  "version": "0.122.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/hooks/__test__/useLtftHomeStartover.test.tsx
+++ b/utilities/hooks/__test__/useLtftHomeStartover.test.tsx
@@ -23,9 +23,9 @@ jest.mock("../../../redux/slices/ltftSummaryListSlice", () => ({
   }))
 }));
 
-jest.mock("../useIsBetaTester", () => ({
+jest.mock("../useIsLtftPilot", () => ({
   __esModule: true,
-  default: jest.fn(() => true)
+  useIsLtftPilot: jest.fn(() => true)
 }));
 
 //Custom Type for test state to avoid having to use the real RootState type!
@@ -62,7 +62,7 @@ describe("useLtftHomeStartover", () => {
     });
   });
 
-  it("should dispatch actions and call resetForm when isBetaTester is true", async () => {
+  it("should dispatch actions and call resetForm when isLtftPilot is true", async () => {
     render(
       <Provider store={testStore}>
         <TestComponent />

--- a/utilities/hooks/useCriticalDataLoader.ts
+++ b/utilities/hooks/useCriticalDataLoader.ts
@@ -4,7 +4,7 @@ import { fetchTraineeProfileData } from "../../redux/slices/traineeProfileSlice"
 import { fetchReference } from "../../redux/slices/referenceSlice";
 import { fetchFeatureFlags } from "../../redux/slices/featureFlagsSlice";
 import {
-  getCognitoGroups,
+  fetchUserAuthInfo,
   getPreferredMfa
 } from "../../redux/slices/userSlice";
 
@@ -42,7 +42,7 @@ export const useCriticalDataLoader = () => {
   useEffect(() => {
     if (!authActionsDispatched) {
       dispatch(getPreferredMfa());
-      dispatch(getCognitoGroups());
+      dispatch(fetchUserAuthInfo());
       setAuthActionsDispatched(true);
     }
   }, [authActionsDispatched, dispatch]);

--- a/utilities/hooks/useIsBetaTester.ts
+++ b/utilities/hooks/useIsBetaTester.ts
@@ -1,9 +1,0 @@
-import store from "../../redux/store/store";
-
-const useIsBetaTester = (): boolean => {
-  const cognitoGroups = store.getState().user.cognitoGroups;
-
-  return cognitoGroups?.includes("beta-participant") ?? false;
-};
-
-export default useIsBetaTester;

--- a/utilities/hooks/useIsLtftPilot.ts
+++ b/utilities/hooks/useIsLtftPilot.ts
@@ -1,0 +1,6 @@
+import { useAppSelector } from "../../redux/hooks/hooks";
+
+export const useIsLtftPilot = (): boolean => {
+  const features = useAppSelector(state => state.user.features);
+  return features?.ltft ?? false;
+};

--- a/utilities/hooks/useLtftHomeStartover.ts
+++ b/utilities/hooks/useLtftHomeStartover.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
-import useIsBetaTester from "./useIsBetaTester";
+import { useIsLtftPilot } from "./useIsLtftPilot";
 import {
   fetchLtftSummaryList,
   updatedLtftFormsRefreshNeeded
@@ -9,16 +9,16 @@ import { resetForm } from "../FormBuilderUtilities";
 
 export const useLtftHomeStartover = () => {
   const dispatch = useAppDispatch();
-  const isBetaTester = useIsBetaTester();
+  const isLtftPilot = useIsLtftPilot();
   const needLtftFormsRefresh = useAppSelector(
     state => state.ltftSummaryList?.ltftFormsRefreshNeeded
   );
 
   useEffect(() => {
-    if (isBetaTester) {
+    if (isLtftPilot) {
       dispatch(fetchLtftSummaryList());
       updatedLtftFormsRefreshNeeded(false);
       resetForm("ltft");
     }
-  }, [dispatch, isBetaTester, needLtftFormsRefresh]);
+  }, [dispatch, isLtftPilot, needLtftFormsRefresh]);
 };


### PR DESCRIPTION

Refactor auth data fetch:
- rename `getCognitoGroups` thunk to `fetchUserAuthInfo` and use this to fetch the `user.features` data.
- Create a new hook `useIsLtftPilot` to check if the user is a LTFT pilot member.
- Delete the old `useIsBetaTester` hook (as the logic is now part of the feature flag BE logic) and all references to it and reference the new `useIsLtftPilot` hook instead to conditionally render the LTFT stuff.


[TIS21-7200](https://hee-tis.atlassian.net/browse/TIS21-7200)

[TIS21-7200]: https://hee-tis.atlassian.net/browse/TIS21-7200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ