### PR TITLE
refactor: page container width

### DIFF
--- a/components/forms/cct/CctSavedDraftsTable.tsx
+++ b/components/forms/cct/CctSavedDraftsTable.tsx
@@ -207,7 +207,8 @@ function RowLtftActions({
       style={{
         minWidth: "18em",
         maxWidth: "18em",
-        fontWeight: "normal"
+        fontWeight: "normal",
+        cursor: "pointer"
       }}
     >
       Apply for Changing hours (LTFT)

--- a/components/forms/form-builder/form-sections/ImportantText.tsx
+++ b/components/forms/form-builder/form-sections/ImportantText.tsx
@@ -95,9 +95,6 @@ const unresolvedDecsText =
 const ltftDiscussionText1 =
   "Please provide the contact details of the Training Programme Director (TPD) you have discussed your Changing hours (LTFT) proposal with prior to completing this form. ";
 
-const ltftDiscussionText2 =
-  "When you submit this application, your TPD will receive an email which will include a summary of your proposal.";
-
 const ltftOtherDiscussionsText =
   "If applicable, please provide details of any other discussions you have had concerning your Changing hours (LTFT) proposal.";
 
@@ -178,7 +175,6 @@ const displayText: DisplayText = {
   newUnresolvedDecsInstructions: generateTextElement([unresolvedDecsText]),
   ltftDiscussionInstructions: generateTextElement([
     ltftDiscussionText1,
-    ltftDiscussionText2,
     ltftOtherDiscussionsText,
     ltftDiscussionText3
   ]),

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -225,7 +225,7 @@ const LtftSummary = ({
         onClick={handleBtnClick(label)}
         size="small"
         type="reset"
-        style={{ minWidth: "6em", ...additionalStyle }}
+        style={{ minWidth: "6em", cursor: "pointer", ...additionalStyle }}
       >
         {label}
       </Button>

--- a/components/navigation/TSSHeader.tsx
+++ b/components/navigation/TSSHeader.tsx
@@ -83,7 +83,7 @@ const TSSHeader = () => {
           </a>
         </span>
       </div>
-      <Header.Nav className="header-nav">
+      <Header.Nav style={{ maxWidth: "100%" }}>
         {makeTSSHeaderLinks(preferredMfa, isLtftPilot)}
         <div className="nhsuk-header__navigation-item mobile-only-nav">
           <SignOutBtn />

--- a/components/notifications/RowActions.tsx
+++ b/components/notifications/RowActions.tsx
@@ -3,6 +3,7 @@ import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
 import { NotificationType } from "../../redux/slices/notificationsSlice";
 import { updateNotificationStatus } from "../../utilities/NotificationsUtilities";
 import { useAppSelector } from "../../redux/hooks/hooks";
+import { Button } from "@aws-amplify/ui-react";
 
 type RowActionsProps = {
   row: NotificationType;
@@ -15,18 +16,19 @@ export function RowActions({ row }: Readonly<RowActionsProps>) {
 
   if (row.status === "READ") {
     return (
-      <button
-        type="button"
-        className="unread-btn"
+      <Button
+        size="small"
+        type="reset"
         onClick={async e => {
           e.stopPropagation();
           updateNotificationStatus(row, "UNREAD");
         }}
         disabled={inProgressUpdate}
+        style={{ cursor: "pointer" }}
       >
         <FontAwesomeIcon icon={faEnvelope} size="sm" className="unread-icon" />
         <span>Mark as unread</span>
-      </button>
+      </Button>
     );
   } else return null;
 }

--- a/cypress/component/forms/ltft/LtftForm.cy.tsx
+++ b/cypress/component/forms/ltft/LtftForm.cy.tsx
@@ -56,7 +56,7 @@ describe("LtftForm - draft", () => {
     cy.get(
       '[data-cy="WarningCallout-ltftDiscussionInstructions-label"] > span'
     ).should("exist");
-    cy.get(".nhsuk-warning-callout > :nth-child(2) > :nth-child(4)").contains(
+    cy.get(".nhsuk-warning-callout > :nth-child(2) > :nth-child(3)").contains(
       "For information on Professional support contact"
     );
     cy.get(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.122.1",
+  "version": "0.122.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.122.1",
+      "version": "0.122.2",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.122.1",
+  "version": "0.122.2",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -23,6 +23,10 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.nhsuk-width-container {
+  max-width: 990px;
+}
+
 [data-amplify-authenticator] {
   font-family: "Frutiger W01", Arial, sans-serif;
   background-color: #005eb8;
@@ -690,9 +694,35 @@ ol[type="a"] {
   }
 }
 
-// ---- Notifications table ----
+// ---- tables ----
 .table-wrapper {
+  width: 100%;
   overflow-x: auto;
+  border-radius: 4px;
+  margin: 16px 0;
+}
+
+.table-wrapper thead {
+  background-color: #f0f4f5;
+  position: sticky;
+  top: 0;
+}
+
+.table-wrapper tbody tr:nth-child(even) {
+  background-color: #f9fafb;
+}
+
+.table-wrapper tr.table-row {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.table-wrapper tr.table-row:hover {
+  background-color: #f2f8ff;
+}
+
+.table-wrapper td[data-cy*="status"] {
+  font-weight: 500;
 }
 
 // ---- Notifications table pagination ----
@@ -739,14 +769,6 @@ ol[type="a"] {
   }
 }
 
-// Row
-.table-row {
-  transition: background-color 0.3s ease;
-  cursor: pointer;
-  &:hover {
-    background-color: #cbe0d9;
-  }
-}
 .row-read {
   font-weight: normal;
   background-color: #d8dde0;
@@ -822,37 +844,13 @@ ol[type="a"] {
   }
 }
 
-.table-row-btn {
-  padding: 2px;
-  border: 1px solid #4c6272;
-  box-shadow: 0 1px 0 #4e6475;
-  border-radius: 4px;
-  color: whitesmoke;
-  transition: all 0.3s ease;
-  cursor: pointer;
-}
-
-.hover-active-states {
-  &:hover {
-    background-color: #212b32;
-    transform: scale(1.05);
-  }
-  &:active {
-    background-color: #003f6d;
-    transform: scale(0.95);
-  }
-}
-
 .unread-btn {
-  @extend .table-row-btn;
-  @extend .hover-active-states;
-  background-color: #6c716f;
   margin-right: 8px;
   min-width: 200px;
 }
 
 .unread-icon {
-  color: white;
+  color: $nhsTracker3;
   margin-right: 0.5em;
 }
 


### PR DESCRIPTION
refactor: Slightly Increase the width of the page container from 960px to 990px to accommodate the table contents on desktop without needing to scroll. 
refactor: table layout to make it consistent across the app and style it some more.
fix: Remove `ImportantText` relating to TPD email in LTFT main application (section 1).

JFDI