### PR TITLE
fix: user error state

### DIFF
--- a/components/main/Main.tsx
+++ b/components/main/Main.tsx
@@ -26,13 +26,30 @@ import { useIsLtftPilot } from "../../utilities/hooks/useIsLtftPilot";
 import { useRedirectHandler } from "../../utilities/hooks/useRedirectHandler";
 import { useCriticalDataLoader } from "../../utilities/hooks/useCriticalDataLoader";
 import ErrorPage from "../common/ErrorPage";
+import { useEffect, useState } from "react";
+import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
+import {
+  fetchUserAuthInfo,
+  getPreferredMfa
+} from "../../redux/slices/userSlice";
 
 const appVersion = packageJson.version;
 
 export const Main = () => {
+  const dispatch = useAppDispatch();
+  const [authActionsDispatched, setAuthActionsDispatched] = useState(false);
   const isLtftPilot = useIsLtftPilot();
   const { isCriticalLoading, isCriticalSuccess, hasCriticalError } =
     useCriticalDataLoader();
+
+  // Fetch user auth data if not already dispatched
+  useEffect(() => {
+    if (!authActionsDispatched) {
+      dispatch(getPreferredMfa());
+      dispatch(fetchUserAuthInfo());
+      setAuthActionsDispatched(true);
+    }
+  }, [authActionsDispatched, dispatch]);
   useRedirectHandler();
 
   if (isCriticalLoading)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.122.5",
+  "version": "0.122.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.122.5",
+      "version": "0.122.6",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.122.5",
+  "version": "0.122.6",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/hooks/useCriticalDataLoader.ts
+++ b/utilities/hooks/useCriticalDataLoader.ts
@@ -3,14 +3,9 @@ import { useAppSelector, useAppDispatch } from "../../redux/hooks/hooks";
 import { fetchTraineeProfileData } from "../../redux/slices/traineeProfileSlice";
 import { fetchReference } from "../../redux/slices/referenceSlice";
 import { fetchFeatureFlags } from "../../redux/slices/featureFlagsSlice";
-import {
-  fetchUserAuthInfo,
-  getPreferredMfa
-} from "../../redux/slices/userSlice";
 
 export const useCriticalDataLoader = () => {
   const dispatch = useAppDispatch();
-  const [authActionsDispatched, setAuthActionsDispatched] = useState(false);
 
   // Get all critical data statuses
   const traineeProfileStatus = useAppSelector(
@@ -18,7 +13,6 @@ export const useCriticalDataLoader = () => {
   );
   const referenceStatus = useAppSelector(state => state.reference.status);
   const featureFlagsStatus = useAppSelector(state => state.featureFlags.status);
-  const userStatus = useAppSelector(state => state.user.status);
 
   useEffect(() => {
     if (traineeProfileStatus === "idle") {
@@ -38,32 +32,20 @@ export const useCriticalDataLoader = () => {
     }
   }, [featureFlagsStatus, dispatch]);
 
-  // Fetch user auth data if not already dispatched
-  useEffect(() => {
-    if (!authActionsDispatched) {
-      dispatch(getPreferredMfa());
-      dispatch(fetchUserAuthInfo());
-      setAuthActionsDispatched(true);
-    }
-  }, [authActionsDispatched, dispatch]);
-
   const isCriticalLoading =
     traineeProfileStatus === "loading" ||
     referenceStatus === "loading" ||
-    featureFlagsStatus === "loading" ||
-    userStatus === "loading";
+    featureFlagsStatus === "loading";
 
   const isCriticalSuccess =
     traineeProfileStatus === "succeeded" &&
     referenceStatus === "succeeded" &&
-    featureFlagsStatus === "succeeded" &&
-    (userStatus === "succeeded" || userStatus === "idle");
+    featureFlagsStatus === "succeeded";
 
   const hasCriticalError =
     traineeProfileStatus === "failed" ||
     referenceStatus === "failed" ||
-    featureFlagsStatus === "failed" ||
-    userStatus === "failed";
+    featureFlagsStatus === "failed";
 
   return {
     isCriticalLoading,


### PR DESCRIPTION
Move the user auth actions from the useCriticalDataLoader back to Main so a user failed state (from any source e.g. totp token error) does not stop the app from being displayed.

JFDI