### PR TITLE
Feat/add modal to cct delete

### DIFF
--- a/components/common/ActionModal.tsx
+++ b/components/common/ActionModal.tsx
@@ -50,42 +50,38 @@ export function ActionModal({
       </WarningCallout>
       <Formik initialValues={{ reason: "", message: "" }} onSubmit={onSubmit}>
         {({ values }) => (
-          <>
-            <Form>
-              {hasReason && (
-                <>
-                  <MultiChoiceInputField
-                    name="reason"
-                    type="radios"
-                    items={
-                      actionType === "Unsubmit"
-                        ? [...ACTION_REASONS.UNSUBMIT, ACTION_REASONS.OTHER]
-                        : [...ACTION_REASONS.WITHDRAW, ACTION_REASONS.OTHER]
-                    }
-                    label={`Please choose the primary reason for the ${actionType.toLowerCase()}`}
-                    id="reason"
-                  />
-                  <TextInputField
-                    name="message"
-                    id="message"
-                    label="Please provide any supplementary information if needed"
-                    placeholder="Enter details here..."
-                    width="300px"
-                    rows={3}
-                  />
-                </>
-              )}
-              <Button
-                type="submit"
-                disabled={isSubmitting || (hasReason && !values.reason)}
-                data-cy={`submitBtn-${warningLabel}`}
-              >
-                {isSubmitting
-                  ? `${submittingBtnText}...`
-                  : "Confirm & Continue"}
-              </Button>
-            </Form>
-          </>
+          <Form>
+            {hasReason && (
+              <>
+                <MultiChoiceInputField
+                  name="reason"
+                  type="radios"
+                  items={
+                    actionType === "Unsubmit"
+                      ? [...ACTION_REASONS.UNSUBMIT, ACTION_REASONS.OTHER]
+                      : [...ACTION_REASONS.WITHDRAW, ACTION_REASONS.OTHER]
+                  }
+                  label={`Please choose the primary reason for the ${actionType.toLowerCase()}`}
+                  id="reason"
+                />
+                <TextInputField
+                  name="message"
+                  id="message"
+                  label="Please provide any supplementary information if needed"
+                  placeholder="Enter details here..."
+                  width="300px"
+                  rows={3}
+                />
+              </>
+            )}
+            <Button
+              type="submit"
+              disabled={isSubmitting || (hasReason && !values.reason)}
+              data-cy={`submitBtn-${warningLabel}`}
+            >
+              {isSubmitting ? `${submittingBtnText}...` : "Confirm & Continue"}
+            </Button>
+          </Form>
         )}
       </Formik>
     </Modal>

--- a/components/forms/cct/CctSavedDraftsTable.tsx
+++ b/components/forms/cct/CctSavedDraftsTable.tsx
@@ -29,6 +29,7 @@ import { populateLtftDraft } from "../../../utilities/ltftUtilities";
 import { Button } from "@aws-amplify/ui-react";
 import { loadCctList } from "../../../redux/slices/cctListSlice";
 import { useSubmitting } from "../../../utilities/hooks/useSubmitting";
+import { ActionModal } from "../../common/ActionModal";
 
 const columnHelper = createColumnHelper<CctCalculation>();
 
@@ -72,12 +73,19 @@ const columnsDefault = [
 ];
 
 const createColumns = (
-  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>
+  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>,
+  setIsCctModalOpen: React.Dispatch<React.SetStateAction<boolean>>,
+  setCalcToDelete: React.Dispatch<React.SetStateAction<string | null>>
 ) => {
   const ltftColumn = columnHelper.display({
     id: "makeLtft",
     cell: props => (
-      <RowCctActions row={props.row.original} setIsModalOpen={setIsModalOpen} />
+      <RowCctActions
+        row={props.row.original}
+        setIsModalOpen={setIsModalOpen}
+        setIsCctModalOpen={setIsCctModalOpen}
+        setCalcToDelete={setCalcToDelete}
+      />
     )
   });
   return [...columnsDefault, ltftColumn];
@@ -99,10 +107,25 @@ export function CctSavedDraftsTable() {
   ]);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isCctModalOpen, setIsCctModalOpen] = useState(false);
+  const [calcIdToDelete, setCalcIdToDelete] = useState<string | null>(null);
+  const { startSubmitting, stopSubmitting } = useSubmitting();
+
+  const deleteCctCalcAndReloadList = async () => {
+    setIsCctModalOpen(false);
+    startSubmitting();
+    await store.dispatch(deleteCctCalc(calcIdToDelete as string));
+    const deleteStatus = store.getState().cct.formDeleteStatus;
+    if (deleteStatus === "succeeded") {
+      store.dispatch(loadCctList());
+    }
+    stopSubmitting();
+    setCalcIdToDelete(null);
+  };
 
   const columns = useMemo(
-    () => createColumns(setIsModalOpen),
-    [setIsModalOpen]
+    () => createColumns(setIsModalOpen, setIsCctModalOpen, setCalcIdToDelete),
+    [setIsCctModalOpen, setIsModalOpen, setCalcIdToDelete]
   );
 
   const table = useReactTable({
@@ -177,6 +200,16 @@ export function CctSavedDraftsTable() {
           history.push("/ltft/create");
         }}
       />
+      <ActionModal
+        onSubmit={deleteCctCalcAndReloadList}
+        isOpen={isCctModalOpen}
+        onClose={() => setIsCctModalOpen(false)}
+        cancelBtnText="Cancel"
+        warningLabel="Delete calculation"
+        warningText="Are you sure you want to delete this calculation? This action cannot be undone."
+        submittingBtnText="Deleting..."
+        actionType="Delete"
+      />
     </div>
   ) : (
     <p data-cy="no-saved-drafts">You have no saved calculations.</p>
@@ -186,14 +219,18 @@ export function CctSavedDraftsTable() {
 type RowLtftActionsProps = {
   row: CctCalculation;
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsCctModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setCalcToDelete: React.Dispatch<React.SetStateAction<string | null>>;
 };
 
 export function RowCctActions({
   row,
-  setIsModalOpen
+  setIsModalOpen,
+  setIsCctModalOpen,
+  setCalcToDelete
 }: Readonly<RowLtftActionsProps>) {
   const isLtftPilot = useIsLtftPilot();
-  const { isSubmitting, startSubmitting, stopSubmitting } = useSubmitting();
+  const { isSubmitting } = useSubmitting();
 
   const makeLtftBtnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
@@ -201,49 +238,38 @@ export function RowCctActions({
     setIsModalOpen(true);
   };
 
-  const deleteCctCalcAndReloadList = async (
-    e: React.MouseEvent<HTMLButtonElement>
-  ) => {
+  const makeCctBtnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    startSubmitting();
-    await store.dispatch(deleteCctCalc(row.id as string));
-    const deleteStatus = store.getState().cct.formDeleteStatus;
-    if (deleteStatus === "succeeded") {
-      store.dispatch(loadCctList());
-    }
-    stopSubmitting();
+    setCalcToDelete(row.id as string);
+    setIsCctModalOpen(true);
   };
 
   return (
     <div style={{ display: "flex", gap: "1em" }}>
       {isLtftPilot && (
         <Button
+          type="button"
+          variation="primary"
+          size="small"
           onClick={makeLtftBtnClick}
           data-cy={`make-ltft-btn-${row.id}`}
-          size="small"
-          type="button"
           style={{
             minWidth: "18em",
-            maxWidth: "18em",
-            backgroundColor: "#005eb8",
-            color: "white",
-            cursor: "pointer"
+            maxWidth: "18em"
           }}
         >
           Apply for Changing hours (LTFT)
         </Button>
       )}
       <Button
-        onClick={deleteCctCalcAndReloadList}
-        data-cy={`delete-cct-btn-${row.id}`}
-        size="small"
         type="button"
-        style={{
-          backgroundColor: "#d5281b",
-          color: "white",
-          cursor: "pointer"
-        }}
-        disabled={isSubmitting}
+        variation="destructive"
+        size="small"
+        isDisabled={isSubmitting}
+        isLoading={isSubmitting}
+        loadingText="Deleting..."
+        onClick={makeCctBtnClick}
+        data-cy={`delete-cct-btn-${row.id}`}
       >
         Delete
       </Button>

--- a/components/forms/cct/__test__/CctSavedDraftsTable.test.tsx
+++ b/components/forms/cct/__test__/CctSavedDraftsTable.test.tsx
@@ -1,0 +1,98 @@
+import { deleteCctCalc } from "../../../../redux/slices/cctSlice";
+import { loadCctList } from "../../../../redux/slices/cctListSlice";
+import store, { RootState } from "../../../../redux/store/store";
+
+type MockStoreType = {
+  dispatch: jest.Mock;
+  getState: jest.Mock<Partial<RootState>>;
+  subscribe: jest.Mock;
+  replaceReducer: jest.Mock;
+};
+
+jest.mock("../../../../redux/store/store", () => {
+  const mockStore: MockStoreType = {
+    dispatch: jest.fn(),
+    getState: jest.fn(() => ({
+      cct: { formDeleteStatus: "succeeded" }
+    })) as jest.Mock<Partial<RootState>>,
+    subscribe: jest.fn(() => jest.fn()),
+    replaceReducer: jest.fn()
+  };
+  return {
+    __esModule: true,
+    default: mockStore
+  };
+});
+
+jest.mock("../../../../redux/slices/cctSlice", () => ({
+  deleteCctCalc: jest.fn((id: string) => "MOCK_DELETE_ACTION")
+}));
+
+jest.mock("../../../../redux/slices/cctListSlice", () => ({
+  loadCctList: jest.fn(() => "MOCK_LOAD_LIST_ACTION")
+}));
+
+describe("CctSavedDraftsTable - Delete Logic", () => {
+  let setIsCctModalOpen: jest.Mock;
+  let setCalcIdToDelete: jest.Mock;
+  let startSubmitting: jest.Mock;
+  let stopSubmitting: jest.Mock;
+
+  // Recreate the function to test directly
+  const deleteCctCalcAndReloadList = async (): Promise<void> => {
+    setIsCctModalOpen(false);
+    startSubmitting();
+
+    // Mock the calcIdToDelete value directly
+    const calcIdToDelete = "test-calc-id";
+
+    if (calcIdToDelete) {
+      await store.dispatch(deleteCctCalc(calcIdToDelete));
+      const deleteStatus = (store.getState() as Partial<RootState>).cct
+        ?.formDeleteStatus;
+      if (deleteStatus === "succeeded") {
+        store.dispatch(loadCctList());
+      }
+    }
+
+    stopSubmitting();
+    setCalcIdToDelete(null);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setIsCctModalOpen = jest.fn();
+    setCalcIdToDelete = jest.fn();
+    startSubmitting = jest.fn();
+    stopSubmitting = jest.fn();
+  });
+
+  it("successfully deletes a calculation and reloads the list", async () => {
+    await deleteCctCalcAndReloadList();
+
+    expect(setIsCctModalOpen).toHaveBeenCalledWith(false);
+    expect(startSubmitting).toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledWith("MOCK_DELETE_ACTION");
+    expect(store.getState).toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledWith("MOCK_LOAD_LIST_ACTION");
+    expect(stopSubmitting).toHaveBeenCalled();
+    expect(setCalcIdToDelete).toHaveBeenCalledWith(null);
+    expect(deleteCctCalc).toHaveBeenCalledWith("test-calc-id");
+  });
+
+  it("doesn't reload the list if deletion fails", async () => {
+    (store.getState as jest.Mock).mockReturnValueOnce({
+      cct: { formDeleteStatus: "failed" }
+    });
+
+    await deleteCctCalcAndReloadList();
+
+    expect(setIsCctModalOpen).toHaveBeenCalledWith(false);
+    expect(startSubmitting).toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledWith("MOCK_DELETE_ACTION");
+    expect(store.getState).toHaveBeenCalled();
+    expect(loadCctList).not.toHaveBeenCalled();
+    expect(stopSubmitting).toHaveBeenCalled();
+    expect(setCalcIdToDelete).toHaveBeenCalledWith(null);
+  });
+});

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -220,12 +220,14 @@ const LtftSummary = ({
       additionalStyle = {}
     ) => (
       <Button
-        data-cy={`${label.toLowerCase()}LtftBtnLink`}
-        fontWeight="normal"
-        onClick={handleBtnClick(label)}
+        type="button"
+        variation={
+          label === "Delete" || label === "Withdraw" ? "destructive" : "warning"
+        }
         size="small"
-        type="reset"
-        style={{ minWidth: "6em", cursor: "pointer", ...additionalStyle }}
+        onClick={handleBtnClick(label)}
+        data-cy={`${label.toLowerCase()}LtftBtnLink`}
+        style={{ minWidth: "6em", ...additionalStyle }}
       >
         {label}
       </Button>
@@ -238,27 +240,14 @@ const LtftSummary = ({
             {renderActionButton("Unsubmit", {
               marginBottom: "0.5em"
             })}
-            {renderActionButton("Withdraw", {
-              backgroundColor: "#d5281b",
-              color: "white"
-            })}
+            {renderActionButton("Withdraw")}
           </>
         ) : null}
         {props.row.original.status === "DRAFT" ? (
-          <>
-            {renderActionButton("Delete", {
-              backgroundColor: "#d5281b",
-              color: "white"
-            })}
-          </>
+          <>{renderActionButton("Delete")}</>
         ) : null}
         {props.row.original.status === "UNSUBMITTED" ? (
-          <>
-            {renderActionButton("Withdraw", {
-              backgroundColor: "#d5281b",
-              color: "white"
-            })}
-          </>
+          <>{renderActionButton("Withdraw")}</>
         ) : null}
       </>
     );

--- a/cypress/component/forms/cct/CctSavedDrafts.cy.tsx
+++ b/cypress/component/forms/cct/CctSavedDrafts.cy.tsx
@@ -74,7 +74,7 @@ describe("CctSavedDrafts", () => {
       .should("exist")
       .click();
     // Check modal
-    cy.get('[data-cy="dialogModal"]').should("exist");
+    cy.get('[data-cy="dialogModal"]').should("be.visible");
     cy.get('[data-cy="ltft-declarations-modal-heading"]').contains(
       "Before proceeding to the main Changing hours (LTFT) application..."
     );
@@ -115,5 +115,15 @@ describe("CctSavedDrafts - not in the ltft pilot", () => {
     cy.get('[data-cy="delete-cct-btn-c96468cc-075c-4ac8-a5a2-1b53220a807e"]')
       .should("exist")
       .click();
+    cy.get('[data-cy="dialogModal"]').should("be.visible");
+    cy.get('[data-cy="warningLabel-Delete calculation"]').should("exist");
+    cy.get('[data-cy="warningText-Delete calculation"]')
+      .should("exist")
+      .contains(
+        "Are you sure you want to delete this calculation? This action cannot be undone."
+      );
+    cy.get('[data-cy="modal-cancel-btn"]').should("exist");
+    cy.get('[data-cy="submitBtn-Delete calculation"]').should("exist").click();
+    cy.get('[data-cy="dialogModal"]').should("not.be.visible");
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.123.0",
+  "version": "0.124.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.123.0",
+      "version": "0.124.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.123.0",
+  "version": "0.124.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -12,7 +12,7 @@ import {
   updatedEditPageNumber,
   updatedFormA
 } from "../redux/slices/formASlice";
-import store, { RootState } from "../redux/store/store";
+import store from "../redux/store/store";
 import {
   Field,
   Form,
@@ -166,7 +166,7 @@ export async function isFormDeleted(
   } else if (formName === "ltft") {
     await store.dispatch(deleteLtft(formId));
   }
-  const state = store.getState() as RootState;
+  const state = store.getState();
   return state[formName].status === "succeeded";
 }
 

--- a/utilities/hooks/useActionState.ts
+++ b/utilities/hooks/useActionState.ts
@@ -21,7 +21,7 @@ export function useActionState() {
   });
 
   const setAction = (label: ActionType, id: string, formName: FormName) => {
-    const actionType = label.toLowerCase() as keyof typeof ACTION_CONFIG;
+    const actionType = label.toLowerCase();
     const actionConfig = ACTION_CONFIG[actionType] || {
       warning: "",
       submitting: ""


### PR DESCRIPTION
- Add modal confirm step to CCT delete (consistent UX with LTFT delete)
- Utilize Amplify Button props more to style table buttons
- Fix some code smells before the new ones arrive

[TIS21-7221](https://hee-tis.atlassian.net/browse/TIS21-7221)

[TIS21-7221]: https://hee-tis.atlassian.net/browse/TIS21-7221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ