### PR TITLE
Fix/action modal button isSubmitting state

### DIFF
--- a/components/common/ActionModal.tsx
+++ b/components/common/ActionModal.tsx
@@ -1,6 +1,5 @@
 import { Modal } from "./Modal";
 import { Button, WarningCallout } from "nhsuk-react-components";
-import { useSubmitting } from "../../utilities/hooks/useSubmitting";
 import { Form, Formik } from "formik";
 import MultiChoiceInputField from "../forms/MultiChoiceInputField";
 import TextInputField from "../forms/TextInputField";
@@ -14,7 +13,7 @@ export type ReasonMsgObj = {
 };
 
 type ActionModalProps = {
-  onSubmit: (values: ReasonMsgObj) => void;
+  onSubmit: (values?: ReasonMsgObj) => void;
   isOpen: boolean;
   onClose: () => void;
   cancelBtnText: string;
@@ -22,6 +21,7 @@ type ActionModalProps = {
   warningText: string;
   submittingBtnText: string;
   actionType?: ActionType;
+  isSubmitting: boolean;
 };
 
 export function ActionModal({
@@ -32,9 +32,9 @@ export function ActionModal({
   warningLabel,
   warningText,
   submittingBtnText,
-  actionType
+  actionType,
+  isSubmitting = false
 }: Readonly<ActionModalProps>) {
-  const { isSubmitting } = useSubmitting();
   const hasReason = actionType === "Unsubmit" || actionType === "Withdraw";
 
   return (

--- a/components/forms/cct/CctSavedDraftsTable.tsx
+++ b/components/forms/cct/CctSavedDraftsTable.tsx
@@ -30,6 +30,7 @@ import { Button } from "@aws-amplify/ui-react";
 import { loadCctList } from "../../../redux/slices/cctListSlice";
 import { useSubmitting } from "../../../utilities/hooks/useSubmitting";
 import { ActionModal } from "../../common/ActionModal";
+import { sureText } from "../../../utilities/Constants";
 
 const columnHelper = createColumnHelper<CctCalculation>();
 
@@ -109,10 +110,9 @@ export function CctSavedDraftsTable() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isCctModalOpen, setIsCctModalOpen] = useState(false);
   const [calcIdToDelete, setCalcIdToDelete] = useState<string | null>(null);
-  const { startSubmitting, stopSubmitting } = useSubmitting();
+  const { isSubmitting, startSubmitting, stopSubmitting } = useSubmitting();
 
   const deleteCctCalcAndReloadList = async () => {
-    setIsCctModalOpen(false);
     startSubmitting();
     await store.dispatch(deleteCctCalc(calcIdToDelete as string));
     const deleteStatus = store.getState().cct.formDeleteStatus;
@@ -121,6 +121,7 @@ export function CctSavedDraftsTable() {
     }
     stopSubmitting();
     setCalcIdToDelete(null);
+    setIsCctModalOpen(false);
   };
 
   const columns = useMemo(
@@ -205,10 +206,10 @@ export function CctSavedDraftsTable() {
         isOpen={isCctModalOpen}
         onClose={() => setIsCctModalOpen(false)}
         cancelBtnText="Cancel"
-        warningLabel="Delete calculation"
-        warningText="Are you sure you want to delete this calculation? This action cannot be undone."
+        warningLabel="Deleting"
+        warningText={sureText}
         submittingBtnText="Deleting..."
-        actionType="Delete"
+        isSubmitting={isSubmitting}
       />
     </div>
   ) : (
@@ -230,7 +231,6 @@ export function RowCctActions({
   setCalcToDelete
 }: Readonly<RowLtftActionsProps>) {
   const isLtftPilot = useIsLtftPilot();
-  const { isSubmitting } = useSubmitting();
 
   const makeLtftBtnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
@@ -238,7 +238,7 @@ export function RowCctActions({
     setIsModalOpen(true);
   };
 
-  const makeCctBtnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const deleteCctBtnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     setCalcToDelete(row.id as string);
     setIsCctModalOpen(true);
@@ -265,10 +265,7 @@ export function RowCctActions({
         type="button"
         variation="destructive"
         size="small"
-        isDisabled={isSubmitting}
-        isLoading={isSubmitting}
-        loadingText="Deleting..."
-        onClick={makeCctBtnClick}
+        onClick={deleteCctBtnClick}
         data-cy={`delete-cct-btn-${row.id}`}
       >
         Delete

--- a/components/forms/cct/__test__/CctSavedDraftsTable.test.tsx
+++ b/components/forms/cct/__test__/CctSavedDraftsTable.test.tsx
@@ -40,7 +40,6 @@ describe("CctSavedDraftsTable - Delete Logic", () => {
 
   // Recreate the function to test directly
   const deleteCctCalcAndReloadList = async (): Promise<void> => {
-    setIsCctModalOpen(false);
     startSubmitting();
 
     // Mock the calcIdToDelete value directly
@@ -57,6 +56,7 @@ describe("CctSavedDraftsTable - Delete Logic", () => {
 
     stopSubmitting();
     setCalcIdToDelete(null);
+    setIsCctModalOpen(false);
   };
 
   beforeEach(() => {

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -47,7 +47,7 @@ export const LtftFormView = () => {
   }, [id, dispatch]);
 
   const ltftStatus = useAppSelector(state => state.ltft.status);
-  const { startSubmitting, stopSubmitting, isSubmitting } = useSubmitting();
+  const { isSubmitting, startSubmitting, stopSubmitting } = useSubmitting();
   const formData = useSelectFormData(ltftJson.name as FormName) as LtftObj;
   const canEditStatus = useAppSelector(state => state.ltft.canEdit);
   const cctSnapshot: CctCalculation = {
@@ -95,10 +95,11 @@ export const LtftFormView = () => {
   };
 
   const handleModalFormSubmit = async () => {
-    setShowModal(false);
     startSubmitting();
     await saveDraftForm(formJson, formData, false, true);
     stopSubmitting();
+    setShowModal(false);
+    resetAction();
   };
 
   if (ltftStatus === "loading") return <Loading />;
@@ -206,6 +207,7 @@ export const LtftFormView = () => {
           warningLabel={currentAction.type ?? ""}
           warningText={currentAction.warningText}
           submittingBtnText={currentAction.submittingText}
+          isSubmitting={isSubmitting}
         />
       </LtftViewWrapper>
     );

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -57,7 +57,7 @@ const LtftSummary = ({
   ltftSummaryList
 }: Readonly<LtftSummaryProps>) => {
   const [showModal, setShowModal] = useState(false);
-  const { startSubmitting, stopSubmitting } = useSubmitting();
+  const { isSubmitting, startSubmitting, stopSubmitting } = useSubmitting();
   const { currentAction, setAction, resetAction } = useActionState();
   const ltftSummaries = ltftSummaryList || [];
 
@@ -388,8 +388,7 @@ const LtftSummary = ({
               </table>
             </div>
             <ActionModal
-              onSubmit={async (reasonObj: ReasonMsgObj) => {
-                setShowModal(false);
+              onSubmit={async (reasonObj?: ReasonMsgObj) => {
                 store.dispatch(updatedLtftFormsRefreshNeeded(false));
                 startSubmitting();
                 const shouldStartOver = await handleLtftSummaryModalSub(
@@ -397,9 +396,11 @@ const LtftSummary = ({
                   reasonObj
                 );
                 stopSubmitting();
+                setShowModal(false);
                 if (shouldStartOver) {
                   checkPush("ltft", "formsList");
                 }
+                resetAction();
               }}
               isOpen={showModal}
               onClose={() => {
@@ -407,10 +408,11 @@ const LtftSummary = ({
                 resetAction();
               }}
               cancelBtnText="Cancel"
-              warningLabel={currentAction.type ?? ""}
+              warningLabel={currentAction.type as ActionType}
               warningText={currentAction.warningText}
               submittingBtnText={currentAction.submittingText}
               actionType={currentAction.type as ActionType}
+              isSubmitting={isSubmitting}
             />
           </>
         ) : (

--- a/cypress/component/common/ActionModal.cy.tsx
+++ b/cypress/component/common/ActionModal.cy.tsx
@@ -1,0 +1,44 @@
+import { mount } from "cypress/react18";
+import { ActionModal } from "../../../components/common/ActionModal";
+import { sureText } from "../../../utilities/Constants";
+
+const baseProps = {
+  isOpen: true,
+  cancelBtnText: "Cancel",
+  warningLabel: "Deleting",
+  warningText: sureText,
+  submittingBtnText: "Deleting",
+  isSubmitting: false
+};
+
+function mountActionModal(customProps = {}) {
+  const defaultProps = {
+    ...baseProps,
+    onSubmit: cy.stub().as("onSubmitHandler"),
+    onClose: cy.stub().as("onCloseHandler")
+  };
+  const props = { ...defaultProps, ...customProps };
+  return mount(<ActionModal {...props} />);
+}
+
+describe("ActionModal", () => {
+  it("shows normal state when not submitting", () => {
+    mountActionModal(); // default props
+
+    cy.get('[data-cy="submitBtn-Deleting"]')
+      .should("be.visible")
+      .should("not.be.disabled")
+      .should("contain", "Confirm & Continue");
+  });
+
+  it("shows submitting state when isSubmitting is true", () => {
+    mountActionModal({
+      isSubmitting: true
+    });
+
+    cy.get('[data-cy="submitBtn-Deleting"]')
+      .should("be.visible")
+      .should("be.disabled")
+      .should("contain", "Deleting...");
+  });
+});

--- a/cypress/component/forms/cct/CctSavedDrafts.cy.tsx
+++ b/cypress/component/forms/cct/CctSavedDrafts.cy.tsx
@@ -116,14 +116,12 @@ describe("CctSavedDrafts - not in the ltft pilot", () => {
       .should("exist")
       .click();
     cy.get('[data-cy="dialogModal"]').should("be.visible");
-    cy.get('[data-cy="warningLabel-Delete calculation"]').should("exist");
-    cy.get('[data-cy="warningText-Delete calculation"]')
+    cy.get('[data-cy="warningLabel-Deleting"]').should("exist");
+    cy.get('[data-cy="warningText-Deleting"]')
       .should("exist")
-      .contains(
-        "Are you sure you want to delete this calculation? This action cannot be undone."
-      );
+      .contains("Are you sure? This action cannot be undone.");
     cy.get('[data-cy="modal-cancel-btn"]').should("exist");
-    cy.get('[data-cy="submitBtn-Delete calculation"]').should("exist").click();
+    cy.get('[data-cy="submitBtn-Deleting"]').should("exist").click();
     cy.get('[data-cy="dialogModal"]').should("not.be.visible");
   });
 });

--- a/cypress/component/forms/ltft/LtftHome.cy.tsx
+++ b/cypress/component/forms/ltft/LtftHome.cy.tsx
@@ -8,6 +8,7 @@ import {
   updatedLtftSummaryListStatus
 } from "../../../../redux/slices/ltftSummaryListSlice";
 import { mockLtftsList1 } from "../../../../mock-data/mock-ltft-data";
+import { sureText } from "../../../../utilities/Constants";
 
 const mountLtftHome = () => {
   mount(
@@ -96,7 +97,7 @@ describe("LtftHome", () => {
         cy.get('[data-cy="warningLabel-Delete"]').contains("Delete");
         cy.get('[data-cy="warningText-Delete"]').should(
           "include.text",
-          "Deleting this application will permanently remove it."
+          `${sureText}`
         );
         cy.get('[data-cy="submitBtn-Delete"]').click();
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.124.0",
+  "version": "0.124.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.124.0",
+      "version": "0.124.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.124.0",
+  "version": "0.124.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/Constants.tsx
+++ b/utilities/Constants.tsx
@@ -589,20 +589,22 @@ export const fteOptions = [
   { value: 50, label: "50%" }
 ];
 
+export const sureText = "Are you sure? This action cannot be undone.";
+
 export const ACTION_CONFIG: Record<
   string,
   { warning: string; submitting: string }
 > = {
   submit: {
-    warning: "Please check the form details carefully before submitting.",
+    warning: "Have you checked the details carefully before submitting?",
     submitting: "Submitting"
   },
   delete: {
-    warning: "Deleting this application will permanently remove it.",
+    warning: `${sureText}`,
     submitting: "Deleting"
   },
   withdraw: {
-    warning: "Withdrawing this application cannot be undone.",
+    warning: `${sureText}`,
     submitting: "Withdrawing"
   },
   unsubmit: {

--- a/utilities/hooks/useActionState.ts
+++ b/utilities/hooks/useActionState.ts
@@ -11,14 +11,17 @@ export type ActionState = {
   formName: FormName | null;
 };
 
+const defaultActionState: ActionState = {
+  type: null,
+  warningText: "",
+  submittingText: "",
+  id: "",
+  formName: null
+};
+
 export function useActionState() {
-  const [currentAction, setCurrentAction] = useState<ActionState>({
-    type: null,
-    warningText: "",
-    submittingText: "",
-    id: "",
-    formName: null
-  });
+  const [currentAction, setCurrentAction] =
+    useState<ActionState>(defaultActionState);
 
   const setAction = (label: ActionType, id: string, formName: FormName) => {
     const actionType = label.toLowerCase();
@@ -37,13 +40,7 @@ export function useActionState() {
   };
 
   const resetAction = () => {
-    setCurrentAction({
-      type: null,
-      warningText: "",
-      submittingText: "",
-      id: "",
-      formName: null
-    });
+    setCurrentAction(defaultActionState);
   };
 
   return {


### PR DESCRIPTION
Another thing spotted on stage with slow internet connection...
Pass in isSubmitting state as prop to the ActionModal component to disable the dialog modal btn and display the correct btn text when the form is submitting.
Change the ordering of the modal close so that the submission logic runs first before closing the modal to ensure that the dialog modal button is still visible until the submission logic concludes.
Delete now redundant btn disable logic in the RowCctActions as it is now handled in the ActionModal component.

Note: the previous btn disable logic in the dialog modal did not work because the useSubmitting hook in the ActionModal component was not accessing the correct state value set in the parent component and so would always be false.

TIS21-7221