### PR TITLE
fix: form edit state bugs

### DIFF
--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -146,12 +146,15 @@ export default function FormBuilder({
     }
   }, [formData, currentPageFields, validationSchema, isFormDirty]);
 
-  const handlePageChange = (e: { preventDefault: () => void }) => {
+  const handlePageChange = (
+    e: { preventDefault: () => void },
+    isShortcut?: boolean
+  ) => {
     e.preventDefault();
     setIsFormDirty(false);
     validateFields(currentPageFields, formData, validationSchema)
       .then(() => {
-        if (currentPage === lastPage || canEditStatus) {
+        if (currentPage === lastPage || isShortcut) {
           continueToConfirm(jsonFormName, formData);
         } else {
           setCurrentPage(currentPage + 1);
@@ -285,7 +288,9 @@ export default function FormBuilder({
           {canEditStatus && (
             <Col width="one-half">
               <Button
-                onClick={handlePageChange}
+                onClick={(e: { preventDefault: () => void }) =>
+                  handlePageChange(e, true)
+                }
                 data-cy="BtnShortcutToConfirm"
                 disabled={Object.keys(formErrors).length > 0}
               >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.126.1",
+  "version": "0.126.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.126.1",
+      "version": "0.126.2",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.126.1",
+  "version": "0.126.2",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/redux/slices/formASlice.ts
+++ b/redux/slices/formASlice.ts
@@ -181,6 +181,8 @@ const formASlice = createSlice({
       })
       .addCase(loadSavedFormA.fulfilled, (state, action) => {
         state.status = "succeeded";
+        state.editPageNumber = 0;
+        state.canEdit = false;
         state.formData = action.payload;
       })
       .addCase(loadSavedFormA.rejected, (state, { error }) => {

--- a/redux/slices/formBSlice.ts
+++ b/redux/slices/formBSlice.ts
@@ -231,6 +231,8 @@ const formBSlice = createSlice({
       })
       .addCase(loadSavedFormB.fulfilled, (state, action) => {
         state.status = "succeeded";
+        state.editPageNumber = 0;
+        state.canEdit = false;
         state.formData =
           action.payload.covidFlagStatus &&
           action.payload.finalForm.haveCovidDeclarations === null

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -426,6 +426,8 @@ const ltftSlice = createSlice({
       })
       .addCase(loadSavedLtft.fulfilled, (state, action) => {
         state.status = "succeeded";
+        state.editPageNumber = 0;
+        state.canEdit = false;
         state.formData = action.payload;
       })
       .addCase(loadSavedLtft.rejected, (state, action) => {


### PR DESCRIPTION
fix: The form edit state is not being reset correctly when reopening a draft form after editing it.
fix: The ususal next-page navigation is incorrectly shortcutting to the Confirm page after editing.

TODO: Next commit will move the handlePageChange function out of FormBuilder so will write tests for it then.

NO TICKET