### PR TITLE
fix: form state reset fix

### DIFF
--- a/components/forms/FormsListBtn.tsx
+++ b/components/forms/FormsListBtn.tsx
@@ -1,9 +1,12 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "nhsuk-react-components";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
 import history from "../navigation/history";
 import { DateType } from "../../utilities/DateUtilities";
-import { loadTheSavedForm } from "../../utilities/FormBuilderUtilities";
+import {
+  loadTheSavedForm,
+  resetForm
+} from "../../utilities/FormBuilderUtilities";
 import { LifeCycleState } from "../../models/LifeCycleState";
 import { FormLinkerModal } from "./form-linker/FormLinkerModal";
 import {
@@ -33,6 +36,10 @@ const FormsListBtn = ({ pathName, latestSubDate }: IFormsListBtn) => {
   const isFormDeleting = useAppSelector(
     state => state[formName].status === "deleting"
   );
+
+  useEffect(() => {
+    resetForm(formName);
+  }, [formName, resetForm]);
 
   const handleBtnClick = async () => {
     // NOTE: this is needed for edge case where stale state from race between form click save event & redirect and auto update event.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.126.2",
+  "version": "0.126.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.126.2",
+      "version": "0.126.3",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.126.2",
+  "version": "0.126.3",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/redux/slices/formASlice.ts
+++ b/redux/slices/formASlice.ts
@@ -181,8 +181,6 @@ const formASlice = createSlice({
       })
       .addCase(loadSavedFormA.fulfilled, (state, action) => {
         state.status = "succeeded";
-        state.editPageNumber = 0;
-        state.canEdit = false;
         state.formData = action.payload;
       })
       .addCase(loadSavedFormA.rejected, (state, { error }) => {

--- a/redux/slices/formBSlice.ts
+++ b/redux/slices/formBSlice.ts
@@ -231,8 +231,6 @@ const formBSlice = createSlice({
       })
       .addCase(loadSavedFormB.fulfilled, (state, action) => {
         state.status = "succeeded";
-        state.editPageNumber = 0;
-        state.canEdit = false;
         state.formData =
           action.payload.covidFlagStatus &&
           action.payload.finalForm.haveCovidDeclarations === null

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -426,8 +426,6 @@ const ltftSlice = createSlice({
       })
       .addCase(loadSavedLtft.fulfilled, (state, action) => {
         state.status = "succeeded";
-        state.editPageNumber = 0;
-        state.canEdit = false;
         state.formData = action.payload;
       })
       .addCase(loadSavedLtft.rejected, (state, action) => {


### PR DESCRIPTION
Easier/more comprehensive fix. Rather than resetting form state for different actions in the form slices:

1. Add a useEffect hook in the FormsListBtn component to reset the form state when the button renders to either begin a new form or continue editing a draft one.
2. The Ltft form reset logic is already handled via a similar useLtftHomeStartover hook in the LtftHome component so no changes are needed there.

NO TICKET