### PR TITLE
fix: isArcp type bug

### DIFF
--- a/components/forms/form-builder/FormView.tsx
+++ b/components/forms/form-builder/FormView.tsx
@@ -30,6 +30,7 @@ import { FormLinkerSummary } from "../form-linker/FormLinkerSummary";
 import { FormRPartA } from "../../../models/FormRPartA";
 import { FormRPartB } from "../../../models/FormRPartB";
 import { useAppSelector } from "../../../redux/hooks/hooks";
+import { StringUtilities } from "../../../utilities/StringUtilities";
 
 type FormViewProps = {
   formData: FormData;
@@ -85,7 +86,7 @@ export const FormView = ({
   ]);
 
   const linkedFormData: LinkedFormRDataType = {
-    isArcp: formData.isArcp,
+    isArcp: StringUtilities.convertToBool(formData.isArcp),
     programmeMembershipId: formData.programmeMembershipId,
     localOfficeName: formData.localOfficeName
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.126.4",
+  "version": "0.126.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.126.4",
+      "version": "0.126.6",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.126.5",
+  "version": "0.126.6",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/StringUtilities.ts
+++ b/utilities/StringUtilities.ts
@@ -33,4 +33,12 @@ export class StringUtilities {
     if (!str) return str;
     return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
   }
+
+  public static convertToBool(
+    val: string | boolean | null | undefined
+  ): boolean {
+    if (val === true) return true;
+    if (typeof val === "string" && val.toLowerCase() === "true") return true;
+    return false;
+  }
 }

--- a/utilities/__test__/StringUtilities.test.ts
+++ b/utilities/__test__/StringUtilities.test.ts
@@ -34,3 +34,37 @@ describe("StringUtilities", () => {
     );
   });
 });
+it("should return true when string 'true' is passed", () => {
+  expect(StringUtilities.convertToBool("true")).toBe(true);
+});
+
+it("should return true when boolean true is passed", () => {
+  expect(StringUtilities.convertToBool(true)).toBe(true);
+});
+
+it("should return false when string 'false' is passed", () => {
+  expect(StringUtilities.convertToBool("false")).toBe(false);
+});
+
+it("should return false when boolean false is passed", () => {
+  expect(StringUtilities.convertToBool(false)).toBe(false);
+});
+
+it("should return false when null is passed", () => {
+  expect(StringUtilities.convertToBool(null)).toBe(false);
+});
+
+it("should return false when undefined is passed", () => {
+  expect(StringUtilities.convertToBool(undefined)).toBe(false);
+});
+
+it("should return false when any other string is passed", () => {
+  expect(StringUtilities.convertToBool("yes")).toBe(false);
+  expect(StringUtilities.convertToBool("1")).toBe(false);
+});
+
+it("should handle case-insensitive 'true' strings", () => {
+  expect(StringUtilities.convertToBool("TRUE")).toBe(true);
+  expect(StringUtilities.convertToBool("True")).toBe(true);
+  expect(StringUtilities.convertToBool("tRuE")).toBe(true);
+});


### PR DESCRIPTION
This commit fixes a bug where the isArcp formData value used in the FormView components is stored as a string type instead of a boolean, which leads to incorrect logic for determining what default linked programme to show and what options to choose from in the pre-submit FormLinkerModal.

NO TICKET