### PR TITLE
fix: duplicate draft form bug

### DIFF
--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -113,7 +113,8 @@ export default function FormBuilder({
     setIsFormDirty,
     currentPageFields,
     setCurrentPageFields,
-    jsonForm
+    jsonForm,
+    isAutosaving
   } = useFormContext();
 
   const jsonFormName = jsonForm.name;
@@ -305,10 +306,10 @@ export default function FormBuilder({
                 e.preventDefault();
                 handleSaveBtnClick();
               }}
-              disabled={isSubmitting} // need isAutoSaving too eventually
+              disabled={isSubmitting || isAutosaving}
               data-cy="BtnSaveDraft"
             >
-              {"Save & exit"}
+              {isSubmitting || isAutosaving ? "Saving..." : "Save & exit"}
             </Button>
           </Col>
           {formData.status?.current?.state != "UNSUBMITTED" ? (

--- a/components/forms/form-builder/FormContext.tsx
+++ b/components/forms/form-builder/FormContext.tsx
@@ -42,6 +42,7 @@ type FormContextType = {
   setFieldWidthData: React.Dispatch<
     React.SetStateAction<ReturnedWidthData | null>
   >;
+  isAutosaving: boolean;
 };
 
 const FormContext = createContext<FormContextType>({} as FormContextType);
@@ -78,11 +79,13 @@ export const FormProvider: React.FC<FormProviderProps> = ({
   );
   const [fieldWidthData, setFieldWidthData] =
     useState<ReturnedWidthData | null>(null);
+  const [isAutosaving, setIsAutosaving] = useState<boolean>(false);
 
   useFormAutosave(
     jsonForm,
     formData as FormRPartA | FormRPartB | LtftObj,
-    isFormDirty
+    isFormDirty,
+    setIsAutosaving
   );
 
   const updateFormData = (
@@ -195,7 +198,8 @@ export const FormProvider: React.FC<FormProviderProps> = ({
       fieldWarning,
       setFieldWarning,
       fieldWidthData,
-      setFieldWidthData
+      setFieldWidthData,
+      isAutosaving
     }),
     [
       formData,
@@ -205,7 +209,8 @@ export const FormProvider: React.FC<FormProviderProps> = ({
       handleBlur,
       handleChange,
       fieldWarning,
-      fieldWidthData
+      fieldWidthData,
+      isAutosaving
     ]
   );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.127.0",
+  "version": "0.127.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.127.0",
+      "version": "0.127.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",
@@ -13466,9 +13466,10 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -20117,9 +20118,9 @@
       "peer": true
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -23805,9 +23806,10 @@
       }
     },
     "node_modules/style-dictionary/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -35861,9 +35863,9 @@
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -40831,9 +40833,9 @@
           "peer": true
         },
         "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
           "peer": true,
           "requires": {
             "balanced-match": "^1.0.0"
@@ -43573,9 +43575,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
           "requires": {
             "balanced-match": "^1.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.127.0",
+  "version": "0.127.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/hooks/useFormAutosave.ts
+++ b/utilities/hooks/useFormAutosave.ts
@@ -8,20 +8,24 @@ import { Form } from "../../components/forms/form-builder/FormBuilder";
 const useFormAutosave = (
   jsonForm: Form,
   formData: FormDataType,
-  isFormDirty: boolean
+  isFormDirty: boolean,
+  setIsAutoSaving: (isAutoSaving: boolean) => void
 ) => {
   const formName = jsonForm.name;
   useEffect(() => {
     if (isFormDirty) {
+      setIsAutoSaving(true);
       const timeoutId = setTimeout(() => {
-        saveDraftForm(jsonForm, formData, true, false, false, false);
+        saveDraftForm(jsonForm, formData, true, false, false, false).finally(
+          () => setIsAutoSaving(false)
+        );
       }, 2000);
 
       return () => {
         clearTimeout(timeoutId);
       };
     }
-  }, [formData, formName, isFormDirty]);
+  }, [formData, formName, isFormDirty, setIsAutoSaving]);
 };
 
 export default useFormAutosave;


### PR DESCRIPTION
Add isAutosaving state to FormBuilder 'save & exit' button to disable it from the point a user edits the form until autosave complete to prevent a duplicate draft form (both FormR and LTFT).

The isAutosaving state is set in the useFormAutosave hook via setAutosave setter. The isAutosaving state is then shared via the context children prop to all child components including the FormBuilder component. In the useFormAutosave hook, the setAutosave is set to true outside the setTimeout to ensure there is no window between the user stopping editing and the form save process starting (currently after 2s) which would allow the user to click the 'save & exit' button potentially creating a duplicate draft form.

Aside from disabling the 'save & exit' button, the button text is also changed to 'Saving...' while editing/autosaving.