### PR TITLE
fix: autosave bug (created when fixing prev bug!)

### DIFF
--- a/components/forms/form-builder/FormContext.tsx
+++ b/components/forms/form-builder/FormContext.tsx
@@ -84,7 +84,6 @@ export const FormProvider: React.FC<FormProviderProps> = ({
   useFormAutosave(
     jsonForm,
     formData as FormRPartA | FormRPartB | LtftObj,
-    isFormDirty,
     setIsAutosaving
   );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.127.1",
+  "version": "0.127.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.127.1",
+      "version": "0.127.2",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.0",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.127.1",
+  "version": "0.127.2",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/hooks/useFormAutosave.ts
+++ b/utilities/hooks/useFormAutosave.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import {
   FormDataType,
   saveDraftForm
@@ -8,24 +8,32 @@ import { Form } from "../../components/forms/form-builder/FormBuilder";
 const useFormAutosave = (
   jsonForm: Form,
   formData: FormDataType,
-  isFormDirty: boolean,
   setIsAutoSaving: (isAutoSaving: boolean) => void
 ) => {
   const formName = jsonForm.name;
-  useEffect(() => {
-    if (isFormDirty) {
-      setIsAutoSaving(true);
-      const timeoutId = setTimeout(() => {
-        saveDraftForm(jsonForm, formData, true, false, false, false).finally(
-          () => setIsAutoSaving(false)
-        );
-      }, 2000);
+  const firstRender = useRef(false);
 
-      return () => {
-        clearTimeout(timeoutId);
-      };
+  useEffect(() => {
+    firstRender.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
     }
-  }, [formData, formName, isFormDirty, setIsAutoSaving]);
+    setIsAutoSaving(true);
+    const timeoutId = setTimeout(() => {
+      saveDraftForm(jsonForm, formData, true, false, false, false).finally(() =>
+        setIsAutoSaving(false)
+      );
+    }, 2000);
+
+    return () => {
+      clearTimeout(timeoutId);
+      setIsAutoSaving(false);
+    };
+  }, [formData, formName, setIsAutoSaving]);
 };
 
 export default useFormAutosave;


### PR DESCRIPTION
Previous [commit](27e3ea158c83051445deaf1e586668d923547580) fixes the duplicate draft form creation but introduces a new bug:
When a user begins editing a form field the autosave kicks in making 'save & exit' button is disabled and the button text shows 'Saving...'. So far so good but if a user then navigates to the next page before the autosave completes then the isAutoSaving state is not reset causing the 'save & exit' button to remain disabled etc.

fix: add a line to the useEffect return statement (see useFormAutosave.ts line 15) to reset the button state. Note, the return part of the useEffect is triggered when the user navigates to the next page and the isFormDirty state is reset (see FormBuilder.tsx handlePageChange function, line 156) i.e. when any of the dependencies in a useEffect change, the return function (known as a cleanup function) is called first before the effect runs again.

refactor: useFormAutosave.ts
Although the above change fixes the autosave bug, there is still a longstanding issue with the useFormAutosave hook. If the autosave is triggered and the user navigates to the next page, then autosave halts, cleanup is run etc.
It would be better if the current autosave continues to completion even if user navigates mid-cycle. To do this requires a refactor of the useFormAutosave hook.
1. Remove the isFormDirty conditional and dependency from the useEffect. However, if we aren't going to use the isFormDirty state to trigger the autosave, then we need to stop it firing on initial page load (which is what isFormDirty was for).
2. Add a firstRender ref (refs hold their state on re-renders) to the useFormAutosave hook to prevent the autosave from firing on page load. Add another useEffect (line 16) to set this to true (this useEffect will only run once on mount as it has no dependencies). A useEffect is needed because ReactStrictMode intentionally runs effects twice in development mode to help with identifying any idempotency issues.
3. Add some conditional logic to the original useEffect (line 21) to prevent the autosave from firing if firstRender is true i.e. first rendef/page load.

[TIS21-7417](https://hee-tis.atlassian.net/browse/TIS21-7417)