### PR TITLE
feat: ignore non-REVIEW_DATA actions

### DIFF
--- a/components/common/PanelsCreator.tsx
+++ b/components/common/PanelsCreator.tsx
@@ -63,7 +63,9 @@ export function PanelsCreator({
             ...filteredPanel
           } = panel;
           const currentAction = unreviewedActions.filter(
-            action => action.tisReferenceInfo.id === panel.tisId
+            action =>
+              action.tisReferenceInfo.id === panel.tisId &&
+              action.type === "REVIEW_DATA"
           );
           return (
             <Card.GroupItem key={index} width="one-half">

--- a/mock-data/trainee-profile.ts
+++ b/mock-data/trainee-profile.ts
@@ -867,6 +867,18 @@ export const mockOutstandingActions: TraineeAction[] = [
     },
     availableFrom: new Date(oneWeekAgo),
     dueBy: new Date(yesterday)
+  },
+  //non REVIEW_DATA type action
+  {
+    id: "6",
+    type: "another type",
+    traineeTisId: "12345",
+    tisReferenceInfo: {
+      id: "315",
+      type: TisReferenceType.placement
+    },
+    availableFrom: new Date(oneWeekAgo),
+    dueBy: new Date(yesterday)
   }
 ];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.127.3",
+  "version": "0.127.4",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.0",

--- a/utilities/ActionSummaryUtilities.ts
+++ b/utilities/ActionSummaryUtilities.ts
@@ -23,12 +23,14 @@ export function getAllOutstandingSummaryActions(
   const programmeActions = traineeActionsData.filter(
     action =>
       action.tisReferenceInfo.type === TisReferenceType.programmeMembership &&
-      today >= dayjs(action.availableFrom).format("YYYY-MM-DD")
+      today >= dayjs(action.availableFrom).format("YYYY-MM-DD") &&
+      action.type === "REVIEW_DATA"
   );
   const placementActions = traineeActionsData.filter(
     action =>
       action.tisReferenceInfo.type === TisReferenceType.placement &&
-      today >= dayjs(action.availableFrom).format("YYYY-MM-DD")
+      today >= dayjs(action.availableFrom).format("YYYY-MM-DD") &&
+      action.type === "REVIEW_DATA"
   );
   return {
     unsignedCojCount,


### PR DESCRIPTION
Pending a big rewrite to use them on the action summary.

New action types added in: https://github.com/Health-Education-England/tis-trainee-actions/pull/64

TIS21-7472