### PR TITLE
fix: open in-page support links in new tab/window

### DIFF
--- a/components/forms/cct/CctCalcCreate.tsx
+++ b/components/forms/cct/CctCalcCreate.tsx
@@ -109,7 +109,9 @@ export function CctCalcCreate() {
             </p>
             <p>
               If your programme is not listed, please{" "}
-              <Link to="/support">contact your Local Office support</Link>
+              <Link to="/support" target="_blank">
+                contact your Local Office support
+              </Link>
             </p>
           </WarningCallout>
           {progsArrNotPast.length > 0 ? (

--- a/components/forms/cct/CctHome.tsx
+++ b/components/forms/cct/CctHome.tsx
@@ -28,7 +28,10 @@ export function CctHome() {
         </WarningCallout.Label>
         <p>
           If your programme is not listed or any of the details are incorrect,
-          please <Link to="/support">contact your Local Office support</Link>
+          please{" "}
+          <Link to="/support" target="_blank">
+            contact your Local Office support
+          </Link>
         </p>
       </WarningCallout>
       <p className={style.panelSubHeader} data-cy="cct-home-subheader-prog">

--- a/components/forms/ltft/LtftDeclarationsModal.tsx
+++ b/components/forms/ltft/LtftDeclarationsModal.tsx
@@ -44,7 +44,10 @@ export const LtftDeclarationsModal = ({
             Your pre-approver will usually be your Training Programme Director
             (TPD), but for GP programmes may be your GP Programme Manager. If
             you are unsure who your pre-approver is, please{" "}
-            <Link to="/support">contact your Local Office support</Link>.
+            <Link to="/support" target="_blank">
+              contact your Local Office support
+            </Link>
+            .
           </Hint>
           <Checkboxes.Box
             name="understandStartover"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.128.2",
+  "version": "0.128.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.128.2",
+      "version": "0.128.3",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.11.1",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.128.2",
+  "version": "0.128.3",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^6.11.1",

--- a/utilities/Constants.tsx
+++ b/utilities/Constants.tsx
@@ -489,7 +489,10 @@ export const onboardingTrackerInfoText = {
     <p>
       If you do notice any discrepancies when reviewing the{" "}
       <Link to="/programmes">Programme</Link> data, please contact{" "}
-      <Link to="/support">Local Office support</Link>.
+      <Link to="/support" target="_blank">
+        Local Office support
+      </Link>
+      .
     </p>
   ),
   SIGN_COJ: (
@@ -555,7 +558,11 @@ export const onboardingTrackerInfoText = {
       </p>
       <p>
         If you do notice any discrepancies when reviewing the Placement details,
-        please contact <Link to="/support">Local Office support</Link>.
+        please contact{" "}
+        <Link to="/support" target="_blank">
+          Local Office support
+        </Link>
+        .
       </p>
     </>
   ),


### PR DESCRIPTION
When clicking support prompts on pages such as the CCT Calculator the trainee is routed to the support page in the current tab, potentially losing progress/track of what they were doing.

NO-TICKET