### PR TITLE
feat: show rejected LTFT

### DIFF
--- a/components/common/ActionModal.tsx
+++ b/components/common/ActionModal.tsx
@@ -58,8 +58,8 @@ export function ActionModal({
                   type="radios"
                   items={
                     actionType === "Unsubmit"
-                      ? [...ACTION_REASONS.UNSUBMIT, ACTION_REASONS.OTHER]
-                      : [...ACTION_REASONS.WITHDRAW, ACTION_REASONS.OTHER]
+                      ? [...ACTION_REASONS.UNSUBMIT]
+                      : [...ACTION_REASONS.WITHDRAW]
                   }
                   label={`Please choose the primary reason for the ${actionType.toLowerCase()}`}
                   id="reason"

--- a/components/forms/ltft/LtftStatusDetails.tsx
+++ b/components/forms/ltft/LtftStatusDetails.tsx
@@ -28,7 +28,8 @@ export const LtftStatusDetails = (formData: LtftObj) => {
             </SummaryList.Row>
             <SummaryList.Row>
               <SummaryList.Key>
-                {StringUtilities.capitalize(formData.status?.current?.state)} date
+                {StringUtilities.capitalize(formData.status?.current?.state)}{" "}
+                date
               </SummaryList.Key>
               <SummaryList.Value data-cy="ltftModified">
                 {dayjs(formData.lastModified).toString()}

--- a/components/forms/ltft/LtftStatusDetails.tsx
+++ b/components/forms/ltft/LtftStatusDetails.tsx
@@ -21,21 +21,22 @@ export const LtftStatusDetails = (formData: LtftObj) => {
               </SummaryList.Value>
             </SummaryList.Row>
             <SummaryList.Row>
-              <SummaryList.Key>Created</SummaryList.Key>
+              <SummaryList.Key>Created date</SummaryList.Key>
               <SummaryList.Value data-cy="ltftCreated">
                 {dayjs(formData.created).toString()}
               </SummaryList.Value>
             </SummaryList.Row>
             <SummaryList.Row>
               <SummaryList.Key>
-                {StringUtilities.capitalize(formData.status?.current?.state)}
+                {StringUtilities.capitalize(formData.status?.current?.state)} date
               </SummaryList.Key>
               <SummaryList.Value data-cy="ltftModified">
                 {dayjs(formData.lastModified).toString()}
               </SummaryList.Value>
             </SummaryList.Row>
             {(formData.status?.current?.state === "UNSUBMITTED" ||
-              formData.status?.current?.state === "WITHDRAWN") && (
+              formData.status?.current?.state === "WITHDRAWN" ||
+              formData.status?.current?.state === "REJECTED") && (
               <>
                 <SummaryList.Row>
                   <SummaryList.Key>

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -147,8 +147,11 @@ const LtftSummary = ({
     <span>{props.renderValue()}</span>
   );
   const renderDayValue = (props: { renderValue: () => ReactNode }) => (
-    <time dateTime={`props.renderValue()`} data-tooltip={dayjs(props.renderValue() as Date | string).toString()}>
-      {dayjs(props.renderValue() as Date | string).format('D MMM YYYY')}
+    <time
+      dateTime={`props.renderValue()`}
+      data-tooltip={dayjs(props.renderValue() as Date | string).toString()}
+    >
+      {dayjs(props.renderValue() as Date | string).format("D MMM YYYY")}
     </time>
   );
 

--- a/components/forms/ltft/LtftSummary.tsx
+++ b/components/forms/ltft/LtftSummary.tsx
@@ -41,7 +41,7 @@ import InfoTooltip from "../../common/InfoTooltip";
 
 type LtftFormStatusSub = Extract<
   LtftFormStatus,
-  "SUBMITTED" | "APPROVED" | "WITHDRAWN" | "DRAFT" | "UNSUBMITTED"
+  "SUBMITTED" | "APPROVED" | "WITHDRAWN" | "DRAFT" | "UNSUBMITTED" | "REJECTED"
 >;
 
 type LtftSummaryType = "CURRENT" | "PREVIOUS";
@@ -68,7 +68,8 @@ const LtftSummary = ({
     APPROVED: true,
     WITHDRAWN: true,
     DRAFT: true,
-    UNSUBMITTED: true
+    UNSUBMITTED: true,
+    REJECTED: true
   });
 
   const filteredLtftSummaries = ltftSummaries.filter(
@@ -105,21 +106,12 @@ const LtftSummary = ({
       data-cy={`table-column_${column.id}`}
     />
   );
-  const renderCreatedHeader = ({
-    column
-  }: HeaderContext<LtftSummaryObj, unknown>) => (
-    <TableColumnHeader
-      column={column}
-      title="Created"
-      data-cy={`table-column_${column.id}`}
-    />
-  );
   const renderLastModifiedHeader = ({
     column
   }: HeaderContext<LtftSummaryObj, unknown>) => (
     <TableColumnHeader
       column={column}
-      title="Updated"
+      title="Last Updated"
       data-cy={`table-column_${column.id}`}
     />
   );
@@ -155,7 +147,9 @@ const LtftSummary = ({
     <span>{props.renderValue()}</span>
   );
   const renderDayValue = (props: { renderValue: () => ReactNode }) => (
-    <span>{dayjs(props.renderValue() as Date | string).toString()}</span>
+    <time dateTime={`props.renderValue()`} data-tooltip={dayjs(props.renderValue() as Date | string).toString()}>
+      {dayjs(props.renderValue() as Date | string).format('D MMM YYYY')}
+    </time>
   );
 
   const renderStatusColumnValue = (props: {
@@ -193,7 +187,8 @@ const LtftSummary = ({
           props.row.original.statusReason
         )}
         {(props.row.original.status === "UNSUBMITTED" ||
-          props.row.original.status === "WITHDRAWN") &&
+          props.row.original.status === "WITHDRAWN" ||
+          props.row.original.status === "REJECTED") &&
         props.row.original.statusMessage ? (
           <Label size="s" onClick={handleTooltipClick}>
             <InfoTooltip
@@ -259,12 +254,6 @@ const LtftSummary = ({
       header: renderNameHeader,
       cell: renderValue
     }),
-    columnHelper.accessor("created", {
-      id: "created",
-      header: renderCreatedHeader,
-      cell: renderDayValue,
-      sortingFn: "datetime"
-    }),
     columnHelper.accessor("lastModified", {
       id: "lastModified",
       header: renderLastModifiedHeader,
@@ -321,7 +310,7 @@ const LtftSummary = ({
   if (ltftSummaryType === "CURRENT") {
     statusFilters = ["DRAFT", "UNSUBMITTED"];
   } else if (ltftSummaryType === "PREVIOUS") {
-    statusFilters = ["APPROVED", "SUBMITTED", "WITHDRAWN"];
+    statusFilters = ["APPROVED", "REJECTED", "SUBMITTED", "WITHDRAWN"];
   }
 
   let content: JSX.Element = <></>;

--- a/cypress/component/forms/ltft/LtftFormView.cy.tsx
+++ b/cypress/component/forms/ltft/LtftFormView.cy.tsx
@@ -12,6 +12,7 @@ import {
 import {
   mockLtftDraft0,
   mockLtftDraft1,
+  mockLtftRejected0,
   mockLtftUnsubmitted0
 } from "../../../../mock-data/mock-ltft-data";
 import { LtftFormView } from "../../../../components/forms/ltft/LtftFormView";
@@ -224,6 +225,27 @@ describe("LTFT Form View - unsubmitted", () => {
     cy.get('[data-cy="BtnSubmit"]').should("exist").contains("Re-submit");
     cy.get('[data-cy="BtnSaveDraft"]').should("exist");
     cy.get('[data-cy="startOverButton"]').should("not.exist");
+  });  
+});
+
+describe("LTFT Form View - rejected", () => {
+  before(() => {
+    mountLtftViewWithMockData(mockLtftRejected0);
+  });
+
+  it("should render rejected reason", () => {
+    // status details section
+    cy.get('[data-cy="REJECTED-header"]')
+      .should("exist")
+      .contains("Rejected application");
+    cy.get('[data-cy="ltftName"]').contains("my Rejected LTFT");
+    cy.get('[data-cy="ltftCreated"]').should("exist");
+    cy.get('[data-cy="ltftModified"]').should("exist");
+    cy.get('[data-cy="ltfReason"]').contains("Rejected reason");
+    cy.get('[data-cy="ltftModifiedBy"]').contains("TIS Admin");
+    cy.get('[data-cy="ltftMessage"]').contains("Rejected message");
+    cy.get('[data-cy="ltftRef"]').contains("ltft_5_001");
+    cy.get('[data-cy="supportingInformation-value"]').contains("Not provided");
   });  
 });
 

--- a/cypress/component/forms/ltft/LtftSummary.cy.tsx
+++ b/cypress/component/forms/ltft/LtftSummary.cy.tsx
@@ -28,10 +28,10 @@ describe("LtftSummary Component", () => {
     it("should sort by lastModified descending by default", () => {
       cy.get('[data-cy^="ltft-row-"]')
         .eq(0)
-        .should("include.text", "Wed, 15 Jan 2025 15:50:36 GMT");
+        .should("include.text", "15 Jan 2025");
       cy.get('[data-cy^="ltft-row-"]')
         .eq(3)
-        .should("include.text", "Thu, 15 Aug 2024 15:50:36 GMT");
+        .should("include.text", "15 Aug 2024");
     });
 
     it("should change sort order when clicking column headers", () => {
@@ -66,7 +66,7 @@ describe("LtftSummary Component", () => {
       cy.get('[data-cy^="ltft-row-"]').should("have.length", 4);
       cy.get('[data-cy="filterUNSUBMITTEDLtft"]').click();
       cy.get('[data-cy^="ltft-row-"]').should("have.length", 2);
-      cy.contains("Wed, 15 Jan 2025 15:50:36 GMT").should("exist");
+      cy.contains("15 Jan 2025").should("exist");
       cy.contains("Programme hours reduction 2").should("not.exist");
       cy.contains("Programme hours reduction 5").should("not.exist");
     });
@@ -94,7 +94,7 @@ describe("LtftSummary Component", () => {
         .find('[data-cy$="-statusMessage-icon"]')
         .should("not.exist");
       cy.get('[data-cy="3_reason"]')
-        .should("contain.text", "Other reason")
+        .should("contain.text", "other reason")
         .find('[data-cy$="-statusMessage-icon"]')
         .click();
       cy.get(".tooltipContent")
@@ -121,8 +121,9 @@ describe("LtftSummary Component", () => {
       );
     });
 
-    it("should display APPROVED, SUBMITTED, and WITHDRAWN filters", () => {
+    it("should display APPROVED, REJECTED, SUBMITTED, and WITHDRAWN filters", () => {
       cy.get('[data-cy="filterAPPROVEDLtft"]').should("exist");
+      cy.get('[data-cy="filterREJECTEDLtft"]').should("exist");
       cy.get('[data-cy="filterSUBMITTEDLtft"]').should("exist");
       cy.get('[data-cy="filterWITHDRAWNLtft"]').should("exist");
       cy.get('[data-cy="filterDRAFTLtft"]').should("not.exist");
@@ -132,6 +133,11 @@ describe("LtftSummary Component", () => {
     it("should filter table when toggling APPROVED status", () => {
       cy.get('[data-cy="filterAPPROVEDLtft"]').click();
       cy.contains("Programme hours reduction 1").should("not.exist");
+    });
+
+    it("should filter table when toggling REJECTED status", () => {
+      cy.get('[data-cy="filterREJECTEDLtft"]').click();
+      cy.contains("Programme hours reduction 5").should("not.exist");
     });
 
     it("should filter table when toggling SUBMITTED status", () => {
@@ -146,6 +152,7 @@ describe("LtftSummary Component", () => {
     });
 
     it("should show only relevant rows when multiple filters are combined", () => {
+      cy.get('[data-cy="filterREJECTEDLtft"]').click();
       cy.get('[data-cy="filterSUBMITTEDLtft"]').click();
       cy.get('[data-cy="filterWITHDRAWNLtft"]').click();
       cy.get('[data-cy^="ltft-row-"]').should("have.length", 2);
@@ -153,6 +160,19 @@ describe("LtftSummary Component", () => {
         .last()
         .should("include.text", "ltft_-1_002");
       cy.contains("Programme hours reduction 1").should("exist");
+    });    
+
+    it("should show reason and message on REJECTED application", () => {
+      cy.get('[data-cy="5_reason"]')
+        .should("contain.text", "Rejected Reason")
+        .find('[data-cy$="-statusMessage-icon"]')
+        .click();
+      cy.get(".tooltipContent")
+        .should("be.visible")
+        .and(
+          "contain.text",
+          "Rejected Message"
+        );
     });
   });
 });

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -104,6 +104,18 @@ export const mockLtftsList1 = [
     statusReason: "",
     statusMessage: "",
     modifiedByRole: ""
+  },
+  {
+    id: "123e4567-e89b-12d3-a456-426614174001",
+    name: "Programme hours reduction 5",
+    programmeMembershipId: "2861fb68-6c08-4af5-a3a1-6f561a37b406",
+    status: "REJECTED",
+    created: "2024-08-15T14:50:36.941Z",
+    lastModified: "2024-08-15T15:50:36.941Z",
+    formRef: "ltft_-1_006",
+    statusReason: "Rejected Reason",
+    statusMessage: "Rejected Message",
+    modifiedByRole: ""
   }
 ];
 
@@ -234,6 +246,69 @@ export const mockLtftUnsubmitted0: LtftObj = {
       detail: {
         reason: "changePercentage",
         message: "status reason message"
+      },
+      modifiedBy: {
+        name: "Admin Name",
+        email: "admin@nhs.net",
+        role: "ADMIN"
+      },
+      timestamp: "",
+      revision: 0
+    },
+    history: []
+  }
+};
+
+export const mockLtftRejected0: LtftObj = {
+  traineeTisId: "4",
+  name: "my Rejected LTFT",
+  formRef: "ltft_5_001",
+  change: {
+    calculationId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    cctDate: "2028-04-02",
+    type: "LTFT",
+    startDate: "2027-01-01",
+    wte: 0.8,
+    changeId: "fc13458c-5b0b-442f-8907-6f9af8fc0ffb"
+  },
+  declarations: {
+    discussedWithTpd: true,
+    informationIsCorrect: null,
+    notGuaranteed: null
+  },
+  tpdName: "",
+  tpdEmail: "",
+  otherDiscussions: null,
+  personalDetails: {
+    title: "Mr",
+    surname: "Gilliam",
+    forenames: "Anthony Mara",
+    telephoneNumber: "01632960363",
+    mobileNumber: "07465879348",
+    email: "email@email.com",
+    gmcNumber: "1111111",
+    gdcNumber: "",
+    publicHealthNumber: "",
+    skilledWorkerVisaHolder: null
+  },
+  programmeMembership: {
+    id: "a6de88b8-de41-48dd-9492-a518f5001176",
+    name: "Cardiology",
+    startDate: "2020-01-01",
+    endDate: "2028-01-01",
+    wte: 1,
+    designatedBodyCode: "WTF3",
+    managingDeanery: "North North West"
+  },
+  reasonsSelected: null,
+  reasonsOtherDetail: null,
+  supportingInformation: null,
+  status: {
+    current: {
+      state: "REJECTED",
+      detail: {
+        reason: "Rejected reason",
+        message: "Rejected message"
       },
       modifiedBy: {
         name: "Admin Name",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.128.3",
+  "version": "0.129.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^6.11.1",

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1136,3 +1136,23 @@ html:has(dialog[data-cy="formLinkerModal"][open]) {
   margin-left: 3rem;
   padding-left: 0.25rem;
 }
+
+time {
+  position: relative;
+  cursor: pointer;
+}
+
+time:hover::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #333;
+  color: #fff;
+  padding: 10px 10px;
+  border-radius: 4px;
+  white-space: nowrap;
+  font-size: 16px;
+  z-index: 99;
+}

--- a/utilities/Constants.tsx
+++ b/utilities/Constants.tsx
@@ -617,10 +617,12 @@ export const ACTION_CONFIG: Record<
 };
 
 export const ACTION_REASONS = {
-  OTHER: { value: "other", label: "other reason" },
   UNSUBMIT: [
     { value: "changePercentage", label: "Change WTE percentage" },
-    { value: "changeStartDate", label: "Change start date" }
+    { value: "changeStartDate", label: "Change start date" },
+    { value: "other", label: "other reason" }
   ],
-  WITHDRAW: [{ value: "changeOfCircs", label: "Change of circumstances" }]
+  WITHDRAW: [
+    { value: "changeOfCircs", label: "Change of circumstances" },
+    { value: "other", label: "other reason" }]
 };

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -376,18 +376,18 @@ export function getStatusReasonLabel(
   if (status === "UNSUBMITTED" && statusReason) {
     return (
       ACTION_REASONS.UNSUBMIT.find(reason => reason.value === statusReason)
-        ?.label ?? "Other reason"
+        ?.label ?? statusReason
     );
   }
 
   if (status === "WITHDRAWN" && statusReason) {
     return (
       ACTION_REASONS.WITHDRAW.find(reason => reason.value === statusReason)
-        ?.label ?? "Other reason"
+        ?.label ?? statusReason
     );
   }
 
-  return "";
+  return statusReason || "";
 }
 
 export function isValidProgramme(progId: string): boolean {


### PR DESCRIPTION
What is included:
- Show REJECTED application with reason in `Previous Application` table on TSS LTFT tab
- Remove `Created` column in summary tables
- Change `Updated` column header to `Last Updated`
- Summary table filter of REJECTED status
- Shown REJECTED application form detail when row click on summary table
- Display date without timestamp in `Last Updated` column, but shown detailed time when mouseover
- Fix logic of `getStatusReasonLabel()` for UNSUBMITTED and WITHDRAWN to show actual value of reason if no matched label instead of "other". (This fix the value mismatch when LTFT is unsubmitted from TIS with reason `Proposed start date` being shown as `other reason`)

<img width="1001" height="563" alt="image" src="https://github.com/user-attachments/assets/8eb8e5a0-42fd-4c52-9177-fdaefb5495c2" />


TIS21-7524
TIS21-7573
TIS21-7575
TIS21-7576
TIS21-7577