### PR TITLE
fix: update notification to fit paged endpoint

### DIFF
--- a/components/navigation/TSSHeader.tsx
+++ b/components/navigation/TSSHeader.tsx
@@ -21,7 +21,13 @@ const TSSHeader = () => {
 
   useEffect(() => {
     if (notificationsStatus === "idle") {
-      dispatch(getNotifications());
+      dispatch(
+        getNotifications({
+          page: "0",
+          size: "0",
+          type: "IN_APP"
+        })
+      );
     }
   }, [notificationsStatus, dispatch]);
 

--- a/mock-data/mock-notifications-data.ts
+++ b/mock-data/mock-notifications-data.ts
@@ -1,0 +1,16 @@
+import { NotificationType } from "../redux/slices/notificationsSlice";
+
+export const inAppNotifications : NotificationType[] = [
+  {
+    id: "68c95c696a84c134c740b0e2",
+    tisReference: "52c7d01c-7595-4a9b-a875-f192c1e1ffb8",
+    type: "IN_APP",
+    subject: "SPONSORSHIP",
+    subjectText: "Sponsorship",
+    contact: null,
+    sentAt: new Date("2025-03-01T15:21:02.939Z"),
+    readAt: new Date("2025-04-01T15:21:02.939Z"),
+    status: "UNREAD",
+    statusDetail: null
+  }
+];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.134.0",
+  "version": "0.134.1",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^6.11.1",

--- a/redux/slices/notificationsSlice.ts
+++ b/redux/slices/notificationsSlice.ts
@@ -140,7 +140,7 @@ const notificationsSlice = createSlice({
         state.status = "succeeded";
         state.notificationsList = action.payload.content;
         state.unreadNotificationCount = unreadNotificationsCount(
-          action.payload ?? 0
+          action.payload.content ?? 0
         );
       })
       .addCase(getNotifications.rejected, (state, { error }) => {
@@ -227,10 +227,9 @@ export const {
   updatedNotificationUpdateInProgress
 } = notificationsSlice.actions;
 
-export function unreadNotificationsCount(notificationsData: NotificationPage) {
-  let notifications = notificationsData.content;
-  if (!Array.isArray(notifications)) return 0;
-  const unreadNotifications = notifications.filter(
+export function unreadNotificationsCount(notificationsData: any[]) {
+  if (!Array.isArray(notificationsData)) return 0;
+  const unreadNotifications = notificationsData.filter(
     notification => notification.status === "UNREAD"
   );
   return unreadNotifications.length;

--- a/redux/slices/notificationsSlice.ts
+++ b/redux/slices/notificationsSlice.ts
@@ -227,7 +227,7 @@ export const {
   updatedNotificationUpdateInProgress
 } = notificationsSlice.actions;
 
-export function unreadNotificationsCount(notificationsData: any[]) {
+export function unreadNotificationsCount(notificationsData: NotificationType[]) {
   if (!Array.isArray(notificationsData)) return 0;
   const unreadNotifications = notificationsData.filter(
     notification => notification.status === "UNREAD"

--- a/redux/slices/notificationsSlice.ts
+++ b/redux/slices/notificationsSlice.ts
@@ -10,6 +10,18 @@ export type NotificationStatus =
   | "SENT"
   | "ARCHIVED";
 
+export type NotificationPage = {
+  content: NotificationType[];
+  page: PageDetails;
+};
+
+export type PageDetails = {
+  size: number;
+  number: number;
+  totalElements: number;
+  totalPages:number;
+};
+
 export type NotificationMsgType = "IN_APP";
 
 export type NotificationType = {
@@ -51,10 +63,10 @@ export const initialState: NotificationsState = {
 
 export const getNotifications = createAsyncThunk(
   "notifications/getNotifications",
-  async () => {
+  async (params?: Record<string, string>) => {
     const notificationService = new TraineeNotificationsService();
-    const response = await notificationService.getAllNotifications();
-    return response.data.filter(n => n.type == "IN_APP");
+    const response = await notificationService.getAllNotifications(params);
+    return response.data;
   }
 );
 
@@ -126,7 +138,7 @@ const notificationsSlice = createSlice({
       })
       .addCase(getNotifications.fulfilled, (state, action) => {
         state.status = "succeeded";
-        state.notificationsList = action.payload;
+        state.notificationsList = action.payload.content;
         state.unreadNotificationCount = unreadNotificationsCount(
           action.payload ?? 0
         );
@@ -215,9 +227,10 @@ export const {
   updatedNotificationUpdateInProgress
 } = notificationsSlice.actions;
 
-export function unreadNotificationsCount(notificationsData: any[]) {
-  if (!Array.isArray(notificationsData)) return 0;
-  const unreadNotifications = notificationsData.filter(
+export function unreadNotificationsCount(notificationsData: NotificationPage) {
+  let notifications = notificationsData.content;
+  if (!Array.isArray(notifications)) return 0;
+  const unreadNotifications = notifications.filter(
     notification => notification.status === "UNREAD"
   );
   return unreadNotifications.length;

--- a/services/TraineeNotificationsService.ts
+++ b/services/TraineeNotificationsService.ts
@@ -1,13 +1,21 @@
 import { AxiosResponse } from "axios";
 import ApiService from "./apiService";
+import { NotificationPage } from "../redux/slices/notificationsSlice";
 
 export class TraineeNotificationsService extends ApiService {
   constructor() {
     super("/api");
   }
-
-  async getAllNotifications(): Promise<AxiosResponse<any[]>> {
-    return this.get<any[]>(`/notifications`);
+  async getAllNotifications(
+    params?: Record<string, string | number>
+  ): Promise<AxiosResponse<NotificationPage>> {    
+    const page = params?.page ? params?.page : "";
+    const size = params?.size ? params?.size : "";
+    const sort = params?.sort ? params?.sort : "";
+    const type = params?.type ? params?.type : "";
+    const status = params?.status ? params?.status : "";
+    const keyword = params?.keyword ? params?.keyword : "";
+    return this.get<NotificationPage>(`/notifications?page=${page}&size=${size}&sort=${sort}&type=${type}&status=${status}&keyword=${keyword}`);
   }
 
   async markNotificationAsRead(

--- a/services/TraineeNotificationsService.ts
+++ b/services/TraineeNotificationsService.ts
@@ -6,16 +6,21 @@ export class TraineeNotificationsService extends ApiService {
   constructor() {
     super("/api");
   }
+  
   async getAllNotifications(
     params?: Record<string, string | number>
-  ): Promise<AxiosResponse<NotificationPage>> {    
-    const page = params?.page ? params?.page : "";
-    const size = params?.size ? params?.size : "";
-    const sort = params?.sort ? params?.sort : "";
-    const type = params?.type ? params?.type : "";
-    const status = params?.status ? params?.status : "";
-    const keyword = params?.keyword ? params?.keyword : "";
-    return this.get<NotificationPage>(`/notifications?page=${page}&size=${size}&sort=${sort}&type=${type}&status=${status}&keyword=${keyword}`);
+  ): Promise<AxiosResponse<NotificationPage>> {
+    const searchParams = new URLSearchParams();
+  
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined && value !== null) {
+          searchParams.append(key, String(value));
+        }
+      }
+    }
+  
+    return this.get<NotificationPage>(`/notifications?${searchParams.toString()}`);
   }
 
   async markNotificationAsRead(

--- a/services/TraineeNotificationsService.ts
+++ b/services/TraineeNotificationsService.ts
@@ -14,13 +14,17 @@ export class TraineeNotificationsService extends ApiService {
   
     if (params) {
       for (const [key, value] of Object.entries(params)) {
-        if (value !== undefined && value !== null) {
+        if (value !== undefined && value !== null && value !== "") {
           searchParams.append(key, String(value));
         }
       }
     }
   
-    return this.get<NotificationPage>(`/notifications?${searchParams.toString()}`);
+    if (!searchParams.toString()) {
+      return this.get<NotificationPage>(`/notifications`);
+    } else {
+      return this.get<NotificationPage>(`/notifications?${searchParams.toString()}`);
+    }
   }
 
   async markNotificationAsRead(

--- a/services/__test__/TraineeNotificationsService.test.ts
+++ b/services/__test__/TraineeNotificationsService.test.ts
@@ -1,0 +1,96 @@
+import { AxiosRequestHeaders, AxiosResponse } from "axios";
+import { TraineeNotificationsService } from "../TraineeNotificationsService";
+import { NotificationPage } from "../../redux/slices/notificationsSlice";
+import { inAppNotifications } from "../../mock-data/mock-notifications-data";
+
+const mockService = new TraineeNotificationsService();
+describe("TraineeNotificationsService", () => {
+  it("getAllNotifications should call /notifications when no params provided", async () => {
+    const mockResponse: AxiosResponse<NotificationPage> = {
+      data: {
+        content: inAppNotifications,
+        page: {
+          size: 2000,
+          number: 0,
+          totalElements: 0,
+          totalPages: 1
+        }
+      },
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config: {
+        headers: {} as AxiosRequestHeaders
+      },
+    };
+
+    jest
+      .spyOn(mockService, "get")
+      .mockResolvedValue(mockResponse);
+
+    const result = await mockService.getAllNotifications();
+
+    expect(mockService.get).toHaveBeenCalledWith("/notifications");
+    expect(result).toEqual(mockResponse);
+  });
+
+  it("getAllNotifications should call /notifications with query string when params are provided", async () => {
+    const params = { page: 1, size: 10, sort:"sentAt,desc", type:"IN_APP", status:"UNREAD", keyword:"Placement" };
+    const mockResponse: AxiosResponse<NotificationPage> = {
+      data: {
+        content: inAppNotifications,
+        page: {
+          size: 2000,
+          number: 0,
+          totalElements: 0,
+          totalPages: 1
+        }
+      },
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config: {
+        headers: {} as AxiosRequestHeaders
+      },
+    };
+
+    jest
+      .spyOn(mockService, "get")
+      .mockResolvedValue(mockResponse);
+
+    const result = await mockService.getAllNotifications(params);
+
+    expect(mockService.get).toHaveBeenCalledWith("/notifications?page=1&size=10&sort=sentAt%2Cdesc&type=IN_APP&status=UNREAD&keyword=Placement");
+    expect(result).toEqual(mockResponse);
+  });
+
+  it("getAllNotifications should ignore empty or null param values", async () => {
+    const params = { page: 1, type: "" };
+    const mockResponse: AxiosResponse<NotificationPage> = {
+      data: {
+        content: inAppNotifications,
+        page: {
+          size: 2000,
+          number: 0,
+          totalElements: 0,
+          totalPages: 1
+        }
+      },
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config: {
+        headers: {} as AxiosRequestHeaders
+      },
+    };
+
+    jest
+      .spyOn(mockService, "get")
+      .mockResolvedValue(mockResponse);
+
+    const result = await mockService.getAllNotifications(params);
+
+    expect(mockService.get).toHaveBeenCalledWith("/notifications?page=1");
+    expect(result).toEqual(mockResponse);
+  });
+});


### PR DESCRIPTION
Update notifications to display paged data from the notification summary endpoint.

This PR mainly make change on the existing in-app notification to fit the merged endpoint changes of BE. 
This is the first part of change to migrate to a paginate filter summary. There will be separated PR(s) for applying the paged and filter features, and to add email notifications to FE.