### PR TITLE
Feat/add 16wks alt start date

### DIFF
--- a/components/forms/__test__/ltftValidationSchema.test.ts
+++ b/components/forms/__test__/ltftValidationSchema.test.ts
@@ -1,0 +1,82 @@
+import dayjs from "dayjs";
+import { ltftValidationSchema } from "../ltft/ltftValidationSchema";
+import store from "../../../redux/store/store";
+import { updatedTraineeProfileData } from "../../../redux/slices/traineeProfileSlice";
+import { mockTraineeProfile } from "../../../mock-data/trainee-profile";
+
+const within16w = dayjs().add(10, "week").format("YYYY-MM-DD");
+const beyond16w = dayjs().add(20, "week").format("YYYY-MM-DD");
+
+const baseValid = {
+  pmId: "7ab1aae3-83c2-4bb6-b1f3-99146e79b362",
+  wteBeforeChange: 100,
+  wte: 80,
+  tpdName: "TPD",
+  tpdEmail: "tpd@example.com",
+  otherDiscussions: null,
+  reasonsSelected: ["Caring responsibilities"],
+  personalDetails: {
+    forenames: "Jo",
+    surname: "Surname",
+    gmcNumber: "1234567",
+    telephoneNumber: "01234567890",
+    mobileNumber: "01234567890",
+    email: "jo@example.com"
+  },
+  startDate: beyond16w,
+  alternativeStartDate: null,
+  skilledWorkerVisaHolder: false,
+  supportingInformation: "info"
+};
+
+describe("ltftValidationSchema - alternativeStartDate (optional)", () => {
+  beforeAll(() => {
+    store.dispatch(updatedTraineeProfileData(mockTraineeProfile));
+  });
+
+  it("accepts a form with no alternativeStartDate when startDate is more than 16 weeks away", async () => {
+    await expect(
+      ltftValidationSchema.validate({ ...baseValid, startDate: beyond16w })
+    ).resolves.toBeTruthy();
+  });
+
+  it("accepts a late startDate with no alternativeStartDate provided", async () => {
+    await expect(
+      ltftValidationSchema.validate({
+        ...baseValid,
+        startDate: within16w,
+        alternativeStartDate: null
+      })
+    ).resolves.toBeTruthy();
+  });
+
+  it("treats an empty string as cleared (no typeError)", async () => {
+    await expect(
+      ltftValidationSchema.validate({
+        ...baseValid,
+        startDate: within16w,
+        alternativeStartDate: ""
+      })
+    ).resolves.toBeTruthy();
+  });
+
+  it("rejects an alternativeStartDate that is itself within 16 weeks", async () => {
+    await expect(
+      ltftValidationSchema.validate({
+        ...baseValid,
+        startDate: within16w,
+        alternativeStartDate: dayjs().add(8, "week").format("YYYY-MM-DD")
+      })
+    ).rejects.toThrow(/at least 16 weeks from today/);
+  });
+
+  it("accepts an alternativeStartDate that is at least 16 weeks away", async () => {
+    await expect(
+      ltftValidationSchema.validate({
+        ...baseValid,
+        startDate: within16w,
+        alternativeStartDate: dayjs().add(20, "week").format("YYYY-MM-DD")
+      })
+    ).resolves.toBeTruthy();
+  });
+});

--- a/components/forms/__test__/ltftValidationSchema.test.ts
+++ b/components/forms/__test__/ltftValidationSchema.test.ts
@@ -24,28 +24,28 @@ const baseValid = {
     email: "jo@example.com"
   },
   startDate: beyond16w,
-  alternativeStartDate: null,
+  altStartDate: null,
   skilledWorkerVisaHolder: false,
   supportingInformation: "info"
 };
 
-describe("ltftValidationSchema - alternativeStartDate (optional)", () => {
+describe("ltftValidationSchema - altStartDate (optional)", () => {
   beforeAll(() => {
     store.dispatch(updatedTraineeProfileData(mockTraineeProfile));
   });
 
-  it("accepts a form with no alternativeStartDate when startDate is more than 16 weeks away", async () => {
+  it("accepts a form with no altStartDate when startDate is more than 16 weeks away", async () => {
     await expect(
       ltftValidationSchema.validate({ ...baseValid, startDate: beyond16w })
     ).resolves.toBeTruthy();
   });
 
-  it("accepts a late startDate with no alternativeStartDate provided", async () => {
+  it("accepts a late startDate with no altStartDate provided", async () => {
     await expect(
       ltftValidationSchema.validate({
         ...baseValid,
         startDate: within16w,
-        alternativeStartDate: null
+        altStartDate: null
       })
     ).resolves.toBeTruthy();
   });
@@ -55,27 +55,27 @@ describe("ltftValidationSchema - alternativeStartDate (optional)", () => {
       ltftValidationSchema.validate({
         ...baseValid,
         startDate: within16w,
-        alternativeStartDate: ""
+        altStartDate: ""
       })
     ).resolves.toBeTruthy();
   });
 
-  it("rejects an alternativeStartDate that is itself within 16 weeks", async () => {
+  it("rejects an altStartDate that is itself within 16 weeks", async () => {
     await expect(
       ltftValidationSchema.validate({
         ...baseValid,
         startDate: within16w,
-        alternativeStartDate: dayjs().add(8, "week").format("YYYY-MM-DD")
+        altStartDate: dayjs().add(8, "week").format("YYYY-MM-DD")
       })
     ).rejects.toThrow(/at least 16 weeks from today/);
   });
 
-  it("accepts an alternativeStartDate that is at least 16 weeks away", async () => {
+  it("accepts an altStartDate that is at least 16 weeks away", async () => {
     await expect(
       ltftValidationSchema.validate({
         ...baseValid,
         startDate: within16w,
-        alternativeStartDate: dayjs().add(20, "week").format("YYYY-MM-DD")
+        altStartDate: dayjs().add(20, "week").format("YYYY-MM-DD")
       })
     ).resolves.toBeTruthy();
   });

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -43,6 +43,14 @@ export type FieldType =
   | "array"
   | "dto";
 
+export type VisibilityMatcherName = "valueInList" | "lessThan16WeeksTest";
+
+export type VisibilityCondition = {
+  field: string;
+  matcher: VisibilityMatcherName;
+  values?: unknown[];
+};
+
 export type Field = {
   name: string;
   label?: string;
@@ -50,12 +58,11 @@ export type Field = {
   visible: boolean;
   optionsKey?: string;
   dependencies?: string[];
-  visibleIf?: unknown[];
+  visibleIf?: VisibilityCondition;
   placeholder?: string;
   warnings?: Warning[];
   canGrow?: boolean;
   viewWhenEmpty?: boolean;
-  parent?: string;
   objectFields?: Field[];
   width?: number;
   isNumberField?: boolean;

--- a/components/forms/form-builder/FormFieldBuilder.tsx
+++ b/components/forms/form-builder/FormFieldBuilder.tsx
@@ -135,6 +135,7 @@ export function FormFieldBuilder({
         <Dates
           name={name}
           label={label}
+          hint={hint}
           fieldError={error}
           placeholder={placeholder}
           value={value}

--- a/components/forms/form-builder/form-fields/Dates.tsx
+++ b/components/forms/form-builder/form-fields/Dates.tsx
@@ -7,6 +7,7 @@ import { FieldWrapper } from "./FieldWrapper";
 type DatesProps = {
   name: string;
   label?: string;
+  hint?: string;
   fieldError?: string;
   placeholder?: string;
   value: string;
@@ -18,6 +19,7 @@ type DatesProps = {
 export const Dates = ({
   name,
   label,
+  hint,
   fieldError,
   placeholder,
   value,
@@ -31,6 +33,7 @@ export const Dates = ({
     <FieldWrapper
       name={name}
       label={label}
+      hint={hint}
       fieldError={fieldError}
       arrayIndex={arrayIndex}
       arrayName={arrayName}

--- a/components/forms/form-builder/form-r/part-a-ph/formA.json
+++ b/components/forms/form-builder/form-r/part-a-ph/formA.json
@@ -74,11 +74,14 @@
               "placeholder": "type here...",
               "type": "text",
               "visible": false,
-              "visibleIf": [
-                "Dependent - other immigration category",
-                "Other immigration categories i.e. overseas government employees, innovators etc."
-              ],
-              "parent": "immigrationStatus"
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "immigrationStatus",
+                "values": [
+                  "Dependent - other immigration category",
+                  "Other immigration categories i.e. overseas government employees, innovators etc."
+                ]
+              }
             },
             {
               "name": "qualification",
@@ -187,10 +190,13 @@
               "label": "Specialty 1 for Award of CCT",
               "type": "select",
               "visible": false,
-              "visibleIf": [
-                "I have been appointed to a programme leading to award of CCT"
-              ],
-              "parent": "declarationType",
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "declarationType",
+                "values": [
+                  "I have been appointed to a programme leading to award of CCT"
+                ]
+              },
               "optionsKey": "curriculum"
             },
             {
@@ -198,10 +204,13 @@
               "label": "Specialty 2 for Award of CCT",
               "type": "select",
               "visible": false,
-              "visibleIf": [
-                "I have been appointed to a programme leading to award of CCT"
-              ],
-              "parent": "declarationType",
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "declarationType",
+                "values": [
+                  "I have been appointed to a programme leading to award of CCT"
+                ]
+              },
               "optionsKey": "curriculum"
             },
             {

--- a/components/forms/form-builder/form-r/part-a/formA.json
+++ b/components/forms/form-builder/form-r/part-a/formA.json
@@ -60,11 +60,14 @@
               "placeholder": "type here...",
               "type": "text",
               "visible": false,
-              "visibleIf": [
-                "Dependent - other immigration category",
-                "Other immigration categories i.e. overseas government employees, innovators etc."
-              ],
-              "parent": "immigrationStatus"
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "immigrationStatus",
+                "values": [
+                  "Dependent - other immigration category",
+                  "Other immigration categories i.e. overseas government employees, innovators etc."
+                ]
+              }
             },
             {
               "name": "qualification",
@@ -173,10 +176,13 @@
               "label": "Specialty 1 for Award of CCT",
               "type": "select",
               "visible": false,
-              "visibleIf": [
-                "I have been appointed to a programme leading to award of CCT"
-              ],
-              "parent": "declarationType",
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "declarationType",
+                "values": [
+                  "I have been appointed to a programme leading to award of CCT"
+                ]
+              },
               "optionsKey": "curriculum"
             },
             {
@@ -184,10 +190,13 @@
               "label": "Specialty 2 for Award of CCT",
               "type": "select",
               "visible": false,
-              "visibleIf": [
-                "I have been appointed to a programme leading to award of CCT"
-              ],
-              "parent": "declarationType",
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "declarationType",
+                "values": [
+                  "I have been appointed to a programme leading to award of CCT"
+                ]
+              },
               "optionsKey": "curriculum"
             },
             {

--- a/components/forms/form-builder/form-r/part-b-ph/formB.json
+++ b/components/forms/form-builder/form-r/part-b-ph/formB.json
@@ -67,8 +67,11 @@
               "label": "Please Specify 'Other'",
               "type": "select",
               "visible": false,
-              "visibleIf": ["other"],
-              "parent": "prevRevalBody",
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "prevRevalBody",
+                "values": ["other"]
+              },
               "optionsKey": "dbcExternal"
             },
             {
@@ -287,8 +290,11 @@
               "label": "Are you complying with these conditions, warnings or undertakings?",
               "type": "checkbox",
               "visible": false,
-              "visibleIf": [true],
-              "parent": "isWarned"
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "isWarned",
+                "values": [true]
+              }
             }
           ]
         }
@@ -331,8 +337,11 @@
               "name": "previousDeclarations",
               "type": "array",
               "visible": false,
-              "visibleIf": [true],
-              "parent": "havePreviousDeclarations",
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "havePreviousDeclarations",
+                "values": [true]
+              },
               "label": "Previous Resolved Declarations",
               "objectFields": [
                 {
@@ -388,8 +397,11 @@
               "placeholder": "• Concern Type\n• Date\n• Location/site\n• Reflection (if available) - location in eportfolio",
               "label": "Please provide a brief summary, including where you were working, the date of the event, and your reflection where appropriate. If known, please identify what investigations are pending relating to the event and which organisation is undertaking the investigation.",
               "visible": false,
-              "visibleIf": [true],
-              "parent": "havePreviousUnresolvedDeclarations"
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "havePreviousUnresolvedDeclarations",
+                "values": [true]
+              }
             }
           ]
         }
@@ -415,8 +427,11 @@
               "name": "currentDeclarations",
               "type": "array",
               "visible": false,
-              "visibleIf": [true],
-              "parent": "haveCurrentDeclarations",
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "haveCurrentDeclarations",
+                "values": [true]
+              },
               "label": "Current Resolved Declarations",
               "objectFields": [
                 {
@@ -472,8 +487,11 @@
               "placeholder": "• Concern Type\n• Date\n• Location/site\n• Reflection (if available) - location in eportfolio",
               "label": "Please provide a brief summary, including where you were working, the date of the event, and your reflection where appropriate. If known, please identify what investigations are pending relating to the event and which organisation is undertaking the investigation.",
               "visible": false,
-              "visibleIf": [true],
-              "parent": "haveCurrentUnresolvedDeclarations"
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "haveCurrentUnresolvedDeclarations",
+                "values": [true]
+              }
             }
           ]
         }
@@ -498,8 +516,11 @@
               "name": "covidDeclarationDto",
               "type": "dto",
               "visible": false,
-              "visibleIf": [true],
-              "parent": "haveCovidDeclarations",
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "haveCovidDeclarations",
+                "values": [true]
+              },
               "objectFields": [
                 {
                   "name": "selfRateForCovid",
@@ -514,11 +535,14 @@
                   "type": "textArea",
                   "placeholder": "type here...",
                   "visible": false,
-                  "visibleIf": [
-                    "Below expectations for stage of training - needs further development",
-                    "Satisfactory progress meeting expectations for stage of training but some required competencies not met due to COVID 19"
-                  ],
-                  "parent": "selfRateForCovid"
+                  "visibleIf": {
+                    "matcher": "valueInList",
+                    "field": "selfRateForCovid",
+                    "values": [
+                      "Below expectations for stage of training - needs further development",
+                      "Satisfactory progress meeting expectations for stage of training but some required competencies not met due to COVID 19"
+                    ]
+                  }
                 },
                 {
                   "name": "otherInformationForPanel",
@@ -554,24 +578,33 @@
                   "type": "select",
                   "optionsKey": "covidChangeCircs",
                   "visible": false,
-                  "visibleIf": [true],
-                  "parent": "haveChangesToPlacement"
+                  "visibleIf": {
+                    "matcher": "valueInList",
+                    "field": "haveChangesToPlacement",
+                    "values": [true]
+                  }
                 },
                 {
                   "name": "changeCircumstanceOther",
                   "label": "Please Specify 'Other'",
                   "type": "textArea",
                   "visible": false,
-                  "visibleIf": ["Other"],
-                  "parent": "changeCircumstances"
+                  "visibleIf": {
+                    "matcher": "valueInList",
+                    "field": "changeCircumstances",
+                    "values": ["Other"]
+                  }
                 },
                 {
                   "name": "howPlacementAdjusted",
                   "label": "Please explain further how your placement was adjusted",
                   "type": "textArea",
                   "visible": false,
-                  "visibleIf": [true],
-                  "parent": "haveChangesToPlacement"
+                  "visibleIf": {
+                    "matcher": "valueInList",
+                    "field": "haveChangesToPlacement",
+                    "values": [true]
+                  }
                 },
                 {
                   "name": "educationSupervisorName",

--- a/components/forms/form-builder/form-r/part-b/formB.json
+++ b/components/forms/form-builder/form-r/part-b/formB.json
@@ -53,8 +53,11 @@
               "label": "Please Specify 'Other'",
               "type": "select",
               "visible": false,
-              "visibleIf": ["other"],
-              "parent": "prevRevalBody",
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "prevRevalBody",
+                "values": ["other"]
+              },
               "optionsKey": "dbcExternal"
             },
             {
@@ -273,8 +276,11 @@
               "label": "Are you complying with these conditions, warnings or undertakings?",
               "type": "checkbox",
               "visible": false,
-              "visibleIf": [true],
-              "parent": "isWarned"
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "isWarned",
+                "values": [true]
+              }
             }
           ]
         }
@@ -317,8 +323,11 @@
               "name": "previousDeclarations",
               "type": "array",
               "visible": false,
-              "visibleIf": [true],
-              "parent": "havePreviousDeclarations",
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "havePreviousDeclarations",
+                "values": [true]
+              },
               "label": "Previous Resolved Declarations",
               "objectFields": [
                 {
@@ -374,8 +383,11 @@
               "placeholder": "• Concern Type\n• Date\n• Location/site\n• Reflection (if available) - location in eportfolio",
               "label": "Please provide a brief summary, including where you were working, the date of the event, and your reflection where appropriate. If known, please identify what investigations are pending relating to the event and which organisation is undertaking the investigation.",
               "visible": false,
-              "visibleIf": [true],
-              "parent": "havePreviousUnresolvedDeclarations"
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "havePreviousUnresolvedDeclarations",
+                "values": [true]
+              }
             }
           ]
         }
@@ -401,8 +413,11 @@
               "name": "currentDeclarations",
               "type": "array",
               "visible": false,
-              "visibleIf": [true],
-              "parent": "haveCurrentDeclarations",
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "haveCurrentDeclarations",
+                "values": [true]
+              },
               "label": "Current Resolved Declarations",
               "objectFields": [
                 {
@@ -458,8 +473,11 @@
               "placeholder": "• Concern Type\n• Date\n• Location/site\n• Reflection (if available) - location in eportfolio",
               "label": "Please provide a brief summary, including where you were working, the date of the event, and your reflection where appropriate. If known, please identify what investigations are pending relating to the event and which organisation is undertaking the investigation.",
               "visible": false,
-              "visibleIf": [true],
-              "parent": "haveCurrentUnresolvedDeclarations"
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "haveCurrentUnresolvedDeclarations",
+                "values": [true]
+              }
             }
           ]
         }
@@ -484,8 +502,11 @@
               "name": "covidDeclarationDto",
               "type": "dto",
               "visible": false,
-              "visibleIf": [true],
-              "parent": "haveCovidDeclarations",
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "haveCovidDeclarations",
+                "values": [true]
+              },
               "objectFields": [
                 {
                   "name": "selfRateForCovid",
@@ -500,11 +521,14 @@
                   "type": "textArea",
                   "placeholder": "type here...",
                   "visible": false,
-                  "visibleIf": [
-                    "Below expectations for stage of training - needs further development",
-                    "Satisfactory progress meeting expectations for stage of training but some required competencies not met due to COVID 19"
-                  ],
-                  "parent": "selfRateForCovid"
+                  "visibleIf": {
+                    "matcher": "valueInList",
+                    "field": "selfRateForCovid",
+                    "values": [
+                      "Below expectations for stage of training - needs further development",
+                      "Satisfactory progress meeting expectations for stage of training but some required competencies not met due to COVID 19"
+                    ]
+                  }
                 },
                 {
                   "name": "otherInformationForPanel",
@@ -540,24 +564,33 @@
                   "type": "select",
                   "optionsKey": "covidChangeCircs",
                   "visible": false,
-                  "visibleIf": [true],
-                  "parent": "haveChangesToPlacement"
+                  "visibleIf": {
+                    "matcher": "valueInList",
+                    "field": "haveChangesToPlacement",
+                    "values": [true]
+                  }
                 },
                 {
                   "name": "changeCircumstanceOther",
                   "label": "Please Specify 'Other'",
                   "type": "textArea",
                   "visible": false,
-                  "visibleIf": ["Other"],
-                  "parent": "changeCircumstances"
+                  "visibleIf": {
+                    "matcher": "valueInList",
+                    "field": "changeCircumstances",
+                    "values": ["Other"]
+                  }
                 },
                 {
                   "name": "howPlacementAdjusted",
                   "label": "Please explain further how your placement was adjusted",
                   "type": "textArea",
                   "visible": false,
-                  "visibleIf": [true],
-                  "parent": "haveChangesToPlacement"
+                  "visibleIf": {
+                    "matcher": "valueInList",
+                    "field": "haveChangesToPlacement",
+                    "values": [true]
+                  }
                 },
                 {
                   "name": "educationSupervisorName",

--- a/components/forms/form-builder/form-sections/ImportantText.tsx
+++ b/components/forms/form-builder/form-sections/ImportantText.tsx
@@ -27,7 +27,13 @@ export const ltftReasonsText1 =
   "The reason(s) for applying will be used for reporting purposes and may inform the decision-making process. This will need to be discussed with your regional office.";
 
 export const ltftStartDateImportantText1 =
-  "Less than full-time (LTFT) training requests with less than 16 weeks’ notice or outside the application window (should a regional team manage applications within a window) will only be considered on an exceptional basis.";
+  "A Less than full-time (LTFT) training request with less than 16 weeks’ notice or outside the application window (should a regional team manage applications within a window) is classed as a late application and will only be considered on an exceptional basis.";
+
+export const ltftStartDateImportantText2 =
+  "If applicable, should your late application not be approved, when choosing a late application start date below, you will also be asked to provide an alternative start date at least 16 weeks in advance. This will hopefully lessen any admin delays in approving your application.";
+
+export const ltftStartDateimportantText3 =
+  "A late application will also need additional supporting information (Part 6 of this form). This includes the reasons for no suitable alternative start date being given (if applicable).";
 
 export const ltftTier2VisaImportantText1 =
   "If you are a Skilled Worker (formerly a Tier 2 General work) visa holder, please make sure the proposed change to your full time working hours percentage (Part 3 of this application) complies with the requirements of your visa.";
@@ -308,7 +314,13 @@ const displayText: DisplayText = {
     </>
   ),
   ltftReasonsInstructions: <p>{ltftReasonsText1}</p>,
-  ltftStartDateImportantText: <p>{ltftStartDateImportantText1}</p>,
+  ltftStartDateImportantText: (
+    <>
+      <p>{ltftStartDateImportantText1}</p>
+      <p>{ltftStartDateImportantText2}</p>
+      <p>{ltftStartDateimportantText3}</p>
+    </>
+  ),
   ltftTier2VisaImportantText: (
     <>
       <p>{ltftTier2VisaImportantText1}</p>

--- a/components/forms/form-builder/form-sections/ImportantText.tsx
+++ b/components/forms/form-builder/form-sections/ImportantText.tsx
@@ -32,7 +32,7 @@ export const ltftStartDateImportantText1 =
 export const ltftStartDateImportantText2 =
   "If applicable, should your late application not be approved, when choosing a late application start date below, you will also be asked to provide an alternative start date at least 16 weeks in advance. This will hopefully lessen any admin delays in approving your application.";
 
-export const ltftStartDateimportantText3 =
+export const ltftStartDateImportantText3 =
   "A late application will also need additional supporting information (Part 6 of this form). This includes the reasons for no suitable alternative start date being given (if applicable).";
 
 export const ltftTier2VisaImportantText1 =
@@ -318,7 +318,7 @@ const displayText: DisplayText = {
     <>
       <p>{ltftStartDateImportantText1}</p>
       <p>{ltftStartDateImportantText2}</p>
-      <p>{ltftStartDateimportantText3}</p>
+      <p>{ltftStartDateImportantText3}</p>
     </>
   ),
   ltftTier2VisaImportantText: (

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -206,13 +206,13 @@ export const LtftFormView = () => {
                     )}
                 </SummaryList.Value>
               </SummaryList.Row>
-              {formData.alternativeStartDate && (
+              {formData.altStartDate && (
                 <SummaryList.Row>
-                  <SummaryList.Key data-cy="alternativeStartDateKey">
+                  <SummaryList.Key data-cy="altStartDateKey">
                     Alternative start date
                   </SummaryList.Key>
-                  <SummaryList.Value data-cy="alternativeStartDateValue">
-                    {dayjs(formData.alternativeStartDate).format("DD/MM/YYYY")}
+                  <SummaryList.Value data-cy="altStartDateValue">
+                    {dayjs(formData.altStartDate).format("DD/MM/YYYY")}
                   </SummaryList.Value>
                 </SummaryList.Row>
               )}

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -206,6 +206,16 @@ export const LtftFormView = () => {
                     )}
                 </SummaryList.Value>
               </SummaryList.Row>
+              {formData.alternativeStartDate && (
+                <SummaryList.Row>
+                  <SummaryList.Key data-cy="alternativeStartDateKey">
+                    Alternative start date
+                  </SummaryList.Key>
+                  <SummaryList.Value data-cy="alternativeStartDateValue">
+                    {dayjs(formData.alternativeStartDate).format("DD/MM/YYYY")}
+                  </SummaryList.Value>
+                </SummaryList.Row>
+              )}
             </SummaryList>
             <CompletionDateChangeText
               wteBeforeChange={formData.wteBeforeChange}

--- a/components/forms/ltft/ltft.json
+++ b/components/forms/ltft/ltft.json
@@ -88,7 +88,81 @@
               "warnings": [
                 {
                   "matcher": "ltft16WeeksTest",
-                  "msgText": "Warning: Giving less than 16 weeks notice to change your working hours is classed as a late application and will only be considered on an exceptional basis."
+                  "msgText": "Warning: The start date you have chosen (within 16 weeks) is classed as a late application and will be considered on an exceptional basis. You will be prompted in Part 6 to provide your reason(s) for this."
+                }
+              ]
+            },
+            {
+              "name": "alternativeStartDate",
+              "label": "If you have an alternative start date that gives at least 16 weeks notice, please enter it here.",
+              "hint": "Leave blank if there is no suitable alternative — you can explain in your supporting information.",
+              "type": "date",
+              "visible": false,
+              "visibleIf": {
+                "matcher": "lessThan16WeeksTest",
+                "field": "startDate"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "pageName": "Reason(s) for applying",
+      "importantTxtName": "ltftReasonsInstructions",
+      "expanderLinkName": "",
+      "sections": [
+        {
+          "sectionHeader": "Reason(s) for applying",
+          "fields": [
+            {
+              "name": "reasonsSelected",
+              "label": "Why are you applying?",
+              "placeholder": "Select all reasons that apply",
+              "type": "select",
+              "isMultiSelect": true,
+              "optionsKey": "ltftReasons",
+              "dependencies": ["reasonsOtherDetail"],
+              "visible": true,
+              "hint": "You can choose more than one reason if applicable (for example, 'Caring responsibilities' and 'Training / career development')."
+            },
+            {
+              "name": "reasonsOtherDetail",
+              "label": "Other reason",
+              "placeholder": "type here...",
+              "type": "text",
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "reasonsSelected",
+                "values": ["other"]
+              },
+              "visible": false,
+              "hint": "Please provide details for your 'other reason'."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "pageName": "Supporting information",
+      "importantTxtName": "",
+      "expanderLinkName": "",
+      "sections": [
+        {
+          "sectionHeader": "Supporting information",
+          "fields": [
+            {
+              "name": "supportingInformation",
+              "label": "Please provide brief supporting information for your application.",
+              "hint": "This helps us understand your circumstances and proposed arrangements.",
+              "placeholder": "Example:\n'I would like to apply for 60% LTFT from March 2026 due to ongoing caring responsibilities. I plan to work three days per week and would appreciate flexibility around clinic days.'",
+              "type": "textArea",
+              "visible": true,
+              "warnings": [
+                {
+                  "matcher": "ltft16WeeksTest",
+                  "msgText": "Please include supporting information for why you are making a late application (less than 16 weeks notice) and why no suitable alternative start date is given (if applicable).",
+                  "conditionalField": "startDate"
                 }
               ]
             }
@@ -158,66 +232,6 @@
                   "type": "select",
                   "optionsKey": "ltftRoles",
                   "visible": true
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "pageName": "Reason(s) for applying",
-      "importantTxtName": "ltftReasonsInstructions",
-      "expanderLinkName": "",
-      "sections": [
-        {
-          "sectionHeader": "Reason(s) for applying",
-          "fields": [
-            {
-              "name": "reasonsSelected",
-              "label": "Why are you applying?",
-              "placeholder": "Select all reasons that apply",
-              "type": "select",
-              "isMultiSelect": true,
-              "optionsKey": "ltftReasons",
-              "dependencies": ["reasonsOtherDetail"],
-              "visible": true,
-              "hint": "You can choose more than one reason if applicable (for example, 'Caring responsibilities' and 'Training / career development')."
-            },
-            {
-              "name": "reasonsOtherDetail",
-              "label": "Other reason",
-              "placeholder": "type here...",
-              "type": "text",
-              "visibleIf": ["other"],
-              "parent": "reasonsSelected",
-              "visible": false,
-              "hint": "Please provide details for your 'other reason'."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "pageName": "Supporting information",
-      "importantTxtName": "",
-      "expanderLinkName": "",
-      "sections": [
-        {
-          "sectionHeader": "Supporting information",
-          "fields": [
-            {
-              "name": "supportingInformation",
-              "label": "Please provide brief supporting information for your application.",
-              "hint": "This helps us understand your circumstances and proposed arrangements.",
-              "placeholder": "Example:\n'I would like to apply for 60% LTFT from March 2026 due to ongoing caring responsibilities. I plan to work three days per week and would appreciate flexibility around clinic days.'",
-              "type": "textArea",
-              "visible": true,
-              "warnings": [
-                {
-                  "matcher": "ltft16WeeksTest",
-                  "msgText": "Please include supporting information for why you are making a late application i.e. giving less than 16 weeks notice to change your working hours.",
-                  "conditionalField": "startDate"
                 }
               ]
             }

--- a/components/forms/ltft/ltft.json
+++ b/components/forms/ltft/ltft.json
@@ -95,7 +95,7 @@
             {
               "name": "altStartDate",
               "label": "If you have an alternative start date that gives at least 16 weeks notice, please enter it here.",
-              "hint": "Leave blank if there is no suitable alternative — you can explain in your supporting information.",
+              "hint": "Leave blank if there is no suitable alternative",
               "type": "date",
               "visible": false,
               "visibleIf": {

--- a/components/forms/ltft/ltft.json
+++ b/components/forms/ltft/ltft.json
@@ -93,7 +93,7 @@
               ]
             },
             {
-              "name": "alternativeStartDate",
+              "name": "altStartDate",
               "label": "If you have an alternative start date that gives at least 16 weeks notice, please enter it here.",
               "hint": "Leave blank if there is no suitable alternative — you can explain in your supporting information.",
               "type": "date",

--- a/components/forms/ltft/ltftValidationSchema.ts
+++ b/components/forms/ltft/ltftValidationSchema.ts
@@ -67,7 +67,7 @@ const changeStartDateValidation = yup
     }
   );
 
-const alternativeStartDateValidation = yup
+const altStartDateValidation = yup
   .date()
   .nullable()
   .transform((value, originalValue) => (originalValue === "" ? null : value))
@@ -131,7 +131,7 @@ export const ltftValidationSchema = yup.object({
     .nullable(),
   personalDetails: personalDetailsDtoValidationSchema,
   startDate: changeStartDateValidation,
-  alternativeStartDate: alternativeStartDateValidation,
+  altStartDate: altStartDateValidation,
   skilledWorkerVisaHolder: yup
     .boolean()
     .typeError(LtftVisaError)

--- a/components/forms/ltft/ltftValidationSchema.ts
+++ b/components/forms/ltft/ltftValidationSchema.ts
@@ -5,6 +5,7 @@ import { CHECK_PHONE_REGEX } from "../../../utilities/Constants";
 import store from "../../../redux/store/store";
 import { isPastIt } from "../../../utilities/DateUtilities";
 import { findLinkedProgramme } from "../../../utilities/CctUtilities";
+import { isDateWithin16WeeksOfFirstDate } from "../../../utilities/FormBuilderUtilities";
 
 export const LtftVisaError =
   "Please select Yes or No for Skilled Worker visa status";
@@ -21,6 +22,26 @@ const phoneValidation = (fieldName: string) =>
     CHECK_PHONE_REGEX,
     `${fieldName} is not valid`
   );
+
+const isOnOrBeforeProgrammeEnd = (
+  value: Date | null | undefined,
+  pmId: string | undefined
+) => {
+  if (!value || !pmId) return true;
+  const progsArrNotPast = store
+    .getState()
+    .traineeProfile.traineeProfileData.programmeMemberships.filter(
+      prog => !isPastIt(prog.endDate)
+    );
+  const linkedProgramme = findLinkedProgramme(pmId, progsArrNotPast);
+  if (!linkedProgramme) return true;
+  const changeStartDate = dayjs(value).startOf("day");
+  const programmeEndDate = dayjs(linkedProgramme.endDate).startOf("day");
+  return (
+    changeStartDate.isBefore(programmeEndDate) ||
+    changeStartDate.isSame(programmeEndDate)
+  );
+};
 
 const changeStartDateValidation = yup
   .date()
@@ -42,26 +63,25 @@ const changeStartDateValidation = yup
     "is-before-programme-end",
     "Change cannot begin after the programme end date",
     function (value) {
-      const { pmId } = this.parent;
-      if (!value || !pmId) {
-        return true;
-      }
-      const progsArrNotPast = store
-        .getState()
-        .traineeProfile.traineeProfileData.programmeMemberships.filter(
-          prog => !isPastIt(prog.endDate)
-        );
-      const linkedProgramme = findLinkedProgramme(pmId, progsArrNotPast);
+      return isOnOrBeforeProgrammeEnd(value, this.parent.pmId);
+    }
+  );
 
-      if (linkedProgramme) {
-        const changeStartDate = dayjs(value).startOf("day");
-        const programmeEndDate = dayjs(linkedProgramme.endDate).startOf("day");
-        return (
-          changeStartDate.isBefore(programmeEndDate) ||
-          changeStartDate.isSame(programmeEndDate)
-        );
-      }
-      return true;
+const alternativeStartDateValidation = yup
+  .date()
+  .nullable()
+  .transform((value, originalValue) => (originalValue === "" ? null : value))
+  .typeError("Alternative start date is not a valid date")
+  .test(
+    "alt-at-least-16-weeks",
+    "Alternative start date must be at least 16 weeks from today",
+    value => !value || !isDateWithin16WeeksOfFirstDate(value)
+  )
+  .test(
+    "alt-before-programme-end",
+    "Alternative start date cannot be after the programme end date",
+    function (value) {
+      return isOnOrBeforeProgrammeEnd(value, this.parent.pmId);
     }
   );
 
@@ -111,6 +131,7 @@ export const ltftValidationSchema = yup.object({
     .nullable(),
   personalDetails: personalDetailsDtoValidationSchema,
   startDate: changeStartDateValidation,
+  alternativeStartDate: alternativeStartDateValidation,
   skilledWorkerVisaHolder: yup
     .boolean()
     .typeError(LtftVisaError)

--- a/cypress/component/forms/ltft/LtftForm.cy.tsx
+++ b/cypress/component/forms/ltft/LtftForm.cy.tsx
@@ -133,7 +133,7 @@ describe("LtftForm - draft", () => {
       "Warning: The start date you have chosen (within 16 weeks) is classed as a late application and will be considered on an exceptional basis. You will be prompted in Part 6 to provide your reason(s) for this."
     );
     cy.get("#startDate-error").should("not.exist");
-    cy.get('[data-cy="alternativeStartDate-input"]').should("be.visible");
+    cy.get('[data-cy="altStartDate-input"]').should("be.visible");
     cy.navNext();
 
     // Part 5

--- a/cypress/component/forms/ltft/LtftForm.cy.tsx
+++ b/cypress/component/forms/ltft/LtftForm.cy.tsx
@@ -16,8 +16,12 @@ import {
 } from "../../../../components/forms/form-builder/form-sections/ImportantText";
 import { LtftObjNew } from "../../../../models/LtftTypes";
 import { makeValidProgrammeOptions } from "../../../../utilities/ltftUtilities";
-import { mockProgrammeMemberships } from "../../../../mock-data/trainee-profile";
+import {
+  mockProgrammeMemberships,
+  mockTraineeProfile
+} from "../../../../mock-data/trainee-profile";
 import { updatedUserFeatures } from "../../../../redux/slices/userSlice";
+import { updatedTraineeProfileData } from "../../../../redux/slices/traineeProfileSlice";
 import dayjs from "dayjs";
 import {
   ltftReasonsError,
@@ -26,6 +30,7 @@ import {
 
 const mountLtftWithMockData = (mockLtftObj: LtftObjNew) => {
   store.dispatch(updatedLtft(mockLtftObj));
+  store.dispatch(updatedTraineeProfileData(mockTraineeProfile));
   const qualifyingProgrammes = ["7ab1aae3-83c2-4bb6-b1f3-99146e79b362"];
   store.dispatch(
     updatedUserFeatures({
@@ -219,6 +224,70 @@ describe("LtftForm - draft", () => {
     cy.get("h3").contains("Part 10 of 10 - Personal Details");
     cy.navNext();
     cy.url().should("include", "/ltft/confirm");
+  });
+});
+
+describe("LtftForm - alternative start date validation", () => {
+  const navigateToStartDateWithAltVisible = () => {
+    cy.clickSelect('[data-cy="pmId"]');
+    cy.navNext();
+    cy.clearAndType('[data-cy="wteBeforeChange-input"]', "100");
+    cy.navNext();
+    cy.clearAndType('[data-cy="wte-input"]', "80");
+    cy.navNext();
+    // Part 4 - Start date
+    cy.get("h3").contains("Part 4 of 10 - Start date");
+    const startDateWithin16Weeks = dayjs()
+      .startOf("day")
+      .add(16, "weeks")
+      .subtract(1, "day")
+      .format("YYYY-MM-DD");
+    cy.clearAndType('[data-cy="startDate-input"]', startDateWithin16Weeks);
+    cy.get('[data-cy="altStartDate-input"]').should("be.visible");
+  };
+
+  it("errors when the alternative start date is less than 16 weeks from today (alt-at-least-16-weeks)", () => {
+    mountLtftWithMockData(mockLtftNewFormObj);
+    navigateToStartDateWithAltVisible();
+    const altDateWithin16Weeks = dayjs()
+      .startOf("day")
+      .add(16, "weeks")
+      .subtract(1, "day")
+      .format("YYYY-MM-DD");
+    cy.clearAndType('[data-cy="altStartDate-input"]', altDateWithin16Weeks);
+    cy.get("#altStartDate-error").contains(
+      "Alternative start date must be at least 16 weeks from today"
+    );
+    const altDateExactly16Weeks = dayjs()
+      .startOf("day")
+      .add(16, "weeks")
+      .format("YYYY-MM-DD");
+    cy.clearAndType('[data-cy="altStartDate-input"]', altDateExactly16Weeks);
+    cy.get("#altStartDate-error").should("not.exist");
+  });
+
+  it("errors when the alternative start date is after the programme end date (alt-before-programme-end)", () => {
+    mountLtftWithMockData(mockLtftNewFormObj);
+    navigateToStartDateWithAltVisible();
+    const altDateAfterProgrammeEnd = dayjs()
+      .startOf("day")
+      .add(3, "years")
+      .add(1, "day")
+      .format("YYYY-MM-DD");
+    cy.clearAndType('[data-cy="altStartDate-input"]', altDateAfterProgrammeEnd);
+    cy.get("#altStartDate-error").contains(
+      "Alternative start date cannot be after the programme end date"
+    );
+
+    const altDateBeforeProgrammeEnd = dayjs()
+      .startOf("day")
+      .add(16, "weeks")
+      .format("YYYY-MM-DD");
+    cy.clearAndType(
+      '[data-cy="altStartDate-input"]',
+      altDateBeforeProgrammeEnd
+    );
+    cy.get("#altStartDate-error").should("not.exist");
   });
 });
 

--- a/cypress/component/forms/ltft/LtftForm.cy.tsx
+++ b/cypress/component/forms/ltft/LtftForm.cy.tsx
@@ -130,13 +130,47 @@ describe("LtftForm - draft", () => {
     cy.get("#startDate-error").contains("Change cannot begin before today");
     cy.clearAndType('[data-cy="startDate-input"]', dateWithin16WeeksOfToday);
     cy.get(".field-warning-msg").contains(
-      "Warning: Giving less than 16 weeks notice to change your working hours is classed as a late application and will only be considered on an exceptional basis."
+      "Warning: The start date you have chosen (within 16 weeks) is classed as a late application and will be considered on an exceptional basis. You will be prompted in Part 6 to provide your reason(s) for this."
     );
     cy.get("#startDate-error").should("not.exist");
+    cy.get('[data-cy="alternativeStartDate-input"]').should("be.visible");
     cy.navNext();
 
     // Part 5
-    cy.get("h3").contains("Part 5 of 10 - Pre-approver discussions");
+    cy.get("h3").contains("Part 5 of 10 - Reason(s) for applying");
+    cy.get(
+      '[data-cy="WarningCallout-ltftReasonsInstructions-label"] > span'
+    ).contains("Important");
+    cy.get(".nhsuk-warning-callout > p").contains(ltftReasonsText1);
+    cy.navNext();
+    cy.get("#reasonsSelected-error").contains(ltftReasonsError);
+    cy.get(".nhsuk-card__heading").contains("Reason(s) for applying");
+    cy.get('[data-cy="reasonsSelected-label"]').should("exist");
+    cy.get('[data-cy="reasonsSelected-hint"]').should(
+      "include.text",
+      "You can choose more than one reason if applicable (for example, 'Caring responsibilities' and 'Training / career development')."
+    );
+    cy.get('[data-cy="reasonsOtherDetail-input"]').should("not.exist");
+    cy.clickSelect('[data-cy="reasonsSelected"]', "other reason");
+    cy.get('[data-cy="reasonsOtherDetail-input"]').type("My other reason");
+    cy.navNext();
+
+    // Part 6
+    cy.get("h3").contains("Part 6 of 10 - Supporting information");
+    cy.navNext();
+    cy.get("#supportingInformation-error").contains(
+      "Supporting information is required"
+    );
+    cy.get('[data-cy="supportingInformation-text-area-input"]').type(
+      "This is my supporting information"
+    );
+    cy.get(".field-warning-msg").contains(
+      "Please include supporting information for why you are making a late application (less than 16 weeks notice) and why no suitable alternative start date is given (if applicable)."
+    );
+    cy.navNext();
+
+    // Part 7
+    cy.get("h3").contains("Part 7 of 10 - Pre-approver discussions");
     cy.get(
       '[data-cy="WarningCallout-ltftDiscussionInstructions-label"] > span'
     ).should("exist");
@@ -164,45 +198,12 @@ describe("LtftForm - draft", () => {
     cy.get('[data-cy="tpdEmail-input"]').type("tpd@e.mail");
     cy.navNext();
 
-    // part 6
-    cy.get("h3").contains("Part 6 of 10 - Other discussions");
+    // Part 8
+    cy.get("h3").contains("Part 8 of 10 - Other discussions");
     cy.get('[data-cy="add-Other Discussions-button"]').should("exist").click();
     cy.clearAndType('[data-cy="name-input"]', "Mr AN Other");
     cy.clearAndType('[data-cy="email-input"]', "mr@an.other");
     cy.clickSelect('[data-cy="role"]');
-    cy.navNext();
-
-    // part 7
-    cy.get("h3").contains("Part 7 of 10 - Reason(s) for applying");
-    cy.get(
-      '[data-cy="WarningCallout-ltftReasonsInstructions-label"] > span'
-    ).contains("Important");
-    cy.get(".nhsuk-warning-callout > p").contains(ltftReasonsText1);
-    cy.navNext();
-    cy.get("#reasonsSelected-error").contains(ltftReasonsError);
-    cy.get(".nhsuk-card__heading").contains("Reason(s) for applying");
-    cy.get('[data-cy="reasonsSelected-label"]').should("exist");
-    cy.get('[data-cy="reasonsSelected-hint"]').should(
-      "include.text",
-      "You can choose more than one reason if applicable (for example, 'Caring responsibilities' and 'Training / career development')."
-    );
-    cy.get('[data-cy="reasonsOtherDetail-input"]').should("not.exist");
-    cy.clickSelect('[data-cy="reasonsSelected"]', "other reason");
-    cy.get('[data-cy="reasonsOtherDetail-input"]').type("My other reason");
-    cy.navNext();
-
-    // part 8
-    cy.get("h3").contains("Part 8 of 10 - Supporting information");
-    cy.navNext();
-    cy.get("#supportingInformation-error").contains(
-      "Supporting information is required"
-    );
-    cy.get('[data-cy="supportingInformation-text-area-input"]').type(
-      "This is my supporting information"
-    );
-    cy.get(".field-warning-msg").contains(
-      "Please include supporting information for why you are making a late application i.e. giving less than 16 weeks notice to change your working hours."
-    );
     cy.navNext();
 
     // part 9

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -162,7 +162,7 @@ export const mockLtftNewFormObj: LtftObjNew = {
   reasonsSelected: null,
   skilledWorkerVisaHolder: null,
   startDate: null,
-  alternativeStartDate: null,
+  altStartDate: null,
   status: {
     current: {
       state: "DRAFT",
@@ -207,7 +207,7 @@ export const mockLtftDraftUpdatedPmFormDtoFirstSavePayload: LtftDto = {
   change: {
     type: "LTFT",
     startDate: null,
-    alternativeStartDate: null,
+    altStartDate: null,
     wte: 0,
     id: null
   },
@@ -372,7 +372,7 @@ export const mockLtftFormObjAfterFirstSave: LtftObjNew = {
   reasonsSelected: [],
   skilledWorkerVisaHolder: null,
   startDate: null,
-  alternativeStartDate: null,
+  altStartDate: null,
   status: {
     current: {
       detail: { message: null, reason: null },
@@ -413,7 +413,7 @@ export const mockLtftSubmittedFormObj: LtftObjNew = {
   managingDeanery: "East of England",
   type: "LTFT",
   startDate: startDate,
-  alternativeStartDate: null,
+  altStartDate: null,
   wteBeforeChange: wteBeforeChange,
   wte: wte,
   declarations: {

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -162,6 +162,7 @@ export const mockLtftNewFormObj: LtftObjNew = {
   reasonsSelected: null,
   skilledWorkerVisaHolder: null,
   startDate: null,
+  alternativeStartDate: null,
   status: {
     current: {
       state: "DRAFT",
@@ -203,7 +204,13 @@ export const mockLtftDraftUpdatedPmFormDtoFirstSavePayload: LtftDto = {
   id: null,
   formRef: null,
   name: null,
-  change: { type: "LTFT", startDate: null, wte: 0, id: null },
+  change: {
+    type: "LTFT",
+    startDate: null,
+    alternativeStartDate: null,
+    wte: 0,
+    id: null
+  },
   declarations: {
     discussedWithTpd: true,
     informationIsCorrect: null,
@@ -365,6 +372,7 @@ export const mockLtftFormObjAfterFirstSave: LtftObjNew = {
   reasonsSelected: [],
   skilledWorkerVisaHolder: null,
   startDate: null,
+  alternativeStartDate: null,
   status: {
     current: {
       detail: { message: null, reason: null },
@@ -405,6 +413,7 @@ export const mockLtftSubmittedFormObj: LtftObjNew = {
   managingDeanery: "East of England",
   type: "LTFT",
   startDate: startDate,
+  alternativeStartDate: null,
   wteBeforeChange: wteBeforeChange,
   wte: wte,
   declarations: {

--- a/models/LtftTypes.ts
+++ b/models/LtftTypes.ts
@@ -15,6 +15,7 @@ export type LtftChange = {
   calculationId?: string | null;
   type: CctType;
   startDate: Date | string | null;
+  alternativeStartDate?: Date | string | null;
   endDate?: Date | string | null;
   wte: number;
 };
@@ -93,6 +94,7 @@ export type LtftObjNew = {
   // change: LtftChange
   type: CctType;
   startDate: Date | string | null;
+  alternativeStartDate: Date | string | null;
   wteBeforeChange: number | null; // currently belongs to PM but needed here for ease of use
   wte: number | null;
 

--- a/models/LtftTypes.ts
+++ b/models/LtftTypes.ts
@@ -15,7 +15,7 @@ export type LtftChange = {
   calculationId?: string | null;
   type: CctType;
   startDate: Date | string | null;
-  alternativeStartDate?: Date | string | null;
+  altStartDate?: Date | string | null;
   endDate?: Date | string | null;
   wte: number;
 };
@@ -94,7 +94,7 @@ export type LtftObjNew = {
   // change: LtftChange
   type: CctType;
   startDate: Date | string | null;
-  alternativeStartDate: Date | string | null;
+  altStartDate: Date | string | null;
   wteBeforeChange: number | null; // currently belongs to PM but needed here for ease of use
   wte: number | null;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.147.0",
+  "version": "0.146.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.147.0",
+      "version": "0.146.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.11.1",
         "@cypress/code-coverage": "^3.12.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.146.0",
+  "version": "0.147.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.146.0",
+      "version": "0.147.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.11.1",
         "@cypress/code-coverage": "^3.12.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.145.2",
+  "version": "0.146.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.145.2",
+      "version": "0.146.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.11.1",
         "@cypress/code-coverage": "^3.12.1",
@@ -14188,12 +14188,12 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/js-tokens": {
@@ -18938,9 +18938,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.147.0",
+  "version": "0.146.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^6.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.145.2",
+  "version": "0.146.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^6.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.146.0",
+  "version": "0.147.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^6.11.1",

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -18,6 +18,8 @@ import type {
   FormData,
   FormName,
   MatcherName,
+  VisibilityCondition,
+  VisibilityMatcherName,
   Warning
 } from "../components/forms/form-builder/FormBuilder";
 import {
@@ -455,11 +457,7 @@ export function setFormRDataForSubmit(
   const newFormData = jsonForm.pages.reduce((fd, page) => {
     page.sections.forEach(section => {
       section.fields.forEach(field => {
-        if (
-          field.visible ||
-          (field.parent &&
-            field?.visibleIf?.includes((fd as FormData)[field.parent]))
-        ) {
+        if (showFormField(field, fd)) {
           (fd as FormData)[field.name] = (formData as FormData)[field.name];
         } else {
           (fd as FormData)[field.name] = null;
@@ -695,12 +693,8 @@ export function validateFields(
         });
       } else if (field.type === "dto") {
         const dtoFields = field.objectFields ?? [];
-        const visibleDtoFields = dtoFields.filter(
-          dtoField =>
-            dtoField.visible ||
-            dtoField.visibleIf?.includes(
-              values[field.name][dtoField.parent as string]
-            )
+        const visibleDtoFields = dtoFields.filter(dtoField =>
+          showFormField(dtoField, values[field.name] ?? {})
         );
         const dtoSchema = visibleDtoFields.reduce((dtoSchema, dtoField) => {
           const dtoFieldSchema = fieldSchema.fields[dtoField.name];
@@ -734,15 +728,29 @@ export function formatFieldName(fieldName: string) {
   return words.join(" ");
 }
 
+type VisibilityMatcher = (
+  fieldValue: unknown,
+  cond: VisibilityCondition
+) => boolean;
+
+const visibilityMatchers: Record<VisibilityMatcherName, VisibilityMatcher> = {
+  valueInList: (fieldValue, cond) => {
+    if (!cond.values) return false;
+    if (Array.isArray(fieldValue)) {
+      return fieldValue.some(v => cond.values!.includes(v));
+    }
+    return cond.values.includes(fieldValue);
+  },
+  lessThan16WeeksTest: fieldValue =>
+    !!fieldValue && isDateWithin16WeeksOfFirstDate(fieldValue as string)
+};
+
 export function showFormField(field: Field, formData: FormData) {
   if (field.visible) return true;
-  if (field.visibleIf) {
-    if (Array.isArray(formData[field.parent as string])) {
-      return formData[field.parent as string].includes(field.visibleIf[0]);
-    }
-    return field.visibleIf.includes(formData[field.parent as string]);
-  }
-  return false;
+  if (!field.visibleIf) return false;
+  const matcher = visibilityMatchers[field.visibleIf.matcher];
+  if (!matcher) return false;
+  return matcher(formData[field.visibleIf.field], field.visibleIf);
 }
 
 // Bug fix to also reset the option to empty string where no match against filtered curriculum data e.g. programmeSpecialty field.

--- a/utilities/__test__/FormBuilderUtilities.test.ts
+++ b/utilities/__test__/FormBuilderUtilities.test.ts
@@ -16,11 +16,13 @@ import {
   isDateWithin16WeeksOfFirstDate,
   setDraftFormRProps,
   setFormRDataForSubmit,
+  showFormField,
   transformReferenceData
 } from "../FormBuilderUtilities";
 import formAJson from "../../components/forms/form-builder/form-r/part-a/formA.json";
 import { formANew } from "../../mock-data/draft-formr-parta";
 import {
+  Field,
   Form,
   FormName
 } from "../../components/forms/form-builder/FormBuilder";
@@ -288,5 +290,84 @@ describe("isDateWithin16WeeksOfFirstDate", () => {
 
     expect(isDateWithin16WeeksOfFirstDate(validDateStr, refStr)).toBe(true);
     expect(isDateWithin16WeeksOfFirstDate(invalidDateStr, refStr)).toBe(false);
+  });
+});
+
+describe("showFormField", () => {
+  const makeField = (overrides: Partial<Field>): Field => ({
+    name: "fieldUnderTest",
+    type: "text",
+    visible: false,
+    ...overrides
+  });
+
+  it("returns true when field.visible is true regardless of visibleIf", () => {
+    const field = makeField({ visible: true });
+    expect(showFormField(field, {})).toBe(true);
+  });
+
+  it("returns false when not visible and no visibleIf is set", () => {
+    expect(showFormField(makeField({}), { anything: "value" })).toBe(false);
+  });
+
+  describe("valueInList matcher", () => {
+    const field = makeField({
+      visibleIf: {
+        matcher: "valueInList",
+        field: "reasonsSelected",
+        values: ["other"]
+      }
+    });
+
+    it("is visible when scalar parent value is in the values list", () => {
+      expect(showFormField(field, { reasonsSelected: "other" })).toBe(true);
+    });
+
+    it("is hidden when scalar parent value is not in the values list", () => {
+      expect(showFormField(field, { reasonsSelected: "caring" })).toBe(false);
+    });
+
+    it("is visible when an array parent value contains a match", () => {
+      expect(
+        showFormField(field, { reasonsSelected: ["caring", "other"] })
+      ).toBe(true);
+    });
+
+    it("is hidden when an array parent value contains no match", () => {
+      expect(
+        showFormField(field, { reasonsSelected: ["caring", "training"] })
+      ).toBe(false);
+    });
+
+    it("is hidden when values is missing", () => {
+      const fieldNoValues = makeField({
+        visibleIf: { matcher: "valueInList", field: "reasonsSelected" }
+      });
+      expect(showFormField(fieldNoValues, { reasonsSelected: "other" })).toBe(
+        false
+      );
+    });
+  });
+
+  describe("lessThan16WeeksTest matcher", () => {
+    const field = makeField({
+      visibleIf: { matcher: "lessThan16WeeksTest", field: "startDate" }
+    });
+
+    it("is visible when startDate is within 16 weeks of today", () => {
+      const within = dayjs().add(10, "week").format("YYYY-MM-DD");
+      expect(showFormField(field, { startDate: within })).toBe(true);
+    });
+
+    it("is hidden when startDate is more than 16 weeks away", () => {
+      const beyond = dayjs().add(20, "week").format("YYYY-MM-DD");
+      expect(showFormField(field, { startDate: beyond })).toBe(false);
+    });
+
+    it("is hidden when startDate is empty", () => {
+      expect(showFormField(field, { startDate: "" })).toBe(false);
+      expect(showFormField(field, { startDate: null })).toBe(false);
+      expect(showFormField(field, {})).toBe(false);
+    });
   });
 });

--- a/utilities/__test__/LtftUtilities.test.ts
+++ b/utilities/__test__/LtftUtilities.test.ts
@@ -41,6 +41,15 @@ describe("mapLtftObjToDto", () => {
     const mappedDto = mapLtftObjToDto(mockLtftDraftUpdatedPmFormObjNoSave);
     expect(mappedDto).toEqual(mockLtftDraftUpdatedPmFormDtoFirstSavePayload);
   });
+
+  it("should map empty altStartDate to null", () => {
+    const mappedDto = mapLtftObjToDto({
+      ...mockLtftDraftUpdatedPmFormObjNoSave,
+      altStartDate: ""
+    });
+
+    expect(mappedDto.change.altStartDate).toBeNull();
+  });
 });
 
 describe("mapDtoToLtftObj", () => {

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -23,7 +23,7 @@ export function populateLtftDraftNew(
     managingDeanery: "",
     type: "LTFT",
     startDate: null,
-    alternativeStartDate: null,
+    altStartDate: null,
     wteBeforeChange: null,
     wte: null,
     declarations: {
@@ -79,7 +79,7 @@ export const mapLtftObjToDto = (ltftObj: LtftObjNew): LtftDto => {
     change: {
       type: "LTFT",
       startDate: ltftObj.startDate,
-      alternativeStartDate: ltftObj.alternativeStartDate,
+      altStartDate: ltftObj.altStartDate,
       wte: ltftObj.wte ? ltftObj.wte / 100 : 0,
       id: null
     },
@@ -174,7 +174,7 @@ export const mapLtftDtoToObj = (ltftDto: LtftDto): LtftObjNew => {
     managingDeanery: ltftDto.programmeMembership.managingDeanery ?? "",
     type: ltftDto.change.type,
     startDate: ltftDto.change.startDate,
-    alternativeStartDate: ltftDto.change.alternativeStartDate ?? null,
+    altStartDate: ltftDto.change.altStartDate ?? null,
     wteBeforeChange: ltftDto.programmeMembership.wte
       ? Math.round(ltftDto.programmeMembership.wte * 100)
       : null,

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -79,7 +79,7 @@ export const mapLtftObjToDto = (ltftObj: LtftObjNew): LtftDto => {
     change: {
       type: "LTFT",
       startDate: ltftObj.startDate,
-      altStartDate: ltftObj.altStartDate,
+      altStartDate: ltftObj.altStartDate ? ltftObj.altStartDate : null,
       wte: ltftObj.wte ? ltftObj.wte / 100 : 0,
       id: null
     },

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -23,6 +23,7 @@ export function populateLtftDraftNew(
     managingDeanery: "",
     type: "LTFT",
     startDate: null,
+    alternativeStartDate: null,
     wteBeforeChange: null,
     wte: null,
     declarations: {
@@ -78,6 +79,7 @@ export const mapLtftObjToDto = (ltftObj: LtftObjNew): LtftDto => {
     change: {
       type: "LTFT",
       startDate: ltftObj.startDate,
+      alternativeStartDate: ltftObj.alternativeStartDate,
       wte: ltftObj.wte ? ltftObj.wte / 100 : 0,
       id: null
     },
@@ -172,6 +174,7 @@ export const mapLtftDtoToObj = (ltftDto: LtftDto): LtftObjNew => {
     managingDeanery: ltftDto.programmeMembership.managingDeanery ?? "",
     type: ltftDto.change.type,
     startDate: ltftDto.change.startDate,
+    alternativeStartDate: ltftDto.change.alternativeStartDate ?? null,
     wteBeforeChange: ltftDto.programmeMembership.wte
       ? Math.round(ltftDto.programmeMembership.wte * 100)
       : null,


### PR DESCRIPTION
Add a new LTFT user journey for late applications:
- startDate <16 weeks reveals an optional `altStartDate` field.
- Blank means "no suitable alternative" — the hint above altStartDate explains this.
- A filled value must be a valid date, at least 16 weeks from today,
  and not after the linked programme's end date. 
- Reorder LTFT pages so Reasons + Supporting follow Start date.
- Supporting information: trainee is prompted to explain reason and why no altStartDate (if applicable).

TIS21-8631
TIS21-8645