### PR TITLE
Refactor/update to nhsuk 10 and nhs react comps 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": ["istanbul"]
-}

--- a/components/Common.module.scss
+++ b/components/Common.module.scss
@@ -26,10 +26,26 @@ $alertYellow: #ffeb3b;
 }
 
 // profile
+.panelsWrapper {
+  .contentsList {
+    margin-left: 2.25rem;
+  }
+}
+
 .panelDiv {
   padding: 0.75rem;
   border-radius: 6px;
   margin: 0 16px 0 16px;
+
+  // Removes the empty 3rd column when there are no actions in nhsuk-react-component Summary List
+  :global(.nhsuk-summary-list__row--no-actions::after) {
+    display: none;
+  }
+
+  // Removes the default padding on the content nhsuk-react-component
+  :global(.nhsuk-card__content) {
+    padding: unset;
+  }
 }
 
 .panelDivHighlight {

--- a/components/actionSummary/ActionSummary.tsx
+++ b/components/actionSummary/ActionSummary.tsx
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import { Button, Card, Fieldset, Table } from "nhsuk-react-components";
+import { Button, Card, Fieldset, Legend, Table } from "nhsuk-react-components";
 import { useAppDispatch } from "../../redux/hooks/hooks";
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -32,21 +32,23 @@ export default function ActionSummary() {
       <Fieldset>
         <div className="nhsuk-grid-row">
           <div className="nhsuk-grid-column-two-thirds">
-            <Fieldset.Legend
+            <Legend
               isPageHeading
               className={style.fieldLegHeader}
               data-cy="actionSummaryHeading"
+              size="xl"
             >
               Action Summary
-            </Fieldset.Legend>
+            </Legend>
           </div>
           <div
             className="nhsuk-grid-column-one-third"
             style={{ textAlign: "right" }}
           >
             <Button
-              onClick={handleRefresh}
+              as="button"
               secondary
+              onClick={handleRefresh}
               data-cy="refreshActionsButton"
             >
               <FontAwesomeIcon icon={faSyncAlt} /> Refresh data
@@ -61,57 +63,55 @@ export default function ActionSummary() {
       ) : (
         groupedOutstandingActions.map(group => (
           <Card key={group["Programme ID"]}>
-            <Card.Content>
-              <Card.Heading>{group["Programme Membership name"]}</Card.Heading>
-              <Table responsive>
-                <Table.Head>
-                  <Table.Row>
-                    <Table.Cell>Action</Table.Cell>
-                    <Table.Cell>Due By</Table.Cell>
-                    <Table.Cell>Status</Table.Cell>
-                  </Table.Row>
-                </Table.Head>
-                <Table.Body>
-                  {group["Outstanding actions"].map(action => {
-                    if (!action.type) return null;
-                    const actionInfo = getActionTypeInfo(action);
-                    if (!actionInfo) return null;
-                    const { label, link } = actionInfo;
-                    return (
-                      <Table.Row key={action.id}>
-                        <Table.Cell>
-                          <Link to={link}>{label}</Link>
-                        </Table.Cell>
-                        <Table.Cell>
-                          {dayjs(action.dueBy).format("DD/MM/YYYY")}
-                        </Table.Cell>
-                        <Table.Cell>
-                          <span>
-                            <FontAwesomeIcon
-                              icon={faExclamationCircle}
-                              color="red"
-                            />{" "}
-                            Outstanding
-                          </span>
-                        </Table.Cell>
-                      </Table.Row>
-                    );
-                  })}
-                </Table.Body>
-              </Table>
-              <div style={{ marginTop: "2rem" }}>
-                <h3 className="nhsuk-heading-s">Onboarding Tracker</h3>
-                <Link
-                  to={`/programmes/${group["Programme ID"]}/onboarding-tracker`}
-                  className="nhsuk-link"
-                >
-                  <p>
-                    View Onboarding Tracker for{" "}
-                    {group["Programme Membership name"]}
-                  </p>
-                </Link>
-              </div>
-            </Card.Content>
+            <Card.Heading>{group["Programme Membership name"]}</Card.Heading>
+            <Table responsive>
+              <Table.Head>
+                <Table.Row>
+                  <Table.Cell>Action</Table.Cell>
+                  <Table.Cell>Due By</Table.Cell>
+                  <Table.Cell>Status</Table.Cell>
+                </Table.Row>
+              </Table.Head>
+              <Table.Body>
+                {group["Outstanding actions"].map(action => {
+                  if (!action.type) return null;
+                  const actionInfo = getActionTypeInfo(action);
+                  if (!actionInfo) return null;
+                  const { label, link } = actionInfo;
+                  return (
+                    <Table.Row key={action.id}>
+                      <Table.Cell>
+                        <Link to={link}>{label}</Link>
+                      </Table.Cell>
+                      <Table.Cell>
+                        {dayjs(action.dueBy).format("DD/MM/YYYY")}
+                      </Table.Cell>
+                      <Table.Cell>
+                        <span>
+                          <FontAwesomeIcon
+                            icon={faExclamationCircle}
+                            color="red"
+                          />{" "}
+                          Outstanding
+                        </span>
+                      </Table.Cell>
+                    </Table.Row>
+                  );
+                })}
+              </Table.Body>
+            </Table>
+            <div style={{ marginTop: "2rem" }}>
+              <h3 className="nhsuk-heading-s">Onboarding Tracker</h3>
+              <Link
+                to={`/programmes/${group["Programme ID"]}/onboarding-tracker`}
+                className="nhsuk-link"
+              >
+                <p>
+                  View Onboarding Tracker for{" "}
+                  {group["Programme Membership name"]}
+                </p>
+              </Link>
+            </div>
           </Card>
         ))
       )}

--- a/components/authentication/Auth.module.scss
+++ b/components/authentication/Auth.module.scss
@@ -15,18 +15,23 @@
       color: #fff;
     }
   }
-  .authFooterLinks.authFooterLinks {
-    justify-content: space-between !important;
-    padding: 30px 0 8px 0;
-    a {
+  .authFooterLinks {
+    display: flex;
+    justify-content: space-between;
+    padding: 30px 0 8px;
+  }
+
+  .authFooterLink {
+    color: whitesmoke;
+
+    &:link {
       color: whitesmoke;
-      &:link {
-        text-decoration: underline;
-        font-weight: 500;
-      }
+      text-decoration: underline;
+      font-weight: 500
     }
   }
-  .authFooterText.authFooterText {
+
+  .authFooterText {
     color: whitesmoke;
   }
 

--- a/components/authentication/setMfa/ChooseMfa.tsx
+++ b/components/authentication/setMfa/ChooseMfa.tsx
@@ -88,18 +88,16 @@ const ChooseMfa = () => {
               </Details.Text>
             </Details>
             <Card feature>
-              <Card.Content>
-                <Card.Heading>Next time I sign in...</Card.Heading>
-                <p>
-                  I want to verify my identity with a One Time Password (OTP):
-                </p>
-                <MultiChoiceInputField
-                  type="radios"
-                  id="mfaChoice"
-                  name="mfaChoice"
-                  items={getMfaOptions(preferredMfa)}
-                ></MultiChoiceInputField>
-              </Card.Content>
+              <Card.Heading>Next time I sign in...</Card.Heading>
+              <p>
+                I want to verify my identity with a One Time Password (OTP):
+              </p>
+              <MultiChoiceInputField
+                type="radios"
+                id="mfaChoice"
+                name="mfaChoice"
+                items={getMfaOptions(preferredMfa)}
+              ></MultiChoiceInputField>
             </Card>
             <Button
               onClick={() => {
@@ -126,9 +124,7 @@ function MfaWarning({ preferredMfa }: MfaWarningProps) {
   const cyTag = preferredMfa === "NOMFA" ? "mfaSetup" : "mfaAlreadyWarning";
   return (
     <WarningCallout data-cy={cyTag}>
-      <WarningCallout.Label visuallyHiddenText={false}>
-        Important
-      </WarningCallout.Label>
+      <WarningCallout.Heading>Important</WarningCallout.Heading>
       <p>{getPrefMfa(preferredMfa)}</p>
     </WarningCallout>
   );

--- a/components/authentication/setMfa/MFA.tsx
+++ b/components/authentication/setMfa/MFA.tsx
@@ -1,6 +1,6 @@
 import { Redirect, Route, Switch } from "react-router-dom";
 import PageTitle from "../../common/PageTitle";
-import { Fieldset } from "nhsuk-react-components";
+import { Fieldset, Legend } from "nhsuk-react-components";
 import ChooseMfa from "./ChooseMfa";
 import CreateTotp from "./totp/CreateTotp";
 import PageNotFound from "../../common/PageNotFound";
@@ -12,13 +12,14 @@ const MFA = () => {
     <>
       <PageTitle title="MFA" />
       <Fieldset>
-        <Fieldset.Legend
+        <Legend
           isPageHeading
           className={style.fieldLegHeader}
           data-cy="mfaHeading"
+          size="xl"
         >
           MFA (Multi-Factor Authentication) set-up
-        </Fieldset.Legend>
+        </Legend>
       </Fieldset>
       <Switch>
         <Route exact path="/mfa/email" component={ConfirmEmail} />

--- a/components/authentication/setMfa/email/ConfirmEmail.tsx
+++ b/components/authentication/setMfa/email/ConfirmEmail.tsx
@@ -34,32 +34,30 @@ const ConfirmEmail = () => {
   return (
     <>
       <Card feature>
-        <Card.Content>
-          <Card.Heading>Email MFA</Card.Heading>
-          <p>Using email as your second authentication factor:</p>
-          <ul>
-            <li>You will enter your email and password</li>
-            <li>Receive a 6-digit verification code via email</li>
-            <li>Enter this code to sign in</li>
-          </ul>
-          <p>
-            This adds an extra layer of security to your account and helps
-            protect your sensitive information.
-          </p>
-          <Details>
-            <Details.Summary>Why use Email MFA?</Details.Summary>
-            <Details.Text>
-              <p>
-                {`
+        <Card.Heading>Email MFA</Card.Heading>
+        <p>Using email as your second authentication factor:</p>
+        <ul>
+          <li>You will enter your email and password</li>
+          <li>Receive a 6-digit verification code via email</li>
+          <li>Enter this code to sign in</li>
+        </ul>
+        <p>
+          This adds an extra layer of security to your account and helps protect
+          your sensitive information.
+        </p>
+        <Details>
+          <Details.Summary>Why use Email MFA?</Details.Summary>
+          <Details.Text>
+            <p>
+              {`
                 Email MFA provides additional security without requiring a
                 mobile phone. It is more secure than SMS MFA and it's convenient
                 as you can access your email from multiple devices. The
                 verification codes expire after a short period, ensuring only
                 you can access your account.`}
-              </p>
-            </Details.Text>
-          </Details>
-        </Card.Content>
+            </p>
+          </Details.Text>
+        </Details>
       </Card>
       <Button
         onClick={handleConfirmEmail}

--- a/components/authentication/setMfa/totp/DecideTotp.tsx
+++ b/components/authentication/setMfa/totp/DecideTotp.tsx
@@ -25,17 +25,15 @@ const DecideTotp = ({ handleSectionSubmit }: IDecideTotp) => {
       {({ values, handleSubmit, isSubmitting }) => (
         <Form>
           <Card feature data-cy="appInstalledAlreadyChoose">
-            <Card.Content>
-              <Card.Heading>
-                I&#39;ve already installed an Authenticator App
-              </Card.Heading>
-              <MultiChoiceInputField
-                type="radios"
-                id="appInstalledAlready"
-                name="appInstalledAlready"
-                items={YES_NO_OPTIONS}
-              ></MultiChoiceInputField>
-            </Card.Content>
+            <Card.Heading>
+              I&#39;ve already installed an Authenticator App
+            </Card.Heading>
+            <MultiChoiceInputField
+              type="radios"
+              id="appInstalledAlready"
+              name="appInstalledAlready"
+              items={YES_NO_OPTIONS}
+            ></MultiChoiceInputField>
           </Card>
           {values.appInstalledAlready === "true" && <ThreeMinMsg />}
           {values.appInstalledAlready !== null && (

--- a/components/authentication/setMfa/totp/ThreeMinMsg.tsx
+++ b/components/authentication/setMfa/totp/ThreeMinMsg.tsx
@@ -3,9 +3,7 @@ import { WarningCallout } from "nhsuk-react-components";
 const ThreeMinMsg = () => {
   return (
     <WarningCallout data-cy="threeMinWarning">
-      <WarningCallout.Label visuallyHiddenText={false}>
-        Important
-      </WarningCallout.Label>
+      <WarningCallout.Heading>Important</WarningCallout.Heading>
       <p>
         On the next screen you will have <strong>3 minutes</strong> to scan a QR
         code using your Authenticator App on your phone before it expires and

--- a/components/authentication/setMfa/totp/TotpInstructions.tsx
+++ b/components/authentication/setMfa/totp/TotpInstructions.tsx
@@ -5,6 +5,7 @@ import {
   Container,
   Details,
   Fieldset,
+  Legend,
   Row
 } from "nhsuk-react-components";
 import MultiChoiceInputField from "../../../forms/MultiChoiceInputField";
@@ -13,121 +14,119 @@ import styles from "../../../authentication/Auth.module.scss";
 const TotpInstructions = () => {
   return (
     <Card feature data-cy="installTotpPanel">
-      <Card.Content>
-        <Card.Heading>
-          Installing the Microsoft Authenticator App on your phone
-        </Card.Heading>
-        <Details>
-          <Details.Summary data-cy="msAuthInfoSummary">
-            More details
-          </Details.Summary>
-          <Details.Text>
-            <p data-cy="msAuthInfoText">
-              Below are instructions to help you install Microsoft Authenticator
-              on your Android phone or iPhone. Please note that Microsoft
-              Athenticator works on mobile devices only (includes iPad).
-            </p>
-            <p>You can use any other Authenticator app if you prefer.</p>
-          </Details.Text>
-        </Details>
-        <Card feature data-cy="scanQrPanel" className={styles.panelBack}>
-          <Card.Content>
-            <Card.Heading>Scan the QR Code with your phone</Card.Heading>
-            <Fieldset.Legend size="m" data-cy="scanQrHeader">
-              Using the camera on your phone, scan a QR Code below to download
-              the Microsoft Authenticator App.
-            </Fieldset.Legend>
-            <Container>
-              <Row>
-                <Col width="one-half">
+      <Card.Heading>
+        Installing the Microsoft Authenticator App on your phone
+      </Card.Heading>
+      <Details>
+        <Details.Summary data-cy="msAuthInfoSummary">
+          More details
+        </Details.Summary>
+        <Details.Text>
+          <p data-cy="msAuthInfoText">
+            Below are instructions to help you install Microsoft Authenticator
+            on your Android phone or iPhone. Please note that Microsoft
+            Athenticator works on mobile devices only (includes iPad).
+          </p>
+          <p>You can use any other Authenticator app if you prefer.</p>
+        </Details.Text>
+      </Details>
+      <Card feature data-cy="scanQrPanel" className={styles.panelBack}>
+        <Card.Heading>Scan the QR Code with your phone</Card.Heading>
+        <Fieldset>
+          <Legend size="m" data-cy="scanQrHeader">
+            Using the camera on your phone, scan a QR Code below to download the
+            Microsoft Authenticator App.
+          </Legend>
+        </Fieldset>
+        <Container>
+          <Row>
+            <Col width="one-half">
+              <img
+                data-cy="qrApple"
+                alt="App Store (Apple) MS Authenticator QR Code"
+                src="https://support.microsoft.com/images/en-us/8d591290-28d1-4c5a-8392-bf7ebbb2875b"
+              ></img>
+              <p>App Store (Apple)</p>
+            </Col>
+            <Col width="one-half">
+              <img
+                data-cy="qrAndroid"
+                alt="Google Play store MS Authenticator QR Code"
+                src="https://support.microsoft.com/images/en-us/752f5229-e6bb-4ce8-8f48-d6d255212648"
+              ></img>
+              <p>Google Play store</p>
+            </Col>
+          </Row>
+        </Container>
+      </Card>
+      <Details className={styles.detailsAuthHelp}>
+        <Details.Summary data-cy="moreHelpSummary">
+          Need more help?
+        </Details.Summary>
+        <Details.Text data-cy="moreHelpText">
+          <ActionLink
+            data-cy="authGuideLink"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://tis-support.hee.nhs.uk/trainees/how-to-set-up-an-authenticator-app-on-your-phone/"
+          >
+            Click here for help installing the Microsoft Authenticator App on
+            your phone (opens in a new tab/window)
+          </ActionLink>
+        </Details.Text>
+        <Details.Text data-cy="altTotpDownloadText">
+          <p>
+            If you need an alternative to a QR code then please click a logo
+            link below to download an Authenticator App:
+          </p>
+        </Details.Text>
+        <Details.Text data-cy="altTotpDownloadLinks">
+          <Container>
+            <Row>
+              <Col width="one-half">
+                <a
+                  data-cy="appLinkApple"
+                  href="https://apps.apple.com/us/app/microsoft-authenticator/id983156458?itsct=apps_box_badge&amp;itscg=30200"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   <img
-                    data-cy="qrApple"
-                    alt="App Store (Apple) MS Authenticator QR Code"
-                    src="https://support.microsoft.com/images/en-us/8d591290-28d1-4c5a-8392-bf7ebbb2875b"
-                  ></img>
-                  <p>App Store (Apple)</p>
-                </Col>
-                <Col width="one-half">
+                    className={styles.altDownloadApple}
+                    src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1432944000&h=39686e6a537b2c44ff7ce60f6287e68f"
+                    alt="Download on the App Store"
+                  />
+                </a>
+              </Col>
+              <Col width="one-half">
+                <a
+                  data-cy="appLinkAndroid"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="https://play.google.com/store/apps/details?id=com.azure.authenticator&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
+                >
                   <img
-                    data-cy="qrAndroid"
-                    alt="Google Play store MS Authenticator QR Code"
-                    src="https://support.microsoft.com/images/en-us/752f5229-e6bb-4ce8-8f48-d6d255212648"
-                  ></img>
-                  <p>Google Play store</p>
-                </Col>
-              </Row>
-            </Container>
-          </Card.Content>
-        </Card>
-        <Details className={styles.detailsAuthHelp}>
-          <Details.Summary data-cy="moreHelpSummary">
-            Need more help?
-          </Details.Summary>
-          <Details.Text data-cy="moreHelpText">
-            <ActionLink
-              data-cy="authGuideLink"
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://tis-support.hee.nhs.uk/trainees/how-to-set-up-an-authenticator-app-on-your-phone/"
-            >
-              Click here for help installing the Microsoft Authenticator App on
-              your phone (opens in a new tab/window)
-            </ActionLink>
-          </Details.Text>
-          <Details.Text data-cy="altTotpDownloadText">
-            <p>
-              If you need an alternative to a QR code then please click a logo
-              link below to download an Authenticator App:
-            </p>
-          </Details.Text>
-          <Details.Text data-cy="altTotpDownloadLinks">
-            <Container>
-              <Row>
-                <Col width="one-half">
-                  <a
-                    data-cy="appLinkApple"
-                    href="https://apps.apple.com/us/app/microsoft-authenticator/id983156458?itsct=apps_box_badge&amp;itscg=30200"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <img
-                      className={styles.altDownloadApple}
-                      src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1432944000&h=39686e6a537b2c44ff7ce60f6287e68f"
-                      alt="Download on the App Store"
-                    />
-                  </a>
-                </Col>
-                <Col width="one-half">
-                  <a
-                    data-cy="appLinkAndroid"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href="https://play.google.com/store/apps/details?id=com.azure.authenticator&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
-                  >
-                    <img
-                      className={styles.altDownloadAndroid}
-                      alt="Get it on Google Play"
-                      src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
-                    />
-                  </a>
-                </Col>
-              </Row>
-            </Container>
-          </Details.Text>
-        </Details>
-        <MultiChoiceInputField
-          data-cy="appInstalledNowCheck"
-          id="appInstalledNow"
-          type="checkbox"
-          name="appInstalledNow"
-          items={[
-            {
-              label: "I have successfully installed an Authenticator App.",
-              value: true
-            }
-          ]}
-        />
-      </Card.Content>
+                    className={styles.altDownloadAndroid}
+                    alt="Get it on Google Play"
+                    src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
+                  />
+                </a>
+              </Col>
+            </Row>
+          </Container>
+        </Details.Text>
+      </Details>
+      <MultiChoiceInputField
+        data-cy="appInstalledNowCheck"
+        id="appInstalledNow"
+        type="checkbox"
+        name="appInstalledNow"
+        items={[
+          {
+            label: "I have successfully installed an Authenticator App.",
+            value: true
+          }
+        ]}
+      />
     </Card>
   );
 };

--- a/components/authentication/setMfa/totp/VerifyTotp.tsx
+++ b/components/authentication/setMfa/totp/VerifyTotp.tsx
@@ -5,7 +5,8 @@ import {
   Details,
   Fieldset,
   Form,
-  Input,
+  Legend,
+  TextInput,
   WarningCallout
 } from "nhsuk-react-components";
 import { useEffect, useRef, useState } from "react";
@@ -100,115 +101,113 @@ const VerifyTotp = () => {
   return (
     <>
       <WarningCallout>
-        <WarningCallout.Label visuallyHiddenText={false}>
+        <WarningCallout.Heading visuallyHiddenText="">
           Remember
-        </WarningCallout.Label>
+        </WarningCallout.Heading>
         <p data-cy="threeMinReminderText">
           You have <strong>3 minutes</strong> to scan the QR code below using
           your Authenticator App on your phone before it expires.
         </p>
       </WarningCallout>
       <Card feature data-cy="addTssTotpHeader">
-        <Card.Content>
-          <Card.Heading>
-            Add &#39;NHS TIS-Self-Service&#39; to your Authenticator App
-          </Card.Heading>
-          <Details>
-            <Details.Summary data-cy="msAuthInfoSummary">
-              Need help?
-            </Details.Summary>
-            <Details.Text data-cy="msAuthInfoText">
-              <ActionLink
-                data-cy="dataSourceLink"
-                target="_blank"
-                rel="noopener noreferrer"
-                href="https://tis-support.hee.nhs.uk/trainees/how-to-set-up-an-authenticator-app-on-your-phone/"
+        <Card.Heading>
+          Add &#39;NHS TIS-Self-Service&#39; to your Authenticator App
+        </Card.Heading>
+        <Details>
+          <Details.Summary data-cy="msAuthInfoSummary">
+            Need help?
+          </Details.Summary>
+          <Details.Text data-cy="msAuthInfoText">
+            <ActionLink
+              data-cy="dataSourceLink"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://tis-support.hee.nhs.uk/trainees/how-to-set-up-an-authenticator-app-on-your-phone/"
+            >
+              Click here for help adding the &#39;NHS TIS Self-Service&#39;
+              account to your Authenticator App on your phone (opens in a new
+              tab/window)
+            </ActionLink>
+          </Details.Text>
+        </Details>
+        <Card feature className={styles.panelBack}>
+          <Card.Heading>using your phone</Card.Heading>
+          <Fieldset>
+            <Legend size="m">
+              Open your Authenticator App, click &#39;add a new account&#39;
+              button then scan the QR Code below.
+            </Legend>
+          </Fieldset>
+          <div className={styles.qrTss}>
+            <RenderQRCodeContent
+              qrCode={qrCode}
+              isLoading={isLoading}
+              isExpired={isExpired}
+              errorQR={errorQR}
+              generateQrCode={generateQrCode}
+            />
+          </div>
+          {isExpired || isLoading ? null : (
+            <>
+              <Details>
+                <Details.Summary data-cy="tssQrCodeHelp">
+                  Unable to scan QR code?
+                </Details.Summary>
+                <Details.Text>
+                  <p>
+                    If you are not using a mobile Authenticator App or are
+                    unable to see the QR code, you can enter the following code
+                    instead.
+                  </p>
+                  <TextInput
+                    data-cy="tssQrCodeStr"
+                    onFocus={(event: React.FocusEvent<HTMLInputElement>) =>
+                      event.target.select()
+                    }
+                    defaultValue={totpStr}
+                    label=""
+                    readOnly
+                  />
+                </Details.Text>
+              </Details>
+              <Formik
+                initialValues={{ confirmTOTPCode: "" }}
+                validationSchema={Yup.object({
+                  confirmTOTPCode: Yup.string()
+                    .required("TOTP code required")
+                    .min(6, "Code must be min 6 characters in length")
+                    .max(6, "Code must be max 6 characters in length")
+                })}
+                onSubmit={values => handleTotpSub(values.confirmTOTPCode)}
               >
-                Click here for help adding the &#39;NHS TIS Self-Service&#39;
-                account to your Authenticator App on your phone (opens in a new
-                tab/window)
-              </ActionLink>
-            </Details.Text>
-          </Details>
-          <Card feature className={styles.panelBack}>
-            <Card.Content>
-              <Card.Heading>using your phone</Card.Heading>
-              <Fieldset.Legend size="m">
-                Open your Authenticator App, click &#39;add a new account&#39;
-                button then scan the QR Code below.
-              </Fieldset.Legend>
-              <div className={styles.qrTss}>
-                <RenderQRCodeContent
-                  qrCode={qrCode}
-                  isLoading={isLoading}
-                  isExpired={isExpired}
-                  errorQR={errorQR}
-                  generateQrCode={generateQrCode}
-                />
-              </div>
-              {isExpired || isLoading ? null : (
-                <>
-                  <Details>
-                    <Details.Summary data-cy="tssQrCodeHelp">
-                      Unable to scan QR code?
-                    </Details.Summary>
-                    <Details.Text>
-                      <p>
-                        If you are not using a mobile Authenticator App or are
-                        unable to see the QR code, you can enter the following
-                        code instead.
-                      </p>
-                      <Input
-                        data-cy="tssQrCodeStr"
-                        onFocus={event => event.target.select()}
-                        defaultValue={totpStr}
-                        label=""
-                        readOnly
-                      />
-                    </Details.Text>
-                  </Details>
-                  <Formik
-                    initialValues={{ confirmTOTPCode: "" }}
-                    validationSchema={Yup.object({
-                      confirmTOTPCode: Yup.string()
-                        .required("TOTP code required")
-                        .min(6, "Code must be min 6 characters in length")
-                        .max(6, "Code must be max 6 characters in length")
-                    })}
-                    onSubmit={values => handleTotpSub(values.confirmTOTPCode)}
-                  >
-                    {({ isValid, isSubmitting, handleSubmit }) => (
-                      <Form>
-                        <TextInputField
-                          width={10}
-                          name="confirmTOTPCode"
-                          label="Enter the 6-digit code from the 'NHS TIS Self-Service' account installed on your phone."
-                          placeholder="6-digit code"
-                        />
-                        <Button
-                          onClick={(e: { preventDefault: () => void }) => {
-                            e.preventDefault();
-                            setErrorVerifyCode(false);
-                            handleSubmit();
-                          }}
-                          disabled={!isValid || isSubmitting}
-                          data-cy="BtnTotpCodeSub"
-                        >
-                          {isSubmitting
-                            ? "Verifying..."
-                            : " Verify code & Log in"}
-                        </Button>
-                        {errorVerifyCode && (
-                          <ErrorPage message="There was an error verifying the TOTP code. Please try again." />
-                        )}
-                      </Form>
+                {({ isValid, isSubmitting, handleSubmit }) => (
+                  <Form>
+                    <TextInputField
+                      width={10}
+                      name="confirmTOTPCode"
+                      label="Enter the 6-digit code from the 'NHS TIS Self-Service' account installed on your phone."
+                      placeholder="6-digit code"
+                    />
+                    <Button
+                      onClick={(e: { preventDefault: () => void }) => {
+                        e.preventDefault();
+                        setErrorVerifyCode(false);
+                        handleSubmit();
+                      }}
+                      disabled={!isValid || isSubmitting}
+                      data-cy="BtnTotpCodeSub"
+                    >
+                      {isSubmitting ? "Verifying..." : " Verify code & Log in"}
+                    </Button>
+                    {errorVerifyCode && (
+                      <ErrorPage message="There was an error verifying the TOTP code. Please try again." />
                     )}
-                  </Formik>
-                </>
-              )}
-            </Card.Content>
-          </Card>
-        </Card.Content>
+                  </Form>
+                )}
+              </Formik>
+            </>
+          )}
+        </Card>
       </Card>
     </>
   );

--- a/components/authentication/signup/footer/AuthFooter.tsx
+++ b/components/authentication/signup/footer/AuthFooter.tsx
@@ -1,28 +1,17 @@
-import { Flex, Text } from "@aws-amplify/ui-react";
-import dayjs from "dayjs";
-import styles from "../../Auth.module.scss";
-
-const footerLinks = [
-  { name: "About", href: "https://tis-support.hee.nhs.uk/about-tis/" },
-  {
-    name: "Privacy & Cookies",
-    href: "https://www.hee.nhs.uk/about/privacy-notice"
-  }
-];
+import { Footer } from "nhsuk-react-components";
 
 export const AuthFooter = (): JSX.Element => {
   return (
-    <Flex className={styles.authFooterLinks}>
-      {footerLinks.map(link => (
-        <Text key={link.name}>
-          <a href={link.href} target="_blank" rel="noopener noreferrer">
-            {link.name}
-          </a>
-        </Text>
-      ))}
-      <Text className={styles.authFooterText} data-cy="footerCopy">
-        &copy; NHS England {dayjs().year()}
-      </Text>
-    </Flex>
+    <Footer>
+      <Footer.Meta>
+        <Footer.ListItem href="https://tis-support.hee.nhs.uk/about-tis/">
+          About
+        </Footer.ListItem>
+        <Footer.ListItem href="https://www.hee.nhs.uk/about/privacy-notice">
+          Privacy & Cookies
+        </Footer.ListItem>
+        <Footer.Copyright data-cy="footerCopy" />
+      </Footer.Meta>
+    </Footer>
   );
 };

--- a/components/authentication/signup/footer/AuthFooter.tsx
+++ b/components/authentication/signup/footer/AuthFooter.tsx
@@ -1,17 +1,29 @@
-import { Footer } from "nhsuk-react-components";
+import styles from "../../Auth.module.scss";
 
 export const AuthFooter = (): JSX.Element => {
   return (
-    <Footer>
-      <Footer.Meta>
-        <Footer.ListItem href="https://tis-support.hee.nhs.uk/about-tis/">
-          About
-        </Footer.ListItem>
-        <Footer.ListItem href="https://www.hee.nhs.uk/about/privacy-notice">
-          Privacy & Cookies
-        </Footer.ListItem>
-        <Footer.Copyright data-cy="footerCopy" />
-      </Footer.Meta>
-    </Footer>
+    <footer className={styles.authFooterLinks}>
+      <a
+        className={styles.authFooterLink}
+        href="https://tis-support.hee.nhs.uk/about-tis/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        About
+      </a>
+
+      <a
+        className={styles.authFooterLink}
+        href="https://www.hee.nhs.uk/about/privacy-notice"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Privacy & Cookies
+      </a>
+
+      <span className={styles.authFooterText}>
+        © NHS England {new Date().getFullYear()}
+      </span>
+    </footer>
   );
 };

--- a/components/common/ActionModal.tsx
+++ b/components/common/ActionModal.tsx
@@ -42,12 +42,12 @@ export function ActionModal({
   return (
     <Modal isOpen={isOpen} onClose={onClose} cancelBtnText={cancelBtnText}>
       <WarningCallout data-cy="actionModalWarning">
-        <WarningCallout.Label
-          visuallyHiddenText={false}
+        <WarningCallout.Heading
+          visuallyHiddenText=""
           data-cy={`warningLabel-${warningLabel}`}
         >
           {warningLabel}
-        </WarningCallout.Label>
+        </WarningCallout.Heading>
         <p data-cy={`warningText-${warningLabel}`}>{warningText}</p>
         {additionalInfo && <p data-cy="additionalInfo">{additionalInfo}</p>}
       </WarningCallout>
@@ -78,7 +78,7 @@ export function ActionModal({
               </>
             )}
             <Button
-              type="submit"
+              as="button"
               disabled={isSubmitting || (hasReason && !values.reason)}
               data-cy={`submitBtn-${warningLabel}`}
             >

--- a/components/common/PanelsCreator.tsx
+++ b/components/common/PanelsCreator.tsx
@@ -2,6 +2,8 @@ import {
   BodyText,
   Button,
   Card,
+  ContentsList,
+  ContentsListItem,
   Label,
   SummaryList
 } from "nhsuk-react-components";
@@ -62,14 +64,28 @@ export function PanelsCreator({
   const keysToDisplay = getKeysToDisplay(panelsName, userFeatures);
   const panelsTitle = PANEL_KEYS[panelsName];
 
+  const getPanelTitle = (panel: ProfileType): string =>
+    panelsName === TraineeProfileName.Programmes
+      ? (panel as ProgrammeMembership).programmeName
+      : (panel as Placement).site;
+
+  const makePanelId = (panel: ProfileType) =>
+    `panel-${getPanelTitle(panel).toLowerCase()}`;
+
   return (
-    <Card.Group>
+    <Card.Group className={style.panelsWrapper}>
+      {panelsArr.length > 1 && (
+        <ContentsList className={style.contentsList}>
+          {panelsArr.map((panel: ProfileType, index: number) => (
+            <ContentsListItem href={`#${makePanelId(panel)}`} key={index}>
+              {getPanelTitle(panel)}
+            </ContentsListItem>
+          ))}
+        </ContentsList>
+      )}
       {panelsArr.length > 0 ? (
         panelsArr.map((panel: ProfileType, index: number) => {
-          const panelTitle =
-            panelsName === TraineeProfileName.Programmes
-              ? (panel as ProgrammeMembership).programmeName
-              : (panel as Placement).site;
+          const panelTitle = getPanelTitle(panel);
 
           const currentAction = unreviewedActions.filter(
             action =>
@@ -77,7 +93,7 @@ export function PanelsCreator({
               action.type === "REVIEW_DATA"
           );
           return (
-            <Card.GroupItem key={index} width="one-half">
+            <Card.GroupItem key={index} width="full">
               <Card
                 className={
                   currentAction.length > 0
@@ -85,7 +101,9 @@ export function PanelsCreator({
                     : style.panelDiv
                 }
               >
-                <p className={style.panelHeader}>{panelTitle}</p>
+                <p id={makePanelId(panel)} className={style.panelHeader}>
+                  {panelTitle}
+                </p>
                 <SummaryList>
                   {panelsName === TraineeProfileName.Programmes &&
                     dayjs(panel.startDate).isAfter(

--- a/components/common/PanelsCreator.tsx
+++ b/components/common/PanelsCreator.tsx
@@ -75,7 +75,10 @@ export function PanelsCreator({
   return (
     <Card.Group className={style.panelsWrapper}>
       {panelsArr.length > 1 && (
-        <ContentsList className={style.contentsList}>
+        <ContentsList
+          className={style.contentsList}
+          data-cy="programmeContents"
+        >
           {panelsArr.map((panel: ProfileType, index: number) => (
             <ContentsListItem href={`#${makePanelId(panel)}`} key={index}>
               {getPanelTitle(panel)}

--- a/components/common/SectionGenerator.tsx
+++ b/components/common/SectionGenerator.tsx
@@ -1,4 +1,4 @@
-import { Fieldset } from "nhsuk-react-components";
+import { Fieldset, Legend } from "nhsuk-react-components";
 import React, { FunctionComponent } from "react";
 import ScrollTo from "../../components/forms/ScrollTo";
 import Loading from "./Loading";
@@ -29,9 +29,9 @@ const SectionGenerator = <U,>({
       <ScrollTo />
       <FormBackLink text="Start over" />
       <main>
-        <Fieldset.Legend size="l">
-          {sectionsArr[section - 1].title}
-        </Fieldset.Legend>
+        <Fieldset>
+          <Legend size="l">{sectionsArr[section - 1].title}</Legend>
+        </Fieldset>
         <div className="form-wrapper">
           <section>
             <div className="page-wrapper">

--- a/components/common/SignOutBtn.tsx
+++ b/components/common/SignOutBtn.tsx
@@ -5,7 +5,7 @@ export const SignOutBtn = () => {
   const { signOut } = useAuthenticator(context => [context.user]);
   return (
     <Button
-      type="button"
+      as="button"
       className="sign-out-btn"
       data-cy="signOutBtn"
       onClick={signOut}

--- a/components/forms/Declarations.tsx
+++ b/components/forms/Declarations.tsx
@@ -37,7 +37,7 @@ export default function Declarations({
   return (
     <Checkboxes>
       {formDeclarations.map(declaration => (
-        <Checkboxes.Box
+        <Checkboxes.Item
           key={declaration.name}
           data-cy={declaration.name}
           name={declaration.name}
@@ -46,7 +46,7 @@ export default function Declarations({
           readOnly={!canEdit}
         >
           {declaration.label}
-        </Checkboxes.Box>
+        </Checkboxes.Item>
       ))}
     </Checkboxes>
   );

--- a/components/forms/MultiChoiceInputField.tsx
+++ b/components/forms/MultiChoiceInputField.tsx
@@ -21,7 +21,7 @@ const MultiChoiceInputField: React.FC<Props> = props => {
   const [field, { error }, helpers] = useField(props);
   const FormElement = props.type === "radios" ? Radios : Checkboxes;
   const FormChildElement =
-    props.type === "radios" ? Radios.Radio : Checkboxes.Box;
+    props.type === "radios" ? Radios.Item : Checkboxes.Item;
   return (
     <div
       data-jest={props.name}

--- a/components/forms/TextInputField.tsx
+++ b/components/forms/TextInputField.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from "react";
 import { useField, connect } from "formik";
-import { Input, Textarea } from "nhsuk-react-components";
+import { TextInput, Textarea } from "nhsuk-react-components";
 import InputFooterLabel from "./InputFooterLabel";
 import { handleKeyDown } from "../../utilities/FormBuilderUtilities";
 interface Props {
@@ -25,7 +25,9 @@ interface Props {
 
 const TextInputField: FunctionComponent<Props> = props => {
   const [field, { error }] = useField(props);
-  const FormElement = props.rows ? Textarea : Input;
+  const FormElement: React.ComponentType<any> = props.rows
+    ? Textarea
+    : TextInput;
   const setFieldWidth = (valueLength: number | undefined) => {
     return valueLength && valueLength < 20 ? 20 : Math.floor(width / 10) * 10;
   };
@@ -67,7 +69,9 @@ const TextInputField: FunctionComponent<Props> = props => {
         <FormElement
           autoComplete="off"
           onKeyDown={handleKeyDown}
-          onInput={e => handleNumberInput(isNumberField, e)}
+          onInput={(
+            e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>
+          ) => handleNumberInput(isNumberField, e)}
           width={width ?? setFieldWidth(field.value?.length)}
           disabled={props.disabled}
           error={error ?? ""}

--- a/components/forms/cct/Cct.tsx
+++ b/components/forms/cct/Cct.tsx
@@ -1,4 +1,4 @@
-import { Fieldset } from "nhsuk-react-components";
+import { Fieldset, Legend } from "nhsuk-react-components";
 import style from "../../Common.module.scss";
 import { Route, Switch } from "react-router-dom";
 import PageNotFound from "../../common/PageNotFound";
@@ -9,13 +9,14 @@ export function Cct() {
   return (
     <>
       <Fieldset>
-        <Fieldset.Legend
+        <Legend
           isPageHeading
           className={style.fieldLegHeader}
           data-cy="cct-header"
+          size="xl"
         >
           Certificate of Completion of Training (CCT)
-        </Fieldset.Legend>
+        </Legend>
       </Fieldset>
       <Switch>
         <Route exact path="/cct/view" component={CctCalcView} />

--- a/components/forms/cct/CctCalcSummaryDetails.tsx
+++ b/components/forms/cct/CctCalcSummaryDetails.tsx
@@ -31,9 +31,9 @@ export function CctCalcSummaryDetails({
   return (
     <Card className="pdf-visible">
       <WarningCallout>
-        <WarningCallout.Label data-cy="cct-calc-warning-label">
+        <WarningCallout.Heading data-cy="cct-calc-warning-label">
           {cctReadBeforeProceedingLabel}
-        </WarningCallout.Label>
+        </WarningCallout.Heading>
         <p data-cy="cct-calc-warning-text1">
           {cctCalcSummaryWarningMsgs.text1}
         </p>
@@ -42,100 +42,97 @@ export function CctCalcSummaryDetails({
         </p>
         <CctCalculatorLinks />
       </WarningCallout>
-      <Card.Content>
-        <Card.Heading data-cy="cct-calc-summary-header">
-          CCT Calculation Summary
-        </Card.Heading>
-        <Container>
-          <Row>
-            <Col width="full">
-              <SummaryList noBorder>
-                <h3 className={style.panelSubHeader}>Linked Programme</h3>
-                <SummaryList.Row>
-                  <SummaryList.Key>Programme name</SummaryList.Key>
-                  <SummaryList.Value>
-                    {programmeMembership.name}
-                  </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                  <SummaryList.Key>Start date</SummaryList.Key>
-                  <SummaryList.Value>
-                    {dayjs(programmeMembership.startDate).format("DD/MM/YYYY")}
-                  </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                  <SummaryList.Key>Completion date</SummaryList.Key>
-                  <SummaryList.Value>
-                    {dayjs(programmeMembership.endDate).format("DD/MM/YYYY")}
-                  </SummaryList.Value>
-                </SummaryList.Row>
-                <h3 className={style.panelSubHeader}> Changes</h3>
-                <SummaryList.Row>
-                  <SummaryList.Key>
-                    Full-time hours percentage before change
-                  </SummaryList.Key>
-                  <SummaryList.Value>
-                    {programmeMembership.wte && programmeMembership.wte * 100}%
-                  </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                  <SummaryList.Key>
-                    Full-time hours percentage after change
-                  </SummaryList.Key>
-                  <SummaryList.Value data-cy="cct-view-new-wte">
-                    {changes[0].wte && changes[0].wte * 100}%
-                    {changes[0].wte! > programmeMembership.wte! && (
-                      <FieldWarningMsg warningMsgs={[wteIncreaseMsg]} />
+      <Card.Heading data-cy="cct-calc-summary-header">
+        CCT Calculation Summary
+      </Card.Heading>
+      <Container>
+        <Row>
+          <Col width="full">
+            <SummaryList noBorder>
+              <h3 className={style.panelSubHeader}>Linked Programme</h3>
+              <SummaryList.Row>
+                <SummaryList.Key>Programme name</SummaryList.Key>
+                <SummaryList.Value>
+                  {programmeMembership.name}
+                </SummaryList.Value>
+              </SummaryList.Row>
+              <SummaryList.Row>
+                <SummaryList.Key>Start date</SummaryList.Key>
+                <SummaryList.Value>
+                  {dayjs(programmeMembership.startDate).format("DD/MM/YYYY")}
+                </SummaryList.Value>
+              </SummaryList.Row>
+              <SummaryList.Row>
+                <SummaryList.Key>Completion date</SummaryList.Key>
+                <SummaryList.Value>
+                  {dayjs(programmeMembership.endDate).format("DD/MM/YYYY")}
+                </SummaryList.Value>
+              </SummaryList.Row>
+              <h3 className={style.panelSubHeader}> Changes</h3>
+              <SummaryList.Row>
+                <SummaryList.Key>
+                  Full-time hours percentage before change
+                </SummaryList.Key>
+                <SummaryList.Value>
+                  {programmeMembership.wte && programmeMembership.wte * 100}%
+                </SummaryList.Value>
+              </SummaryList.Row>
+              <SummaryList.Row>
+                <SummaryList.Key>
+                  Full-time hours percentage after change
+                </SummaryList.Key>
+                <SummaryList.Value data-cy="cct-view-new-wte">
+                  {changes[0].wte && changes[0].wte * 100}%
+                  {changes[0].wte! > programmeMembership.wte! && (
+                    <FieldWarningMsg warningMsgs={[wteIncreaseMsg]} />
+                  )}
+                  {!fteOptions.some(
+                    option => option.value === (changes[0].wte as number) * 100
+                  ) && <FieldWarningMsg warningMsgs={[wteCustomMsg]} />}
+                </SummaryList.Value>
+              </SummaryList.Row>
+              <SummaryList.Row>
+                <SummaryList.Key>Change start date</SummaryList.Key>
+                <SummaryList.Value>
+                  {dayjs(changes[0].startDate).format("DD/MM/YYYY")}
+                  {dayjs(changes[0].startDate).isSameOrAfter(
+                    dayjs().startOf("day")
+                  ) &&
+                    isDateWithin16WeeksOfFirstDate(changes[0].startDate) && (
+                      <FieldWarningMsg warningMsgs={[shortNoticeMsg]} />
                     )}
-                    {!fteOptions.some(
-                      option =>
-                        option.value === (changes[0].wte as number) * 100
-                    ) && <FieldWarningMsg warningMsgs={[wteCustomMsg]} />}
-                  </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                  <SummaryList.Key>Change start date</SummaryList.Key>
-                  <SummaryList.Value>
-                    {dayjs(changes[0].startDate).format("DD/MM/YYYY")}
-                    {dayjs(changes[0].startDate).isSameOrAfter(
-                      dayjs().startOf("day")
-                    ) &&
-                      isDateWithin16WeeksOfFirstDate(changes[0].startDate) && (
-                        <FieldWarningMsg warningMsgs={[shortNoticeMsg]} />
-                      )}
-                    {dayjs(changes[0].startDate).isBefore(
-                      dayjs().startOf("day")
-                    ) && (
-                      <FieldWarningMsg
-                        warningMsgs={["Change start date is now in the past"]}
-                      />
-                    )}
-                  </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                  <SummaryList.Key>New completion date</SummaryList.Key>
-                  <SummaryList.Value
-                    style={{
-                      color: "teal",
-                      fontWeight: "bold"
-                    }}
-                    data-cy="saved-cct-date"
-                  >
-                    {cctDate && dayjs(cctDate).format("DD/MM/YYYY")}
-                  </SummaryList.Value>
-                </SummaryList.Row>
-              </SummaryList>
-            </Col>
-          </Row>
-        </Container>
-        {name && created && lastModified && (
-          <section data-cy="saved-cct-details">
-            <div>{`Name: ${name}`}</div>
-            <div>{`Created: ${dayjs(created).toString()}`}</div>
-            <div>{`Last saved: ${dayjs(lastModified).toString()}`}</div>
-          </section>
-        )}
-      </Card.Content>
+                  {dayjs(changes[0].startDate).isBefore(
+                    dayjs().startOf("day")
+                  ) && (
+                    <FieldWarningMsg
+                      warningMsgs={["Change start date is now in the past"]}
+                    />
+                  )}
+                </SummaryList.Value>
+              </SummaryList.Row>
+              <SummaryList.Row>
+                <SummaryList.Key>New completion date</SummaryList.Key>
+                <SummaryList.Value
+                  style={{
+                    color: "teal",
+                    fontWeight: "bold"
+                  }}
+                  data-cy="saved-cct-date"
+                >
+                  {cctDate && dayjs(cctDate).format("DD/MM/YYYY")}
+                </SummaryList.Value>
+              </SummaryList.Row>
+            </SummaryList>
+          </Col>
+        </Row>
+      </Container>
+      {name && created && lastModified && (
+        <section data-cy="saved-cct-details">
+          <div>{`Name: ${name}`}</div>
+          <div>{`Created: ${dayjs(created).toString()}`}</div>
+          <div>{`Last saved: ${dayjs(lastModified).toString()}`}</div>
+        </section>
+      )}
     </Card>
   );
 }

--- a/components/forms/cct/CctHome.tsx
+++ b/components/forms/cct/CctHome.tsx
@@ -20,7 +20,7 @@ export function CctHome() {
   return (
     <>
       <WarningCallout data-cy="cct-home-warning">
-        <WarningCallout.Heading>
+        <WarningCallout.Heading visuallyHiddenText="">
           {cctReadBeforeProceedingLabel}
         </WarningCallout.Heading>
         <p data-cy="cct-home-warning-text1">{cctHomeWarningMsgs.text1}</p>

--- a/components/forms/cct/CctHome.tsx
+++ b/components/forms/cct/CctHome.tsx
@@ -20,9 +20,9 @@ export function CctHome() {
   return (
     <>
       <WarningCallout data-cy="cct-home-warning">
-        <WarningCallout.Label visuallyHiddenText={false}>
+        <WarningCallout.Heading>
           {cctReadBeforeProceedingLabel}
-        </WarningCallout.Label>
+        </WarningCallout.Heading>
         <p data-cy="cct-home-warning-text1">{cctHomeWarningMsgs.text1}</p>
         <p data-cy="cct-home-warning-text2">{cctHomeWarningMsgs.text2}</p>
         <p data-cy="cct-home-warning-text3">{cctHomeWarningMsgs.text3}</p>

--- a/components/forms/conditionOfJoining/CojGg10.tsx
+++ b/components/forms/conditionOfJoining/CojGg10.tsx
@@ -7,195 +7,190 @@ type CojGg10Props = {
 const CojGg10: React.FC<CojGg10Props> = ({ progName }) => {
   return (
     <Card feature>
-      <Card.Content>
-        <Card.Heading data-cy="cojHeading-gg10">
-          Conditions of Joining Agreement
-        </Card.Heading>
-        <h3 className="card-heading-spaced-top">{`${progName} Specialty Training Programme `}</h3>
-        <SummaryList noBorder>
-          <SummaryList.Row>
-            <SummaryList.Value>
-              <b>Please note: This is not an offer of employment.</b>
-            </SummaryList.Value>
-          </SummaryList.Row>
-          <SummaryList.Row>
-            <SummaryList.Value>Dear Postgraduate Dean,</SummaryList.Value>
-          </SummaryList.Row>
-          <SummaryList.Row>
-            <SummaryList.Value>
-              On accepting an offer to join a training programme in{" "}
-              <b>{progName}</b>, I agree to meet the following requirements
-              throughout the duration of the programme:
-            </SummaryList.Value>
-          </SummaryList.Row>
-          <ul>
-            <li>
-              I will always have at the forefront of my clinical and
-              professional practice the principles of Good Medical Practice for
-              the benefit of safe patient care. I am aware that Good Medical
-              Practice requires me to keep my knowledge and skills up to date
-              throughout my working life, and to regularly take part in
-              educational activities that maintain and further develop my
-              capabilities, competence and performance.
-            </li>
-            <li>
-              As a postgraduate doctor in training, I will make myself familiar
-              with my curriculum and meet the requirements set within it. I will
-              use the available training resources optimally to develop my
-              knowledge, skills and attitudes to the standards set by the
-              relevant curriculum. This will include additional requirements as
-              set out by the relevant curriculum.
-            </li>
-            <li>
-              I will ensure that the care I give to patients is responsive to
-              their needs, and that it is equitable, respects human rights,
-              challenges discrimination, promotes equality, and maintains the
-              dignity of patients and carers.
-            </li>
-            <li>
-              I will ensure that I treat my clinical and non-clinical colleagues
-              with respect, promoting a culture of teamworking across all
-              professions working in healthcare.
-            </li>
-            <li>
-              I will maintain my General Medical Council (GMC) registration with
-              a licence to practise (even if temporarily out of programme). For
-              all postgraduate doctors in training, failure to do so may result
-              in a police investigation, immediate suspension from employment
-              and referral to the GMC. Failure to do so may also result in my
-              removal from the training programme.
-            </li>
-            <li>
-              I understand my responsibilities within revalidation, that I must
-              declare my full scope of practice (including locum positions) and
-              that I will provide evidence for all areas of activity using Form
-              R (Part B) to inform the Annual Review of Competence Progression
-              panel and Responsible Officer (RO) of my full scope of practice. I
-              understand that my RO is the Postgraduate Dean (or the Medical
-              Director in Health Education and Improvement Wales (HEIW), and the
-              Northern Ireland Medical and Dental Training Agency (NIMDTA)), and
-              that NHS England Workforce, Training and Education (NHSE WTE), NHS
-              Education for Scotland (NES), HEIW or NIMDTA is my designated
-              body.
-            </li>
-            <li>
-              I agree that I will only assume responsibility for or perform
-              procedures in areas where I have sufficient knowledge, experience
-              and expertise as set out by the GMC, my employers and my clinical
-              supervisors.
-            </li>
-            <li>
-              I will have adequate insurance and indemnity cover, in accordance
-              with GMC guidance. I understand that personal indemnity cover is
-              also strongly recommended.
-            </li>
-            <li>
-              I will inform my RO, NHSE WTE/NES/HEIW/NIMDTA and my employer
-              immediately if I am currently under investigation by the police,
-              the GMC/General Dental Council (GDC), NHS Resolution or other
-              regulatory body, and I will inform my RO and NHSE
-              WTE/NES/HEIW/NIMDTA if I am under investigation by my employer. I
-              also agree to share information on the progress of any
-              investigations.
-            </li>
-            <li>
-              I will inform my RO, NHSE WTE/NES/HEIW/NIMDTA and my employer
-              immediately if the Medical Practitioners Tribunal Service or
-              GMC/GDC place any conditions (interim or otherwise) on my licence,
-              or if I am suspended or erased/removed from the medical or dental
-              register/Performers List, or if NHSE WTE/NES/HEIW/NIMDTA takes
-              action to restrict my ability to work as a doctor or a dentist.
-            </li>
-            <li>
-              I will provide my employer and NHSE WTE/NES/HEIW/NIMDTA with
-              adequate notice as per GMC guidance/contract requirements if I
-              wish to resign from my post/training programme.
-            </li>
-            <li>
-              I will maintain a prescribed connection with NHSE
-              WTE/NES/HEIW/NIMDTA, work in an approved practice setting until my
-              GMC revalidation date (this applies to all doctors granted full
-              registration after 2 June 2014) and comply with all requirements
-              regarding the GMC revalidation process.
-            </li>
-            <li>
-              I will ensure that I comply with the standards required from
-              doctors when engaging with social media, and I will adhere to my
-              employer’s policy on social media and GMC guidance.
-            </li>
-            <li>
-              I acknowledge that as an employee in a healthcare organisation, I
-              accept the responsibility to abide by Good Medical Practice and
-              work effectively as an employee for that organisation; this
-              includes familiarity with policies (including absence policies) as
-              well as participating in pre-employment checks and occupational
-              health assessments, employer/departmental inductions, and
-              workplace-based appraisal and educational appraisal. I acknowledge
-              and agree to the need to share information about my performance as
-              a postgraduate doctor in training with other organisations (e.g.
-              employers, medical schools, the GMC and Colleges/training bodies
-              involved in my training) and with the Postgraduate Dean on a
-              regular basis.
-            </li>
-            <li>
-              I acknowledge that data will be collected to support the following
-              processes, and I will comply with the requirements of the General
-              Data Protection Regulation, the Data Protection Act 2018 and such
-              other data protection as is in force from time to time:
-              <ol type="a">
-                <li>
-                  Managing the provision of training programmes including
-                  inter-deanery transfers
-                </li>
-                <li>
-                  Managing processes allied to training programmes, such as
-                  certification, evidence to support revalidation and supporting
-                  the requirements of regulators
-                </li>
-                <li>Quality assurance of training programmes</li>
-                <li>Workforce planning</li>
-                <li>Ensuring and improving patient safety</li>
-                <li>
-                  Compliance with legal and regulatory responsibilities,
-                  including monitoring under the Equality Act 2010
-                </li>
-                <li>Research related to any of the above</li>
-              </ol>
-            </li>
-            <li>
-              I will maintain regular contact with my Training Programme
-              Director, other trainers and NHSE WTE/NES/HEIW/NIMDTA by
-              responding promptly to communications from them.
-            </li>
-            <li>
-              I will participate proactively in the appraisal, assessment and
-              programme planning process, including providing required
-              documentation to the prescribed timescales and progressing my
-              training without unreasonable delay.
-            </li>
-            <li>
-              I will ensure that I develop and keep up to date my learning
-              e-portfolio, which underpins the training process and documents my
-              progress through the programme.
-            </li>
-            <li>
-              I agree to ensure timely registration with the appropriate
-              College/Faculty.
-            </li>
-            <li>
-              I will support the development and evaluation of my training
-              programme by participating actively in the GMC’s annual national
-              training survey/programme-specific surveys as well as in any other
-              activities that contribute to the quality improvement of training.
-            </li>
-            <li>
-              I acknowledge that where programmes are time dependant, failure to
-              complete the required time in programme may result in a
-              developmental outcome.
-            </li>
-          </ul>
-        </SummaryList>
-      </Card.Content>
+      <Card.Heading data-cy="cojHeading-gg10">
+        Conditions of Joining Agreement
+      </Card.Heading>
+      <h3 className="card-heading-spaced-top">{`${progName} Specialty Training Programme `}</h3>
+      <SummaryList noBorder>
+        <SummaryList.Row>
+          <SummaryList.Value>
+            <b>Please note: This is not an offer of employment.</b>
+          </SummaryList.Value>
+        </SummaryList.Row>
+        <SummaryList.Row>
+          <SummaryList.Value>Dear Postgraduate Dean,</SummaryList.Value>
+        </SummaryList.Row>
+        <SummaryList.Row>
+          <SummaryList.Value>
+            On accepting an offer to join a training programme in{" "}
+            <b>{progName}</b>, I agree to meet the following requirements
+            throughout the duration of the programme:
+          </SummaryList.Value>
+        </SummaryList.Row>
+        <ul>
+          <li>
+            I will always have at the forefront of my clinical and professional
+            practice the principles of Good Medical Practice for the benefit of
+            safe patient care. I am aware that Good Medical Practice requires me
+            to keep my knowledge and skills up to date throughout my working
+            life, and to regularly take part in educational activities that
+            maintain and further develop my capabilities, competence and
+            performance.
+          </li>
+          <li>
+            As a postgraduate doctor in training, I will make myself familiar
+            with my curriculum and meet the requirements set within it. I will
+            use the available training resources optimally to develop my
+            knowledge, skills and attitudes to the standards set by the relevant
+            curriculum. This will include additional requirements as set out by
+            the relevant curriculum.
+          </li>
+          <li>
+            I will ensure that the care I give to patients is responsive to
+            their needs, and that it is equitable, respects human rights,
+            challenges discrimination, promotes equality, and maintains the
+            dignity of patients and carers.
+          </li>
+          <li>
+            I will ensure that I treat my clinical and non-clinical colleagues
+            with respect, promoting a culture of teamworking across all
+            professions working in healthcare.
+          </li>
+          <li>
+            I will maintain my General Medical Council (GMC) registration with a
+            licence to practise (even if temporarily out of programme). For all
+            postgraduate doctors in training, failure to do so may result in a
+            police investigation, immediate suspension from employment and
+            referral to the GMC. Failure to do so may also result in my removal
+            from the training programme.
+          </li>
+          <li>
+            I understand my responsibilities within revalidation, that I must
+            declare my full scope of practice (including locum positions) and
+            that I will provide evidence for all areas of activity using Form R
+            (Part B) to inform the Annual Review of Competence Progression panel
+            and Responsible Officer (RO) of my full scope of practice. I
+            understand that my RO is the Postgraduate Dean (or the Medical
+            Director in Health Education and Improvement Wales (HEIW), and the
+            Northern Ireland Medical and Dental Training Agency (NIMDTA)), and
+            that NHS England Workforce, Training and Education (NHSE WTE), NHS
+            Education for Scotland (NES), HEIW or NIMDTA is my designated body.
+          </li>
+          <li>
+            I agree that I will only assume responsibility for or perform
+            procedures in areas where I have sufficient knowledge, experience
+            and expertise as set out by the GMC, my employers and my clinical
+            supervisors.
+          </li>
+          <li>
+            I will have adequate insurance and indemnity cover, in accordance
+            with GMC guidance. I understand that personal indemnity cover is
+            also strongly recommended.
+          </li>
+          <li>
+            I will inform my RO, NHSE WTE/NES/HEIW/NIMDTA and my employer
+            immediately if I am currently under investigation by the police, the
+            GMC/General Dental Council (GDC), NHS Resolution or other regulatory
+            body, and I will inform my RO and NHSE WTE/NES/HEIW/NIMDTA if I am
+            under investigation by my employer. I also agree to share
+            information on the progress of any investigations.
+          </li>
+          <li>
+            I will inform my RO, NHSE WTE/NES/HEIW/NIMDTA and my employer
+            immediately if the Medical Practitioners Tribunal Service or GMC/GDC
+            place any conditions (interim or otherwise) on my licence, or if I
+            am suspended or erased/removed from the medical or dental
+            register/Performers List, or if NHSE WTE/NES/HEIW/NIMDTA takes
+            action to restrict my ability to work as a doctor or a dentist.
+          </li>
+          <li>
+            I will provide my employer and NHSE WTE/NES/HEIW/NIMDTA with
+            adequate notice as per GMC guidance/contract requirements if I wish
+            to resign from my post/training programme.
+          </li>
+          <li>
+            I will maintain a prescribed connection with NHSE
+            WTE/NES/HEIW/NIMDTA, work in an approved practice setting until my
+            GMC revalidation date (this applies to all doctors granted full
+            registration after 2 June 2014) and comply with all requirements
+            regarding the GMC revalidation process.
+          </li>
+          <li>
+            I will ensure that I comply with the standards required from doctors
+            when engaging with social media, and I will adhere to my employer’s
+            policy on social media and GMC guidance.
+          </li>
+          <li>
+            I acknowledge that as an employee in a healthcare organisation, I
+            accept the responsibility to abide by Good Medical Practice and work
+            effectively as an employee for that organisation; this includes
+            familiarity with policies (including absence policies) as well as
+            participating in pre-employment checks and occupational health
+            assessments, employer/departmental inductions, and workplace-based
+            appraisal and educational appraisal. I acknowledge and agree to the
+            need to share information about my performance as a postgraduate
+            doctor in training with other organisations (e.g. employers, medical
+            schools, the GMC and Colleges/training bodies involved in my
+            training) and with the Postgraduate Dean on a regular basis.
+          </li>
+          <li>
+            I acknowledge that data will be collected to support the following
+            processes, and I will comply with the requirements of the General
+            Data Protection Regulation, the Data Protection Act 2018 and such
+            other data protection as is in force from time to time:
+            <ol type="a">
+              <li>
+                Managing the provision of training programmes including
+                inter-deanery transfers
+              </li>
+              <li>
+                Managing processes allied to training programmes, such as
+                certification, evidence to support revalidation and supporting
+                the requirements of regulators
+              </li>
+              <li>Quality assurance of training programmes</li>
+              <li>Workforce planning</li>
+              <li>Ensuring and improving patient safety</li>
+              <li>
+                Compliance with legal and regulatory responsibilities, including
+                monitoring under the Equality Act 2010
+              </li>
+              <li>Research related to any of the above</li>
+            </ol>
+          </li>
+          <li>
+            I will maintain regular contact with my Training Programme Director,
+            other trainers and NHSE WTE/NES/HEIW/NIMDTA by responding promptly
+            to communications from them.
+          </li>
+          <li>
+            I will participate proactively in the appraisal, assessment and
+            programme planning process, including providing required
+            documentation to the prescribed timescales and progressing my
+            training without unreasonable delay.
+          </li>
+          <li>
+            I will ensure that I develop and keep up to date my learning
+            e-portfolio, which underpins the training process and documents my
+            progress through the programme.
+          </li>
+          <li>
+            I agree to ensure timely registration with the appropriate
+            College/Faculty.
+          </li>
+          <li>
+            I will support the development and evaluation of my training
+            programme by participating actively in the GMC’s annual national
+            training survey/programme-specific surveys as well as in any other
+            activities that contribute to the quality improvement of training.
+          </li>
+          <li>
+            I acknowledge that where programmes are time dependant, failure to
+            complete the required time in programme may result in a
+            developmental outcome.
+          </li>
+        </ul>
+      </SummaryList>
     </Card>
   );
 };

--- a/components/forms/conditionOfJoining/CojGg9.tsx
+++ b/components/forms/conditionOfJoining/CojGg9.tsx
@@ -7,206 +7,202 @@ type CojGg9Props = {
 const CojGg9: React.FC<CojGg9Props> = ({ progName }) => {
   return (
     <Card feature>
-      <Card.Content>
-        <Card.Heading data-cy="cojHeading-gg9">
-          Conditions of Joining Agreement
-        </Card.Heading>
-        <h3 className="card-heading-spaced-top">{`${progName} Specialty Training Programme `}</h3>
-        <SummaryList noBorder>
-          <SummaryList.Row>
-            <SummaryList.Value>
-              <b>Please note: This is not an offer of employment.</b>
-            </SummaryList.Value>
-          </SummaryList.Row>
-          <SummaryList.Row>
-            <SummaryList.Value>Dear Postgraduate Dean,</SummaryList.Value>
-          </SummaryList.Row>
-          <SummaryList.Row>
-            <SummaryList.Value>
-              On accepting an offer to join a training programme in{" "}
-              <b>{progName}</b>, I agree to meet the following requirements
-              throughout the duration of the programme:
-            </SummaryList.Value>
-          </SummaryList.Row>
-          <ul>
-            <li>
-              I will always have at the forefront of my clinical and
-              professional practice the principles of Good Medical Practice for
-              the benefit of safe patient care. I am aware that Good Medical
-              Practice requires me to keep my knowledge and skills up to date
-              throughout my working life, and to regularly take part in
-              educational activities that maintain and further develop my
-              capabilities, competence and performance.
-            </li>
-            <li>
-              As a doctor in training, I will make myself familiar with my
-              curriculum and meet the requirements set within it. I will use
-              training resources available optimally to develop my knowledge,
-              skills and attitudes to the standards set by the relevant
-              curriculum. This will include additional requirements as set out
-              by the relevant curricula.
-            </li>
-            <li>
-              I will ensure that the care I give to patients is responsive to
-              their needs, and that it is equitable, respects human rights,
-              challenges discrimination, promotes equality, and maintains the
-              dignity of patients and carers.
-            </li>
-            <li>
-              I will ensure I treat my clinical and non-clinical colleagues with
-              respect, promoting a culture of teamworking across all professions
-              working in healthcare.
-            </li>
-            <li>
-              I will maintain my General Medical Council (GMC) registration with
-              a licence to practise (even if temporarily out of programme). For
-              all trainees, failure to do so may result in a police
-              investigation, immediate exclusion from employment and referral to
-              the GMC. Failure to do so may also result in my removal from the
-              training programme.
-            </li>
-            <li>
-              I understand my responsibilities within revalidation, that I must
-              declare my full scope of practice (including locum positions) and
-              that I will provide evidence for all areas of activity using the
-              Form R part B to inform the ARCP panel and RO of the full scope of
-              practice. I understand that my Responsible Officer is the
-              Postgraduate Dean or Medical Director (NIMDTA and HEIW where the
-              Medical Director is the RO) and that Health Education England
-              (HEE), NHS Education for Scotland (NES), HEIW or the Northern
-              Ireland Medical and Dental Training Agency (NIMDTA) is my
-              designated body.
-            </li>
-            <li>
-              If starting at F1 level, I will have achieved a primary medical
-              qualification as recognised by the GMC and obtained provisional
-              registration by the time I am scheduled to commence the F1 year. I
-              understand that I will need to obtain full registration with the
-              GMC in advance of commencing as a F2 doctor.
-            </li>
-            <li>
-              I will ensure that when carrying out work in a general practice
-              setting, I am on the GP Performers List (specialty trainees only).
-            </li>
-            <li>
-              I agree that I will only assume responsibility for or perform
-              procedures in areas where I have sufficient knowledge, experience
-              and expertise as set out by the GMC, my employers and my clinical
-              supervisors.
-            </li>
-            <li>
-              I will have adequate insurance and indemnity cover, in accordance
-              with GMC guidance. I understand that personal indemnity cover is
-              also strongly recommended.
-            </li>
-            <li>
-              I will inform my Responsible Officer, HEE/NES/HEIW/NIMDTA and my
-              employer immediately if I am currently under investigation by the
-              police, the GMC/General Dental Council (GDC), NHS Resolution
-              (formerly the National Clinical Assessment Service) or other
-              regulatory body, and I will inform my Responsible Officer and
-              HEE/NES/HEIW/NIMDTA if I am under investigation by my employer. I
-              also agree to share information on the progress of any
-              investigations.
-            </li>
-            <li>
-              I will inform my Responsible Officer, HEE/NES/HEIW/NIMDTA and my
-              employer immediately if the MTPS or GMC/GDC place any conditions
-              (interim or otherwise) on my licence, or if my name is suspended
-              or erased/removed from the Medical or Dental Register/Performers
-              List, or if NHS England take action to restrict my ability to work
-              as a doctor or a dentist.
-            </li>
-            <li>
-              I will provide my employer and HEE/NES/HEIW/NIMDTA with adequate
-              notice as per GMC guidance/contract requirements if I wish to
-              resign from my post/training programme.
-            </li>
-            <li>
-              I will maintain a prescribed connection with HEE/NES/HEIW/NIMDTA,
-              work in an approved practice setting until my GMC revalidation
-              date (this applies to all doctors granted full registration after
-              2 June 2014) and comply with all requirements regarding the GMC
-              revalidation process.
-            </li>
-            <li>
-              I will ensure that I comply with the standards required from
-              doctors when engaging with social media, and I will adhere to my
-              employer’s policy on social media and GMC guidance.
-            </li>
-            <li>
-              I acknowledge that as an employee in a healthcare organisation, I
-              accept the responsibility to abide by and work effectively as an
-              employee for that organisation; this includes familiarity with
-              policies (including absence policies), participating in
-              pre-employment checks and occupational health assessments,
-              employer and departmental inductions, and workplace-based
-              appraisal as well as educational appraisal. I acknowledge and
-              agree to the need to share information about my performance as a
-              doctor in training with other organisations (e.g. employers,
-              medical schools, the GMC, Colleges/training bodies involved in my
-              training) and with the Postgraduate Dean on a regular basis.
-            </li>
-            <li>
-              I acknowledge that data will be collected to support the following
-              processes and I will comply with the requirements of the General
-              Data Protection Regulation (GDPR) May 2018, Data Protection Act
-              (DPA) 2018 and such other data protection as is in force from time
-              to time:
-              <ol type="a">
-                <li>
-                  Managing the provision of training programmes including inter
-                  deanery transfers
-                </li>
-                <li>
-                  Managing processes allied to training programmes, such as
-                  certification, evidence to support revalidation and supporting
-                  the requirements of regulators
-                </li>
-                <li>Quality assurance of training programmes</li>
-                <li>Workforce planning</li>
-                <li>Ensuring and improving patient safety</li>
-                <li>
-                  Compliance with legal and regulatory responsibilities,
-                  including monitoring under the Equality Act 2010
-                </li>
-                <li>Research related to any of the above</li>
-              </ol>
-            </li>
-            <li>
-              I will maintain regular contact with my Training Programme
-              Director, other trainers and HEE/NES/HEIW/NIMDTA by responding
-              promptly to communications from them.
-            </li>
-            <li>
-              I will participate proactively in the appraisal, assessment and
-              programme planning process, including providing documentation that
-              will be required to the prescribed timescales and progressing my
-              training without unreasonable delay.
-            </li>
-            <li>
-              I will ensure that I develop and keep up to date my learning
-              e-portfolio, which underpins the training process and documents my
-              progress through the programme.
-            </li>
-            <li>
-              I agree to ensure timely registration with the appropriate
-              College/Faculty.
-            </li>
-            <li>
-              I will support the development and evaluation of my training
-              programme by participating actively in the national annual GMC
-              Trainee Survey/programme specific surveys as well as any other
-              activities that contribute to the quality improvement of training.
-            </li>
-            <li>
-              I acknowledge that where programmes are time dependant, failure to
-              complete the required time in programme may result in an
-              unsatisfactory outcome.
-            </li>
-          </ul>
-        </SummaryList>
-      </Card.Content>
+      <Card.Heading data-cy="cojHeading-gg9">
+        Conditions of Joining Agreement
+      </Card.Heading>
+      <h3 className="card-heading-spaced-top">{`${progName} Specialty Training Programme `}</h3>
+      <SummaryList noBorder>
+        <SummaryList.Row>
+          <SummaryList.Value>
+            <b>Please note: This is not an offer of employment.</b>
+          </SummaryList.Value>
+        </SummaryList.Row>
+        <SummaryList.Row>
+          <SummaryList.Value>Dear Postgraduate Dean,</SummaryList.Value>
+        </SummaryList.Row>
+        <SummaryList.Row>
+          <SummaryList.Value>
+            On accepting an offer to join a training programme in{" "}
+            <b>{progName}</b>, I agree to meet the following requirements
+            throughout the duration of the programme:
+          </SummaryList.Value>
+        </SummaryList.Row>
+        <ul>
+          <li>
+            I will always have at the forefront of my clinical and professional
+            practice the principles of Good Medical Practice for the benefit of
+            safe patient care. I am aware that Good Medical Practice requires me
+            to keep my knowledge and skills up to date throughout my working
+            life, and to regularly take part in educational activities that
+            maintain and further develop my capabilities, competence and
+            performance.
+          </li>
+          <li>
+            As a doctor in training, I will make myself familiar with my
+            curriculum and meet the requirements set within it. I will use
+            training resources available optimally to develop my knowledge,
+            skills and attitudes to the standards set by the relevant
+            curriculum. This will include additional requirements as set out by
+            the relevant curricula.
+          </li>
+          <li>
+            I will ensure that the care I give to patients is responsive to
+            their needs, and that it is equitable, respects human rights,
+            challenges discrimination, promotes equality, and maintains the
+            dignity of patients and carers.
+          </li>
+          <li>
+            I will ensure I treat my clinical and non-clinical colleagues with
+            respect, promoting a culture of teamworking across all professions
+            working in healthcare.
+          </li>
+          <li>
+            I will maintain my General Medical Council (GMC) registration with a
+            licence to practise (even if temporarily out of programme). For all
+            trainees, failure to do so may result in a police investigation,
+            immediate exclusion from employment and referral to the GMC. Failure
+            to do so may also result in my removal from the training programme.
+          </li>
+          <li>
+            I understand my responsibilities within revalidation, that I must
+            declare my full scope of practice (including locum positions) and
+            that I will provide evidence for all areas of activity using the
+            Form R part B to inform the ARCP panel and RO of the full scope of
+            practice. I understand that my Responsible Officer is the
+            Postgraduate Dean or Medical Director (NIMDTA and HEIW where the
+            Medical Director is the RO) and that Health Education England (HEE),
+            NHS Education for Scotland (NES), HEIW or the Northern Ireland
+            Medical and Dental Training Agency (NIMDTA) is my designated body.
+          </li>
+          <li>
+            If starting at F1 level, I will have achieved a primary medical
+            qualification as recognised by the GMC and obtained provisional
+            registration by the time I am scheduled to commence the F1 year. I
+            understand that I will need to obtain full registration with the GMC
+            in advance of commencing as a F2 doctor.
+          </li>
+          <li>
+            I will ensure that when carrying out work in a general practice
+            setting, I am on the GP Performers List (specialty trainees only).
+          </li>
+          <li>
+            I agree that I will only assume responsibility for or perform
+            procedures in areas where I have sufficient knowledge, experience
+            and expertise as set out by the GMC, my employers and my clinical
+            supervisors.
+          </li>
+          <li>
+            I will have adequate insurance and indemnity cover, in accordance
+            with GMC guidance. I understand that personal indemnity cover is
+            also strongly recommended.
+          </li>
+          <li>
+            I will inform my Responsible Officer, HEE/NES/HEIW/NIMDTA and my
+            employer immediately if I am currently under investigation by the
+            police, the GMC/General Dental Council (GDC), NHS Resolution
+            (formerly the National Clinical Assessment Service) or other
+            regulatory body, and I will inform my Responsible Officer and
+            HEE/NES/HEIW/NIMDTA if I am under investigation by my employer. I
+            also agree to share information on the progress of any
+            investigations.
+          </li>
+          <li>
+            I will inform my Responsible Officer, HEE/NES/HEIW/NIMDTA and my
+            employer immediately if the MTPS or GMC/GDC place any conditions
+            (interim or otherwise) on my licence, or if my name is suspended or
+            erased/removed from the Medical or Dental Register/Performers List,
+            or if NHS England take action to restrict my ability to work as a
+            doctor or a dentist.
+          </li>
+          <li>
+            I will provide my employer and HEE/NES/HEIW/NIMDTA with adequate
+            notice as per GMC guidance/contract requirements if I wish to resign
+            from my post/training programme.
+          </li>
+          <li>
+            I will maintain a prescribed connection with HEE/NES/HEIW/NIMDTA,
+            work in an approved practice setting until my GMC revalidation date
+            (this applies to all doctors granted full registration after 2 June
+            2014) and comply with all requirements regarding the GMC
+            revalidation process.
+          </li>
+          <li>
+            I will ensure that I comply with the standards required from doctors
+            when engaging with social media, and I will adhere to my employer’s
+            policy on social media and GMC guidance.
+          </li>
+          <li>
+            I acknowledge that as an employee in a healthcare organisation, I
+            accept the responsibility to abide by and work effectively as an
+            employee for that organisation; this includes familiarity with
+            policies (including absence policies), participating in
+            pre-employment checks and occupational health assessments, employer
+            and departmental inductions, and workplace-based appraisal as well
+            as educational appraisal. I acknowledge and agree to the need to
+            share information about my performance as a doctor in training with
+            other organisations (e.g. employers, medical schools, the GMC,
+            Colleges/training bodies involved in my training) and with the
+            Postgraduate Dean on a regular basis.
+          </li>
+          <li>
+            I acknowledge that data will be collected to support the following
+            processes and I will comply with the requirements of the General
+            Data Protection Regulation (GDPR) May 2018, Data Protection Act
+            (DPA) 2018 and such other data protection as is in force from time
+            to time:
+            <ol type="a">
+              <li>
+                Managing the provision of training programmes including inter
+                deanery transfers
+              </li>
+              <li>
+                Managing processes allied to training programmes, such as
+                certification, evidence to support revalidation and supporting
+                the requirements of regulators
+              </li>
+              <li>Quality assurance of training programmes</li>
+              <li>Workforce planning</li>
+              <li>Ensuring and improving patient safety</li>
+              <li>
+                Compliance with legal and regulatory responsibilities, including
+                monitoring under the Equality Act 2010
+              </li>
+              <li>Research related to any of the above</li>
+            </ol>
+          </li>
+          <li>
+            I will maintain regular contact with my Training Programme Director,
+            other trainers and HEE/NES/HEIW/NIMDTA by responding promptly to
+            communications from them.
+          </li>
+          <li>
+            I will participate proactively in the appraisal, assessment and
+            programme planning process, including providing documentation that
+            will be required to the prescribed timescales and progressing my
+            training without unreasonable delay.
+          </li>
+          <li>
+            I will ensure that I develop and keep up to date my learning
+            e-portfolio, which underpins the training process and documents my
+            progress through the programme.
+          </li>
+          <li>
+            I agree to ensure timely registration with the appropriate
+            College/Faculty.
+          </li>
+          <li>
+            I will support the development and evaluation of my training
+            programme by participating actively in the national annual GMC
+            Trainee Survey/programme specific surveys as well as any other
+            activities that contribute to the quality improvement of training.
+          </li>
+          <li>
+            I acknowledge that where programmes are time dependant, failure to
+            complete the required time in programme may result in an
+            unsatisfactory outcome.
+          </li>
+        </ul>
+      </SummaryList>
     </Card>
   );
 };

--- a/components/forms/form-builder/FormArrayPanelBuilder.tsx
+++ b/components/forms/form-builder/FormArrayPanelBuilder.tsx
@@ -56,36 +56,34 @@ export function FormArrayPanelBuilder({
     <div id={field.name} data-cy={`${field.name}-panel`}>
       {formData[field.name]?.map((_arrObj: any, index: number) => (
         <Card key={index} id={`${field.name}-${index}`} className="container">
-          <Card.Content>
-            <p>
-              <b>{`${formattedFieldName} ${index + 1}`}</b>
-            </p>
-            {field.objectFields?.map(objField => (
-              <div key={objField.name} className="nhsuk-form-group">
-                {showFormField(objField, formData[field.name][index]) ? (
-                  <FormFieldBuilder
-                    field={objField}
-                    value={formData[field.name][index][objField.name] ?? ""}
-                    error={panelErrors?.[index]?.[objField.name] ?? ""}
-                    options={options}
-                    arrayDetails={{ arrayIndex: index, arrayName: field.name }}
-                  />
-                ) : null}
-              </div>
-            ))}
-            <div>
-              <Button
-                secondary
-                onClick={(e: { preventDefault: () => void }) => {
-                  e.preventDefault();
-                  removePanel(index);
-                }}
-                data-cy={`remove-${formattedFieldName}-${index + 1}-button`}
-              >
-                {`Remove ${formattedFieldName} ${index + 1}`}
-              </Button>
+          <p>
+            <b>{`${formattedFieldName} ${index + 1}`}</b>
+          </p>
+          {field.objectFields?.map(objField => (
+            <div key={objField.name} className="nhsuk-form-group">
+              {showFormField(objField, formData[field.name][index]) ? (
+                <FormFieldBuilder
+                  field={objField}
+                  value={formData[field.name][index][objField.name] ?? ""}
+                  error={panelErrors?.[index]?.[objField.name] ?? ""}
+                  options={options}
+                  arrayDetails={{ arrayIndex: index, arrayName: field.name }}
+                />
+              ) : null}
             </div>
-          </Card.Content>
+          ))}
+          <div>
+            <Button
+              secondary
+              onClick={(e: { preventDefault: () => void }) => {
+                e.preventDefault();
+                removePanel(index);
+              }}
+              data-cy={`remove-${formattedFieldName}-${index + 1}-button`}
+            >
+              {`Remove ${formattedFieldName} ${index + 1}`}
+            </Button>
+          </div>
         </Card>
       ))}
       <Button

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -369,6 +369,7 @@ export function FormErrors({
       aria-labelledby="errorSummaryTitle"
       role="alert"
       tabIndex={-1}
+      disableAutoFocus
     >
       <div className="error-summary" data-cy="errorSummary">
         <h2 id="errorSummaryTitle" className="nhsuk-error-summary__title">

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -246,27 +246,25 @@ export default function FormBuilder({
           {pages[currentPage]?.sections.map((section: Section) => (
             <React.Fragment key={section.sectionHeader}>
               <Card feature>
-                <Card.Content>
-                  <Card.Heading>{section.sectionHeader}</Card.Heading>
-                  {section.fields.map((field: Field) => {
-                    if (conditionalChildNames.has(field.name)) return null;
+                <Card.Heading>{section.sectionHeader}</Card.Heading>
+                {section.fields.map((field: Field) => {
+                  if (conditionalChildNames.has(field.name)) return null;
 
-                    const fieldComponent = (
-                      <FormFieldBuilder
-                        field={field}
-                        value={formData[field.name] ?? ""}
-                        error={formErrors[field.name] ?? ""}
-                        options={options}
-                        formErrors={formErrors}
-                      />
-                    );
-                    return (
-                      <div key={field.name} className="nhsuk-form-group">
-                        {showFormField(field, formData) ? fieldComponent : null}
-                      </div>
-                    );
-                  })}
-                </Card.Content>
+                  const fieldComponent = (
+                    <FormFieldBuilder
+                      field={field}
+                      value={formData[field.name] ?? ""}
+                      error={formErrors[field.name] ?? ""}
+                      options={options}
+                      formErrors={formErrors}
+                    />
+                  );
+                  return (
+                    <div key={field.name} className="nhsuk-form-group">
+                      {showFormField(field, formData) ? fieldComponent : null}
+                    </div>
+                  );
+                })}
               </Card>
             </React.Fragment>
           ))}

--- a/components/forms/form-builder/FormViewBuilder.tsx
+++ b/components/forms/form-builder/FormViewBuilder.tsx
@@ -90,14 +90,14 @@ function VisibleField({
             )}
           </SummaryList.Value>
           {canEdit && (
-            <SummaryList.Actions>
+            <SummaryList.Action asElement="span">
               <ChangeLink
                 targetField={field.name}
                 label={field.label ?? ""}
                 jsonFormName={jsonFormName}
                 pageIndex={pageIndex}
               />
-            </SummaryList.Actions>
+            </SummaryList.Action>
           )}
         </SummaryList.Row>
       </SummaryList>
@@ -124,29 +124,27 @@ export default function FormViewBuilder({
       {jsonForm.pages.map((page, pageIndex) => (
         <div key={page.pageName}>
           <Card>
-            <Card.Content>
-              <Card.Heading
-                data-cy={`pageHeader-${page.pageName}`}
-                style={{ color: "#005eb8" }}
-              >
-                {page.pageName}
-              </Card.Heading>
-              {page.sections.map((section, _sectionIndex) => (
-                <div key={section.sectionHeader}>
-                  {section.fields.map(field => (
-                    <VisibleField
-                      key={field.name}
-                      field={field}
-                      formData={formData}
-                      formErrors={formErrors}
-                      pageIndex={pageIndex}
-                      jsonFormName={jsonForm.name}
-                      canEdit={canEdit}
-                    />
-                  ))}
-                </div>
-              ))}
-            </Card.Content>
+            <Card.Heading
+              data-cy={`pageHeader-${page.pageName}`}
+              style={{ color: "#005eb8" }}
+            >
+              {page.pageName}
+            </Card.Heading>
+            {page.sections.map((section, _sectionIndex) => (
+              <div key={section.sectionHeader}>
+                {section.fields.map(field => (
+                  <VisibleField
+                    key={field.name}
+                    field={field}
+                    formData={formData}
+                    formErrors={formErrors}
+                    pageIndex={pageIndex}
+                    jsonFormName={jsonForm.name}
+                    canEdit={canEdit}
+                  />
+                ))}
+              </div>
+            ))}
           </Card>
         </div>
       ))}

--- a/components/forms/form-builder/form-fields/FieldWrapper.tsx
+++ b/components/forms/form-builder/form-fields/FieldWrapper.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Hint } from "nhsuk-react-components";
+import { HintText } from "nhsuk-react-components";
 
 export type BaseFieldProps = {
   name: string;
@@ -49,7 +49,7 @@ export function FieldWrapper({
       >
         {label}
       </label>
-      {hint && <Hint data-cy={`${name}-hint`}>{hint}</Hint>}
+      {hint && <HintText data-cy={`${name}-hint`}>{hint}</HintText>}
       {fieldError && (
         <span id={errorId} className="nhsuk-error-message">
           <span className="nhsuk-u-visually-hidden">Error:</span> {fieldError}

--- a/components/forms/form-builder/form-fields/Text.tsx
+++ b/components/forms/form-builder/form-fields/Text.tsx
@@ -5,7 +5,7 @@ import {
 } from "../../../../utilities/FormBuilderUtilities";
 import FieldWarningMsg from "../../FieldWarningMsg";
 import { useFormContext } from "../FormContext";
-import { Hint } from "nhsuk-react-components";
+import { HintText } from "nhsuk-react-components";
 
 type TextProps = {
   name: string;
@@ -62,7 +62,7 @@ export const Text: React.FC<TextProps> = ({
       >
         {label}
       </label>
-      {hint && <Hint data-cy={`${name}-hint`}>{hint}</Hint>}
+      {hint && <HintText data-cy={`${name}-hint`}>{hint}</HintText>}
       {fieldError && (
         <span id={errorId} className="nhsuk-error-message">
           <span className="nhsuk-u-visually-hidden">Error:</span> {fieldError}

--- a/components/forms/form-builder/form-r/FormRHome.tsx
+++ b/components/forms/form-builder/form-r/FormRHome.tsx
@@ -50,9 +50,9 @@ export function FormRHome() {
         <ScrollTo />
         <br />
         <WarningCallout data-cy="formr-migration-warning">
-          <WarningCallout.Label visuallyHiddenText={false}>
+          <WarningCallout.Heading visuallyHiddenText="">
             Form-R Migration in Progress
-          </WarningCallout.Label>
+          </WarningCallout.Heading>
           <p>
             We are currently migrating Form-Rs to a new system. The migration
             process may take up to 24 hours to complete.

--- a/components/forms/form-builder/form-r/FormRView.tsx
+++ b/components/forms/form-builder/form-r/FormRView.tsx
@@ -213,7 +213,7 @@ const FormRReviewView = ({
       />
 
       <WarningCallout>
-        <WarningCallout.Label>Declarations</WarningCallout.Label>
+        <WarningCallout.Heading>Declarations</WarningCallout.Heading>
         <form>
           <Declarations
             setCanSubmit={setCanSubmit}

--- a/components/forms/form-builder/form-r/SubmittedFormRList.tsx
+++ b/components/forms/form-builder/form-r/SubmittedFormRList.tsx
@@ -1,4 +1,4 @@
-import { Card, Hint, WarningCallout } from "nhsuk-react-components";
+import { Card, HintText, WarningCallout } from "nhsuk-react-components";
 import { IFormR } from "../../../../models/IFormR";
 import {
   DateUtilities,
@@ -193,15 +193,13 @@ const SubmittedFormRList = ({
     <>
       {formRList.length ? (
         <>
-          <Hint data-cy="formsTrueHint">
+          <HintText data-cy="formsTrueHint">
             To save a PDF copy of your submitted form, please click on a form
             below and then click the <b>Save a copy as a PDF</b> button at the
             top of that page.
-          </Hint>
+          </HintText>
           <WarningCallout data-cy="formsListWarning">
-            <WarningCallout.Label visuallyHiddenText={false}>
-              Important
-            </WarningCallout.Label>
+            <WarningCallout.Heading>Important</WarningCallout.Heading>
             {isWithinRange(latestSubDate, 31, "d") && (
               <p>
                 {`Your previous form was submitted recently on ${DateUtilities.ConvertToLondonTime(
@@ -220,18 +218,16 @@ const SubmittedFormRList = ({
           </WarningCallout>
         </>
       ) : (
-        <Hint data-cy="formsFalseHint">
+        <HintText data-cy="formsFalseHint">
           After you submit your completed form, instructions on how to{" "}
           <b>save a copy as a PDF</b> will appear here.
-        </Hint>
+        </HintText>
       )}
       <Card>
-        <Card.Content>
-          <Card.Heading data-cy="formr-previous-header">
-            Submitted forms
-          </Card.Heading>
-          {content}
-        </Card.Content>
+        <Card.Heading data-cy="formr-previous-header">
+          Submitted forms
+        </Card.Heading>
+        {content}
       </Card>
     </>
   );

--- a/components/forms/form-builder/form-r/part-a/FormRPartA.tsx
+++ b/components/forms/form-builder/form-r/part-a/FormRPartA.tsx
@@ -1,7 +1,7 @@
 import { Route, Switch, useLocation } from "react-router-dom";
 import ScrollTo from "../../../ScrollTo";
 import PageTitle from "../../../../common/PageTitle";
-import { Fieldset } from "nhsuk-react-components";
+import { Fieldset, Legend } from "nhsuk-react-components";
 import PageNotFound from "../../../../common/PageNotFound";
 import {
   FORMR_HEADING_TEXT,
@@ -19,13 +19,14 @@ export default function FormA() {
       <PageTitle title="Form R Part-A" />
       <ScrollTo />
       <Fieldset>
-        <Fieldset.Legend
+        <Legend
           isPageHeading
           className="fieldset-legend__header"
           data-cy="formRAHeading"
+          size="xl"
         >
           Form R (Part A)
-        </Fieldset.Legend>
+        </Legend>
         {location.pathname === "/formr-a" && (
           <>
             <p className="nhsuk-heading-s" data-cy="formraSubheading">

--- a/components/forms/form-builder/form-r/part-b/FormRPartB.tsx
+++ b/components/forms/form-builder/form-r/part-b/FormRPartB.tsx
@@ -1,7 +1,7 @@
 import { Route, Switch, useLocation } from "react-router-dom";
 import ScrollTo from "../../../ScrollTo";
 import PageTitle from "../../../../common/PageTitle";
-import { Fieldset } from "nhsuk-react-components";
+import { Fieldset, Legend } from "nhsuk-react-components";
 import PageNotFound from "../../../../common/PageNotFound";
 import {
   FORMR_HEADING_TEXT,
@@ -20,13 +20,14 @@ export default function FormB() {
       <PageTitle title="Form R Part-B" />
       <ScrollTo />
       <Fieldset>
-        <Fieldset.Legend
+        <Legend
           isPageHeading
           className="fieldset-legend__header"
           data-cy="formRBHeading"
+          size="xl"
         >
           Form R (Part B)
-        </Fieldset.Legend>
+        </Legend>
         {location.pathname === "/formr-b" && (
           <>
             <p className="nhsuk-heading-s" data-cy="formrbSubheading">

--- a/components/forms/form-builder/form-sections/ImportantText.tsx
+++ b/components/forms/form-builder/form-sections/ImportantText.tsx
@@ -9,7 +9,10 @@ type ImportantText = {
 export const ImportantText = ({ txtName }: ImportantText) => {
   return (
     <WarningCallout>
-      <WarningCallout.Heading data-cy={`WarningCallout-${txtName}-label`}>
+      <WarningCallout.Heading
+        data-cy={`WarningCallout-${txtName}-label`}
+        visuallyHiddenText=""
+      >
         Important
       </WarningCallout.Heading>
       {displayText[txtName]}

--- a/components/forms/form-builder/form-sections/ImportantText.tsx
+++ b/components/forms/form-builder/form-sections/ImportantText.tsx
@@ -9,12 +9,9 @@ type ImportantText = {
 export const ImportantText = ({ txtName }: ImportantText) => {
   return (
     <WarningCallout>
-      <WarningCallout.Label
-        visuallyHiddenText={false}
-        data-cy={`WarningCallout-${txtName}-label`}
-      >
+      <WarningCallout.Heading data-cy={`WarningCallout-${txtName}-label`}>
         Important
-      </WarningCallout.Label>
+      </WarningCallout.Heading>
       {displayText[txtName]}
     </WarningCallout>
   );

--- a/components/forms/form-linker/FormLinkerForm.tsx
+++ b/components/forms/form-linker/FormLinkerForm.tsx
@@ -83,7 +83,7 @@ export function FormLinkerForm({
     <div>
       {warningText && (
         <WarningCallout data-cy="formWarning">
-          <WarningCallout.Label>Important</WarningCallout.Label>
+          <WarningCallout.Heading>Important</WarningCallout.Heading>
           <p>{warningText}</p>
         </WarningCallout>
       )}

--- a/components/forms/ltft/Ltft.tsx
+++ b/components/forms/ltft/Ltft.tsx
@@ -1,4 +1,4 @@
-import { Fieldset } from "nhsuk-react-components";
+import { Fieldset, Legend } from "nhsuk-react-components";
 import { Route, Switch } from "react-router-dom";
 import PageNotFound from "../../common/PageNotFound";
 import { LtftHome } from "./LtftHome";
@@ -22,13 +22,14 @@ export function Ltft() {
   return (
     <>
       <Fieldset>
-        <Fieldset.Legend
+        <Legend
           isPageHeading
           data-cy="ltftHeading"
           style={{ color: "#005eb8" }}
+          size="xl"
         >
           Less than full-time (LTFT) training
-        </Fieldset.Legend>
+        </Legend>
       </Fieldset>
       <Switch>
         <Route

--- a/components/forms/ltft/LtftDeclarationsModal.tsx
+++ b/components/forms/ltft/LtftDeclarationsModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkboxes, Hint } from "nhsuk-react-components";
+import { Button, Checkboxes, HintText } from "nhsuk-react-components";
 import { Modal } from "../../common/Modal";
 import { useState } from "react";
 import { Link } from "react-router-dom";
@@ -33,7 +33,7 @@ export const LtftDeclarationsModal = ({
       </h2>
       <div>
         <Checkboxes>
-          <Checkboxes.Box
+          <Checkboxes.Item
             name="madeCctCalc"
             data-cy="madeCctCalc"
             checked={decValues.madeCctCalc}
@@ -41,21 +41,21 @@ export const LtftDeclarationsModal = ({
           >
             I understand that a change to my full time working hours percentage
             will affect my programme completion date.
-          </Checkboxes.Box>
-          <Hint className="checkbox-hint">
+          </Checkboxes.Item>
+          <HintText className="checkbox-hint">
             You can make a CCT Calculation using a{" "}
             <Link to="/cct">CCT Calculator</Link> to get an idea how changing
             your hours will affect your programme completion date.
-          </Hint>
-          <Checkboxes.Box
+          </HintText>
+          <Checkboxes.Item
             name="discussedWithTpd"
             data-cy="discussedWithTpd"
             checked={decValues.discussedWithTpd}
             onChange={handleCheckboxChange}
           >
             {`I have discussed my proposed changes and the effect on my completion date with my pre-approver. They are aware of this application to change my hours.`}
-          </Checkboxes.Box>
-          <Hint className="checkbox-hint">
+          </Checkboxes.Item>
+          <HintText className="checkbox-hint">
             <ExpanderMsg expanderName="preApproverInfo" />
             <p>
               Your pre-approver will usually be your Training Programme Director
@@ -66,7 +66,7 @@ export const LtftDeclarationsModal = ({
               </Link>
               .
             </p>
-          </Hint>
+          </HintText>
         </Checkboxes>
         <Button
           type="button"

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -153,78 +153,76 @@ export const LtftFormView = () => {
           formErrors={{}}
         />
         <Card style={{ border: "4px #005eb8 solid" }}>
-          <Card.Content>
-            <Card.Heading data-cy="completionDateChangeHeading">
-              Summary of changes to your {formData.pmName} Programme
-            </Card.Heading>
-            <SummaryList>
+          <Card.Heading data-cy="completionDateChangeHeading">
+            Summary of changes to your {formData.pmName} Programme
+          </Card.Heading>
+          <SummaryList>
+            <SummaryList.Row>
+              <SummaryList.Key data-cy="completionDateChangePmKey">
+                Programme
+              </SummaryList.Key>
+              <SummaryList.Value data-cy="completionDateChangePmValue">
+                {formData.pmName}
+              </SummaryList.Value>
+            </SummaryList.Row>
+            <SummaryList.Row>
+              <SummaryList.Key data-cy="completionDateChangeCurrentCompletionDateKey">
+                Current completion date
+              </SummaryList.Key>
+              <SummaryList.Value data-cy="completionDateChangeCurrentCompletionDateValue">
+                {dayjs(formData.pmEndDate).format("DD/MM/YYYY")} (Programme end
+                date on TIS)
+              </SummaryList.Value>
+            </SummaryList.Row>
+            <SummaryList.Row>
+              <SummaryList.Key data-cy="completionDateChangeWtesKey">
+                Working hours percentage change
+              </SummaryList.Key>
+              <SummaryList.Value data-cy="completionDateChangeWtesValue">
+                {formData.wteBeforeChange}% → {formData.wte}%
+              </SummaryList.Value>
+            </SummaryList.Row>
+            <SummaryList.Row>
+              <SummaryList.Key data-cy="completionDateChangeStartDateKey">
+                LTFT Start date
+              </SummaryList.Key>
+              <SummaryList.Value data-cy="completionDateChangeStartDateValue">
+                {dayjs(formData.startDate).format("DD/MM/YYYY")}
+                {formData.startDate &&
+                  latestSubmittedLtft &&
+                  isDateWithin16WeeksOfFirstDate(
+                    formData.startDate,
+                    latestSubmittedLtft
+                  ) && (
+                    <FieldWarningMsg
+                      warningMsgs={[ltft16WeeksWarningTextSubmitted]}
+                    />
+                  )}
+                {formData.startDate &&
+                  !latestSubmittedLtft &&
+                  isDateWithin16WeeksOfFirstDate(formData.startDate) && (
+                    <FieldWarningMsg warningMsgs={[ltft16WeeksWarningText]} />
+                  )}
+              </SummaryList.Value>
+            </SummaryList.Row>
+            {formData.altStartDate && (
               <SummaryList.Row>
-                <SummaryList.Key data-cy="completionDateChangePmKey">
-                  Programme
+                <SummaryList.Key data-cy="altStartDateKey">
+                  Alternative start date
                 </SummaryList.Key>
-                <SummaryList.Value data-cy="completionDateChangePmValue">
-                  {formData.pmName}
+                <SummaryList.Value data-cy="altStartDateValue">
+                  {dayjs(formData.altStartDate).format("DD/MM/YYYY")}
                 </SummaryList.Value>
               </SummaryList.Row>
-              <SummaryList.Row>
-                <SummaryList.Key data-cy="completionDateChangeCurrentCompletionDateKey">
-                  Current completion date
-                </SummaryList.Key>
-                <SummaryList.Value data-cy="completionDateChangeCurrentCompletionDateValue">
-                  {dayjs(formData.pmEndDate).format("DD/MM/YYYY")} (Programme
-                  end date on TIS)
-                </SummaryList.Value>
-              </SummaryList.Row>
-              <SummaryList.Row>
-                <SummaryList.Key data-cy="completionDateChangeWtesKey">
-                  Working hours percentage change
-                </SummaryList.Key>
-                <SummaryList.Value data-cy="completionDateChangeWtesValue">
-                  {formData.wteBeforeChange}% → {formData.wte}%
-                </SummaryList.Value>
-              </SummaryList.Row>
-              <SummaryList.Row>
-                <SummaryList.Key data-cy="completionDateChangeStartDateKey">
-                  LTFT Start date
-                </SummaryList.Key>
-                <SummaryList.Value data-cy="completionDateChangeStartDateValue">
-                  {dayjs(formData.startDate).format("DD/MM/YYYY")}
-                  {formData.startDate &&
-                    latestSubmittedLtft &&
-                    isDateWithin16WeeksOfFirstDate(
-                      formData.startDate,
-                      latestSubmittedLtft
-                    ) && (
-                      <FieldWarningMsg
-                        warningMsgs={[ltft16WeeksWarningTextSubmitted]}
-                      />
-                    )}
-                  {formData.startDate &&
-                    !latestSubmittedLtft &&
-                    isDateWithin16WeeksOfFirstDate(formData.startDate) && (
-                      <FieldWarningMsg warningMsgs={[ltft16WeeksWarningText]} />
-                    )}
-                </SummaryList.Value>
-              </SummaryList.Row>
-              {formData.altStartDate && (
-                <SummaryList.Row>
-                  <SummaryList.Key data-cy="altStartDateKey">
-                    Alternative start date
-                  </SummaryList.Key>
-                  <SummaryList.Value data-cy="altStartDateValue">
-                    {dayjs(formData.altStartDate).format("DD/MM/YYYY")}
-                  </SummaryList.Value>
-                </SummaryList.Row>
-              )}
-            </SummaryList>
-            <CompletionDateChangeText
-              wteBeforeChange={formData.wteBeforeChange}
-              wte={formData.wte}
-            />
-          </Card.Content>
+            )}
+          </SummaryList>
+          <CompletionDateChangeText
+            wteBeforeChange={formData.wteBeforeChange}
+            wte={formData.wte}
+          />
         </Card>
         <WarningCallout>
-          <WarningCallout.Label>Declarations</WarningCallout.Label>
+          <WarningCallout.Heading>Declarations</WarningCallout.Heading>
 
           <Declarations
             setCanSubmit={setCanSubmit}

--- a/components/forms/ltft/LtftHome.tsx
+++ b/components/forms/ltft/LtftHome.tsx
@@ -63,50 +63,46 @@ export function LtftHome({ pmOptions }: Readonly<LtftHomeProps>) {
       <ExpanderMsg expanderName="ltft16WeeksNotice" />
       <ExpanderMsg expanderName="skilledVisaWorker" />
       <Card>
-        <Card.Content>
-          <>
-            <Card.Heading data-cy="ltft-in-progress-header">
-              In progress applications
-            </Card.Heading>
-            <LtftSummary
-              ltftSummaryType="CURRENT"
-              ltftSummaryStatus={ltftFormsListStatus}
-              ltftSummaryList={draftOrUnsubmittedLtftSummary}
-            />
-            <Container>
-              <Row style={{ fontSize: "19px" }}>
-                <Col width="full">
-                  {pmOptions.length ? (
-                    <Button
-                      data-cy="make-new-ltft-btn"
-                      onClick={() => setIsModalOpen(true)}
-                    >
-                      Make a new application
-                    </Button>
-                  ) : (
-                    <p data-cy="no-eligable-pms-message">
-                      You are not eligible to make a Less than full-time (LTFT)
-                      application at this time as you have no active current or
-                      upcoming Programmes.
-                    </p>
-                  )}
-                </Col>
-              </Row>
-            </Container>
-          </>
-        </Card.Content>
-      </Card>
-      <Card>
-        <Card.Content>
-          <Card.Heading data-cy="ltft-previous-header">
-            Previous applications
+        <>
+          <Card.Heading data-cy="ltft-in-progress-header">
+            In progress applications
           </Card.Heading>
           <LtftSummary
-            ltftSummaryType="PREVIOUS"
+            ltftSummaryType="CURRENT"
             ltftSummaryStatus={ltftFormsListStatus}
-            ltftSummaryList={previousLtftSummaries}
+            ltftSummaryList={draftOrUnsubmittedLtftSummary}
           />
-        </Card.Content>
+          <Container>
+            <Row style={{ fontSize: "19px" }}>
+              <Col width="full">
+                {pmOptions.length ? (
+                  <Button
+                    data-cy="make-new-ltft-btn"
+                    onClick={() => setIsModalOpen(true)}
+                  >
+                    Make a new application
+                  </Button>
+                ) : (
+                  <p data-cy="no-eligable-pms-message">
+                    You are not eligible to make a Less than full-time (LTFT)
+                    application at this time as you have no active current or
+                    upcoming Programmes.
+                  </p>
+                )}
+              </Col>
+            </Row>
+          </Container>
+        </>
+      </Card>
+      <Card>
+        <Card.Heading data-cy="ltft-previous-header">
+          Previous applications
+        </Card.Heading>
+        <LtftSummary
+          ltftSummaryType="PREVIOUS"
+          ltftSummaryStatus={ltftFormsListStatus}
+          ltftSummaryList={previousLtftSummaries}
+        />
       </Card>
       <LtftDeclarationsModal
         isOpen={isModalOpen}

--- a/components/home/Home.tsx
+++ b/components/home/Home.tsx
@@ -1,4 +1,4 @@
-import { Card, Fieldset } from "nhsuk-react-components";
+import { Card, Fieldset, Legend } from "nhsuk-react-components";
 import { useAppSelector } from "../../redux/hooks/hooks";
 import { chunkArray } from "../../utilities/ListUtilities";
 import { isFeatureEnabled } from "../../utilities/FeatureFlagUtilities";
@@ -15,9 +15,11 @@ const Home = () => {
 
   return (
     <div className="nhsuk-width-container nhsuk-u-margin-top-5">
-      <Fieldset.Legend size="m" data-cy="tssOverview">
-        TIS Self-Service overview
-      </Fieldset.Legend>
+      <Fieldset>
+        <Legend size="m" data-cy="tssOverview">
+          TIS Self-Service overview
+        </Legend>
+      </Fieldset>
 
       {cardGroups.map((group, index) => (
         <Card.Group key={index}>

--- a/components/home/PageCard.tsx
+++ b/components/home/PageCard.tsx
@@ -31,12 +31,10 @@ export function PageCard({
       }}
       data-cy={linkHeader}
     >
-      <Card.Content>
-        <Card.Heading className="nhsuk-heading-m">
-          <Card.Link href="">{linkHeader}</Card.Link>
-        </Card.Heading>
-        <ul className={style.ull}>{listItems}</ul>
-      </Card.Content>
+      <Card.Heading className="nhsuk-heading-m">
+        <Card.Link href="">{linkHeader}</Card.Link>
+      </Card.Heading>
+      <ul className={style.ull}>{listItems}</ul>
     </Card>
   );
 }

--- a/components/home/TssUpdates.tsx
+++ b/components/home/TssUpdates.tsx
@@ -1,4 +1,4 @@
-import { ListPanel } from "nhsuk-react-components";
+// import { ListPanel } from "nhsuk-react-components";
 import { useAppSelector } from "../../redux/hooks/hooks";
 import { Post } from "../../models/WPPost";
 
@@ -52,7 +52,7 @@ export const TssUpdates: React.FC = () => {
   return (
     <div className="tss-updates-content" data-cy="tssUpdatesContainer">
       <WhatsNewHeader />
-      <ListPanel>
+      {/* <ListPanel>
         <ListPanel.Item key={id}>
           <h3 className="list-panel-header" data-cy={`postTitle${id}`}>
             {title.rendered}
@@ -61,7 +61,7 @@ export const TssUpdates: React.FC = () => {
             {extractTextFromHTML(excerpt.rendered)}
           </p>
         </ListPanel.Item>
-      </ListPanel>
+      </ListPanel> */}
     </div>
   );
 };

--- a/components/home/TssUpdates.tsx
+++ b/components/home/TssUpdates.tsx
@@ -52,9 +52,7 @@ export const TssUpdates: React.FC = () => {
     <div className="tss-updates-content" data-cy="tssUpdatesContainer">
       <WhatsNewHeader />
       <article className="whats-new-item">
-        <h3 data-cy={`postTitle${id}`}>
-          {title.rendered}
-        </h3>
+        <h3 data-cy={`postTitle${id}`}>{title.rendered}</h3>
         <p data-cy={`postExcerpt${id}`}>
           {extractTextFromHTML(excerpt.rendered)}
         </p>

--- a/components/home/TssUpdates.tsx
+++ b/components/home/TssUpdates.tsx
@@ -1,4 +1,3 @@
-// import { ListPanel } from "nhsuk-react-components";
 import { useAppSelector } from "../../redux/hooks/hooks";
 import { Post } from "../../models/WPPost";
 
@@ -52,16 +51,14 @@ export const TssUpdates: React.FC = () => {
   return (
     <div className="tss-updates-content" data-cy="tssUpdatesContainer">
       <WhatsNewHeader />
-      {/* <ListPanel>
-        <ListPanel.Item key={id}>
-          <h3 className="list-panel-header" data-cy={`postTitle${id}`}>
-            {title.rendered}
-          </h3>
-          <p data-cy={`postExcerpt${id}`}>
-            {extractTextFromHTML(excerpt.rendered)}
-          </p>
-        </ListPanel.Item>
-      </ListPanel> */}
+      <article className="whats-new-item">
+        <h3 data-cy={`postTitle${id}`}>
+          {title.rendered}
+        </h3>
+        <p data-cy={`postExcerpt${id}`}>
+          {extractTextFromHTML(excerpt.rendered)}
+        </p>
+      </article>
     </div>
   );
 };

--- a/components/main/GlobalAlert.tsx
+++ b/components/main/GlobalAlert.tsx
@@ -1,5 +1,10 @@
 import { useAppSelector } from "../../redux/hooks/hooks";
-import { ActionLink, Fieldset, Legend } from "nhsuk-react-components";
+import {
+  ActionLink,
+  Fieldset,
+  Legend,
+  CrossIcon
+} from "nhsuk-react-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
 import { Link, useLocation } from "react-router-dom";
@@ -109,7 +114,7 @@ function RecruitAlert({ onDismiss }: Readonly<{ onDismiss: () => void }>) {
         title="Dismiss recruitment alert"
         onClick={onDismiss}
       >
-        x
+        <CrossIcon />
       </button>
     </div>
   );

--- a/components/main/GlobalAlert.tsx
+++ b/components/main/GlobalAlert.tsx
@@ -1,5 +1,5 @@
 import { useAppSelector } from "../../redux/hooks/hooks";
-import { ActionLink, CloseIcon, Fieldset } from "nhsuk-react-components";
+import { ActionLink, Fieldset, Legend } from "nhsuk-react-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
 import { Link, useLocation } from "react-router-dom";
@@ -66,9 +66,11 @@ function ActionsSummaryAlert() {
 function BookmarkAlert() {
   return (
     <div data-cy="bookmarkAlert" className="bookmark-alert">
-      <Fieldset.Legend size="s" className="bookmark-alert-header">
-        We have moved
-      </Fieldset.Legend>
+      <Fieldset>
+        <Legend size="s" className="bookmark-alert-header">
+          We have moved
+        </Legend>
+      </Fieldset>
       <p>
         You are seeing this message because you accessed this site using an old
         address, we have redirected you here automatically.
@@ -107,7 +109,7 @@ function RecruitAlert({ onDismiss }: Readonly<{ onDismiss: () => void }>) {
         title="Dismiss recruitment alert"
         onClick={onDismiss}
       >
-        <CloseIcon />
+        x
       </button>
     </div>
   );

--- a/components/navigation/TSSFooter.module.scss
+++ b/components/navigation/TSSFooter.module.scss
@@ -1,3 +1,36 @@
+.footerWrapper :global(.nhsuk-footer__meta) {
+  border-top: none;
+}
+
+.footerContent {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+.footerNav {
+  display: flex;
+  flex-direction: column;
+}
+
+.footerList {
+  display: flex;
+  gap: 2rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.version {
+  font-size: 0.75rem;
+  margin-left: auto;
+}
+
+.copyright {
+  white-space: nowrap;
+}
+
 .refLink {
   text-decoration: none;
   &:hover {

--- a/components/navigation/TSSFooter.tsx
+++ b/components/navigation/TSSFooter.tsx
@@ -1,5 +1,6 @@
 import { Footer } from "nhsuk-react-components";
 import { NavLink } from "react-router-dom";
+import styles from "./TSSFooter.module.scss";
 
 interface TSSFooterProps {
   appVersion: string;
@@ -7,42 +8,45 @@ interface TSSFooterProps {
 
 const TSSFooter = ({ appVersion }: TSSFooterProps) => {
   return (
-    <Footer>
-      <Footer.Meta>
-        <Footer.ListItem
-          asElement={NavLink}
-          data-cy="linkSupport"
-          href="/support"
-          to="/support"
-        >
-          Support
-        </Footer.ListItem>
-        <Footer.ListItem
-          data-cy="linkAbout"
-          href="https://tis-support.hee.nhs.uk/about-tis/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          About
-        </Footer.ListItem>
-        <Footer.ListItem
-          data-cy="linkPrivacyPolicy"
-          href="https://www.hee.nhs.uk/about/privacy-notice"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Privacy & Cookies Policy
-        </Footer.ListItem>
-        <Footer.Copyright data-cy="copyrightText">
-          &copy; NHS England
-          {appVersion && (
-            <span
-              className="nhsuk-u-display-block nhsuk-u-margin-top-2"
-              data-cy="versionText"
-            >{`version: ${appVersion}`}</span>
-          )}
-        </Footer.Copyright>
-      </Footer.Meta>
+    <Footer className={styles.footerWrapper}>
+      <Footer.Content width="full">
+        <nav className={styles.footerNav} aria-label="Footer navigation">
+          <ul className={styles.footerList}>
+            <li>
+              <NavLink to="/support" data-cy="linkSupport">
+                Support
+              </NavLink>
+            </li>
+
+            <li>
+              <a
+                href="https://tis-support.hee.nhs.uk/about-tis/"
+                target="_blank"
+                rel="noopener noreferrer"
+                data-cy="linkAbout"
+              >
+                About
+              </a>
+            </li>
+
+            <li>
+              <a
+                href="https://www.hee.nhs.uk/about/privacy-notice"
+                target="_blank"
+                rel="noopener noreferrer"
+                data-cy="linkPrivacyPolicy"
+              >
+                Privacy & Cookies Policy
+              </a>
+            </li>
+            {appVersion && (
+              <li className={styles.version} data-cy="versionText">
+                Version: {appVersion}
+              </li>
+            )}
+          </ul>
+        </nav>
+      </Footer.Content>
     </Footer>
   );
 };

--- a/components/navigation/TSSFooter.tsx
+++ b/components/navigation/TSSFooter.tsx
@@ -1,7 +1,5 @@
-import dayjs from "dayjs";
-import { Col, Footer, Row } from "nhsuk-react-components";
+import { Footer } from "nhsuk-react-components";
 import { NavLink } from "react-router-dom";
-import styles from "./TSSFooter.module.scss";
 
 interface TSSFooterProps {
   appVersion: string;
@@ -10,54 +8,41 @@ interface TSSFooterProps {
 const TSSFooter = ({ appVersion }: TSSFooterProps) => {
   return (
     <Footer>
-      <Footer.List>
-        <Row>
-          <Col width="one-quarter">
-            <NavLink
-              className={styles.refLink}
-              data-cy="linkSupport"
-              to={"/support"}
-            >
-              Support
-            </NavLink>
-          </Col>
-          <Col width="one-quarter">
-            <a
-              className={styles.refLink}
-              data-cy="linkAbout"
-              href="https://tis-support.hee.nhs.uk/about-tis/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              About
-            </a>
-          </Col>
-          <Col width="one-quarter">
-            <a
-              className={styles.refLink}
-              data-cy="linkPrivacyPolicy"
-              href="https://www.hee.nhs.uk/about/privacy-notice"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Privacy &amp; Cookies Policy
-            </a>
-          </Col>
-        </Row>
-      </Footer.List>
-      <Footer.Copyright data-cy="copyrightText">
-        &copy; NHS England {dayjs().year()}
-      </Footer.Copyright>
-      {appVersion ? (
-        <Footer.List>
-          <Footer.ListItem>
+      <Footer.Meta>
+        <Footer.ListItem
+          asElement={NavLink}
+          data-cy="linkSupport"
+          href="/support"
+          to="/support"
+        >
+          Support
+        </Footer.ListItem>
+        <Footer.ListItem
+          data-cy="linkAbout"
+          href="https://tis-support.hee.nhs.uk/about-tis/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          About
+        </Footer.ListItem>
+        <Footer.ListItem
+          data-cy="linkPrivacyPolicy"
+          href="https://www.hee.nhs.uk/about/privacy-notice"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Privacy & Cookies Policy
+        </Footer.ListItem>
+        <Footer.Copyright data-cy="copyrightText">
+          &copy; NHS England
+          {appVersion && (
             <span
-              className={styles.footerVersionText}
+              className="nhsuk-u-display-block nhsuk-u-margin-top-2"
               data-cy="versionText"
             >{`version: ${appVersion}`}</span>
-          </Footer.ListItem>
-        </Footer.List>
-      ) : null}
+          )}
+        </Footer.Copyright>
+      </Footer.Meta>
     </Footer>
   );
 };

--- a/components/navigation/TSSHeader.tsx
+++ b/components/navigation/TSSHeader.tsx
@@ -106,11 +106,11 @@ function makeTSSHeaderLinks(
       featureEnabled: userFeatures.details.placements.enabled
     },
     {
-      path: "cct",
-      name: "CCT",
+      path: "ltft",
+      name: "Less than full-time (LTFT)",
       mobileOnly: false,
       showWithNoMfa: false,
-      featureEnabled: userFeatures.cct.enabled
+      featureEnabled: userFeatures.forms.ltft.enabled
     },
     {
       path: "formr-a",
@@ -127,20 +127,6 @@ function makeTSSHeaderLinks(
       featureEnabled: userFeatures.forms.formr.enabled
     },
     {
-      path: "support",
-      name: "Support",
-      mobileOnly: true,
-      showWithNoMfa: true,
-      featureEnabled: true
-    },
-    {
-      path: "mfa",
-      name: "MFA set-up",
-      mobileOnly: true,
-      showWithNoMfa: true,
-      featureEnabled: true
-    },
-    {
       path: "profile",
       name: "Profile",
       mobileOnly: false,
@@ -148,11 +134,25 @@ function makeTSSHeaderLinks(
       featureEnabled: userFeatures.details.profile.enabled
     },
     {
-      path: "ltft",
-      name: "Less than full-time (LTFT)",
+      path: "support",
+      name: "Support",
+      mobileOnly: false,
+      showWithNoMfa: true,
+      featureEnabled: true
+    },
+    {
+      path: "mfa",
+      name: "MFA set-up",
+      mobileOnly: false,
+      showWithNoMfa: true,
+      featureEnabled: true
+    },
+    {
+      path: "cct",
+      name: "CCT",
       mobileOnly: false,
       showWithNoMfa: false,
-      featureEnabled: userFeatures.forms.ltft.enabled
+      featureEnabled: userFeatures.cct.enabled
     }
   ];
 

--- a/components/navigation/TSSHeader.tsx
+++ b/components/navigation/TSSHeader.tsx
@@ -1,15 +1,15 @@
 import { Header } from "nhsuk-react-components";
 import { NavLink } from "react-router-dom";
-import { SignOutBtn } from "../common/SignOutBtn";
-import { NHSEnglandLogoWhite } from "../../public/NHSEnglandLogoWhite";
-import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
 import { useEffect } from "react";
+import { useAuthenticator } from "@aws-amplify/ui-react";
+import { useAppDispatch, useAppSelector } from "../../redux/hooks/hooks";
 import { getNotificationCount } from "../../redux/slices/notificationsSlice";
 import { NotificationsBtn } from "../notifications/NotificationsBtn";
-import { UserFeaturesType } from "../../models/FeatureFlags";
 import { EmailsBtn } from "../notifications/EmailsBtn";
+import { UserFeaturesType } from "../../models/FeatureFlags";
 
 const TSSHeader = () => {
+  const { signOut } = useAuthenticator(context => [context.user]);
   const dispatch = useAppDispatch();
   const unreadNotificationCount = useAppSelector(
     state => state.notifications.unreadNotificationCount
@@ -19,6 +19,10 @@ const TSSHeader = () => {
   );
   const preferredMfa = useAppSelector(state => state.user.preferredMfa);
   const userFeatures = useAppSelector(state => state.user.features);
+  const traineeProfileDetails = useAppSelector(
+    state => state.traineeProfile.traineeProfileData.personalDetails
+  );
+  const concatName = `${traineeProfileDetails.forenames} ${traineeProfileDetails.surname}`;
 
   useEffect(() => {
     if (notificationsStatus === "idle") {
@@ -26,77 +30,53 @@ const TSSHeader = () => {
     }
   }, [notificationsStatus, dispatch]);
 
-  const notificationBtns = userFeatures.notifications.enabled && (
-    <>
-      <EmailsBtn data-cy="emailBtnHDR" />
-      <NotificationsBtn
-        unreadNotificationCount={unreadNotificationCount}
-        data-cy="notificationBtnHDR"
-      />
-    </>
-  );
-
   return (
-    <Header>
-      <Header.Container>
-        <div className="nhsuk-header__logo" data-cy="headerLogo">
-          <a
-            href="/"
-            aria-label="TSS home page"
-            className="nhsuk-header__navigation-link header-logo-link"
-          >
-            <NHSEnglandLogoWhite />
-          </a>
-        </div>
-        <Header.Content>
-          <div className="mobile-header">
-            {notificationBtns}
-            <Header.MenuToggle data-cy="menuToggleBtn" />
-          </div>
-          <div className="top-nav-container">
-            {notificationBtns}
-            <div className="top-nav-container">
-              <NavLink
-                className="nhsuk-header__navigation-link"
-                data-cy="topNavSupport"
-                to="/support"
-              >
-                Support
-              </NavLink>
-              <NavLink
-                className="nhsuk-header__navigation-link"
-                data-cy="topNavMfaSetup"
-                to="/mfa"
-              >
-                MFA set-up
-              </NavLink>
-              <SignOutBtn />
-            </div>
-          </div>
-        </Header.Content>
-      </Header.Container>
-      <div className="nhsuk-width-container">
-        <span className="tss-name" data-cy="tssName">
-          TIS Self-Service{" "}
-          <a
-            className="tss-beta-link"
-            href="https://architecture.digital.nhs.uk/information/glossary"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <i>(Private Beta)</i>
-          </a>
-        </span>
-      </div>
-      <Header.Nav style={{ maxWidth: "100%" }}>
+    <Header
+      service={{
+        href: "/",
+        text: "TIS Self-Service"
+      }}
+    >
+      <Header.Account>
+        {userFeatures.notifications.enabled && (
+          <>
+            <Header.AccountItem>
+              <NotificationsBtn
+                unreadNotificationCount={unreadNotificationCount}
+                data-cy="notificationBtnHDR"
+              />
+            </Header.AccountItem>
+            <Header.AccountItem>
+              <EmailsBtn data-cy="emailBtnHDR" />
+            </Header.AccountItem>
+          </>
+        )}
+
+        <Header.AccountItem
+          asElement={NavLink}
+          data-cy="profileLink"
+          href="/profile"
+          icon
+          to="/profile"
+        >
+          {concatName}
+        </Header.AccountItem>
+        <Header.AccountItem
+          as="button"
+          data-cy="signOutBtn"
+          onClick={signOut}
+          type="button"
+        >
+          Sign out
+        </Header.AccountItem>
+      </Header.Account>
+      <Header.Navigation>
         {makeTSSHeaderLinks(preferredMfa, userFeatures)}
-        <div className="nhsuk-header__navigation-item mobile-only-nav">
-          <SignOutBtn />
-        </div>
-      </Header.Nav>
+      </Header.Navigation>
     </Header>
   );
 };
+
 export default TSSHeader;
 
 function makeTSSHeaderLinks(
@@ -176,33 +156,34 @@ function makeTSSHeaderLinks(
     }
   ];
 
-  const makeLi = (pathObj: {
+  const makeNavigationItem = (pathObj: {
     path: string;
     name: string;
     mobileOnly: boolean;
     showWithNoMfa: boolean;
     featureEnabled: boolean;
-  }) => (
-    <div
-      data-cy="nav-link-wrapper"
-      key={pathObj.name}
-      className={`nhsuk-header__navigation-item ${
-        pathObj.mobileOnly ? "mobile-only-nav" : ""
-      }`}
-      hidden={
-        ((preferredMfa === "NOMFA" || preferredMfa === "SMS") &&
-          !pathObj.showWithNoMfa) ||
-        !pathObj?.featureEnabled
-      }
-    >
-      <NavLink
+  }) => {
+    const hasRestrictedMfa = preferredMfa === "NOMFA" || preferredMfa === "SMS";
+    const shouldShow =
+      pathObj.featureEnabled && (!hasRestrictedMfa || pathObj.showWithNoMfa);
+
+    if (!shouldShow) {
+      return null;
+    }
+
+    return (
+      <Header.NavigationItem
+        asElement={NavLink}
+        className={pathObj.mobileOnly ? "mobile-only-nav" : undefined}
         data-cy={pathObj.name}
-        className="nhsuk-header__navigation-link"
+        href={`/${pathObj.path}`}
+        key={pathObj.name}
         to={`/${pathObj.path}`}
       >
         {pathObj.name}
-      </NavLink>
-    </div>
-  );
-  return paths.map(p => makeLi(p));
+      </Header.NavigationItem>
+    );
+  };
+
+  return paths.map(makeNavigationItem);
 }

--- a/components/notifications/EmailsBtn.tsx
+++ b/components/notifications/EmailsBtn.tsx
@@ -10,17 +10,25 @@ export const EmailsBtn = () => {
     history.push("/notifications");
   };
   return (
-    <Button
-      type="button"
-      className="notification-btn"
+    <button
       data-cy="emailBtn"
       data-tooltip-id="EmailCount"
       onClick={handleBtnClick}
+      style={{
+        background: "none",
+        border: "none",
+        marginRight: "0.5rem",
+        cursor: "pointer"
+      }}
     >
       <span>
-        <FontAwesomeIcon icon={faEnvelope} size="xs" color="white" />
-        <Tooltip id="EmailCount" content="Email notifications" />
+        <FontAwesomeIcon icon={faEnvelope} size="xl" color="white" />
+        <Tooltip
+          id="EmailCount"
+          content="Email notifications"
+          positionStrategy="fixed"
+        />
       </span>
-    </Button>
+    </button>
   );
 };

--- a/components/notifications/EmailsBtn.tsx
+++ b/components/notifications/EmailsBtn.tsx
@@ -1,4 +1,3 @@
-import { Button } from "nhsuk-react-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
 import { Tooltip } from "react-tooltip";

--- a/components/notifications/Notifications.tsx
+++ b/components/notifications/Notifications.tsx
@@ -1,7 +1,7 @@
 import { Route, Switch } from "react-router-dom";
 import ScrollTo from "../forms/ScrollTo";
 import PageTitle from "../common/PageTitle";
-import { Fieldset } from "nhsuk-react-components";
+import { Fieldset, Legend } from "nhsuk-react-components";
 import PageNotFound from "../common/PageNotFound";
 import { NotificationsTable } from "./NotificationsTable";
 import { NotificationMessage } from "./NotificationMessage";
@@ -14,13 +14,14 @@ export const Notifications = () => {
       <PageTitle title="Notifications" />
       <ScrollTo />
       <Fieldset>
-        <Fieldset.Legend
+        <Legend
           isPageHeading
           className="fieldset-legend__header"
           data-cy="notificationsHeading"
+          size="xl"
         >
           {viewingType === "IN_APP" ? "In-app" : "Email"} Notifications
-        </Fieldset.Legend>
+        </Legend>
       </Fieldset>
       <Switch>
         <Route

--- a/components/notifications/NotificationsBtn.tsx
+++ b/components/notifications/NotificationsBtn.tsx
@@ -15,20 +15,44 @@ export const NotificationsBtn = ({
     history.push("/notifications");
   };
   return (
-    <Button
-      type="button"
-      className="notification-btn"
+    <button
       data-cy="notificationBtn"
       data-tooltip-id="NotificationsCount"
       onClick={handleBtnClick}
+      className="notification-btn"
+      style={{
+        background: "none",
+        border: "none",
+        cursor: "pointer"
+      }}
     >
       <span>
-        <FontAwesomeIcon icon={faBell} size="xs" color="white" />
-        <Tooltip id="NotificationsCount" content="In-app notifications" />
+        <FontAwesomeIcon icon={faBell} size="xl" color="white" style={{}} />
+        <Tooltip
+          id="NotificationsCount"
+          content="In-app notifications"
+          positionStrategy="fixed"
+        />
         {unreadNotificationCount > 0 && (
-          <span className="notification-badge">{unreadNotificationCount}</span>
+          <span
+            style={{
+              position: "relative",
+              top: "-6px",
+              right: "6px",
+              backgroundColor: "#FF5733",
+              color: "white",
+              borderRadius: "50%",
+              padding: "2px 6px",
+              fontSize: "12px",
+              fontWeight: "bold",
+              minWidth: "20px",
+              textAlign: "center"
+            }}
+          >
+            {unreadNotificationCount}
+          </span>
         )}
       </span>
-    </Button>
+    </button>
   );
 };

--- a/components/notifications/NotificationsBtn.tsx
+++ b/components/notifications/NotificationsBtn.tsx
@@ -1,4 +1,3 @@
-import { Button } from "nhsuk-react-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBell } from "@fortawesome/free-solid-svg-icons";
 import { Tooltip } from "react-tooltip";
@@ -35,6 +34,7 @@ export const NotificationsBtn = ({
         />
         {unreadNotificationCount > 0 && (
           <span
+            className="notification-badge"
             style={{
               position: "relative",
               top: "-6px",

--- a/components/notifications/NotificationsTableView.tsx
+++ b/components/notifications/NotificationsTableView.tsx
@@ -145,7 +145,7 @@ function NotificationTypeButton({
 
   return (
     <Button
-      type="button"
+      as="button"
       className={`notification-type-btn ${isActive ? "active-type-btn" : ""}`}
       data-cy={dataCy}
       onClick={() => switchNotification(type)}

--- a/components/notifications/NotificationsTableView.tsx
+++ b/components/notifications/NotificationsTableView.tsx
@@ -14,7 +14,13 @@ import {
   switchNotification
 } from "../../utilities/NotificationsUtilities";
 import { emailColumns, inAppColumns } from "./columns";
-import { Button, Col, Container, Row } from "nhsuk-react-components";
+import {
+  Button,
+  Checkboxes,
+  Col,
+  Container,
+  Row
+} from "nhsuk-react-components";
 import {
   markNotificationAsRead,
   NotificationMsgType,
@@ -172,29 +178,20 @@ function NotificationFilterCheckbox({
   );
 
   return (
-    <div className="nhsuk-checkboxes nhsuk-checkboxes--small">
-      <div className="nhsuk-checkboxes__item">
-        <input
-          className="nhsuk-checkboxes__input"
-          type="checkbox"
-          id={id}
-          value={notificationsStatusFilter || ""}
-          defaultChecked={false}
-          checked={notificationsStatusFilter === filterValue}
-          onChange={() =>
-            applyNotificationStatusFilter(
-              notificationsStatusFilter === "" ? filterValue : ""
-            )
-          }
-        />
-        <label
-          htmlFor={id}
-          className="nhsuk-label nhsuk-checkboxes__label"
-          data-cy={`checkboxLabel-${label}`}
-        >
-          {label}
-        </label>
-      </div>
-    </div>
+    <Checkboxes small>
+      <Checkboxes.Item
+        id={id}
+        data-cy={id}
+        value={filterValue}
+        checked={notificationsStatusFilter === filterValue}
+        onChange={() =>
+          applyNotificationStatusFilter(
+            notificationsStatusFilter === "" ? filterValue : ""
+          )
+        }
+      >
+        {label}
+      </Checkboxes.Item>
+    </Checkboxes>
   );
 }

--- a/components/profile/Profile.tsx
+++ b/components/profile/Profile.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Fieldset, SummaryList } from "nhsuk-react-components";
+import { Fieldset, Legend, SummaryList } from "nhsuk-react-components";
 import { Button } from "@aws-amplify/ui-react";
 import PageTitle from "../common/PageTitle";
 import ScrollTo from "../forms/ScrollTo";
@@ -156,13 +156,14 @@ const Profile = () => {
       <PageTitle title="Profile" />
       <ScrollTo />
       <Fieldset>
-        <Fieldset.Legend
+        <Legend
           isPageHeading
           className={style.fieldLegHeader}
           data-cy="profileHeading"
+          size="xl"
         >
           Profile
-        </Fieldset.Legend>
+        </Legend>
       </Fieldset>
       <DataSourceMsg />
       <SummaryList>
@@ -173,7 +174,6 @@ const Profile = () => {
             {forenames && `${forenames} `}
             {surname}
           </SummaryList.Value>
-          <SummaryList.Actions></SummaryList.Actions>
         </SummaryList.Row>
         {personalData?.map(pd => (
           <SummaryList.Row key={pd.label} data-cy={pd.label}>
@@ -183,7 +183,7 @@ const Profile = () => {
             <SummaryList.Value data-cy={`${pd.label}-value`}>
               {pd.value}
             </SummaryList.Value>
-            <SummaryList.Actions>
+            <SummaryList.Action asElement="span">
               {pd.label === emailFieldLabel && (
                 <Button
                   data-cy="updateEmailBtn"
@@ -192,7 +192,7 @@ const Profile = () => {
                   change
                 </Button>
               )}
-            </SummaryList.Actions>
+            </SummaryList.Action>
           </SummaryList.Row>
         ))}
 
@@ -204,7 +204,6 @@ const Profile = () => {
             <p>{address3}</p>
             <p data-cy="postCode">{postCode}</p>
           </SummaryList.Value>
-          <SummaryList.Actions></SummaryList.Actions>
         </SummaryList.Row>
         <div className="nhsuk-heading-m nhsuk-u-margin-top-4">
           Registration details
@@ -219,7 +218,7 @@ const Profile = () => {
                 <SummaryList.Value data-cy={`${rd.label}-value`}>
                   {rd.value}
                 </SummaryList.Value>
-                <SummaryList.Actions>
+                <SummaryList.Action asElement="span">
                   {rd.type === FieldType.Editable &&
                     rd.label === gmcFieldLabel && (
                       <Button
@@ -229,7 +228,7 @@ const Profile = () => {
                         change
                       </Button>
                     )}
-                </SummaryList.Actions>
+                </SummaryList.Action>
               </SummaryList.Row>
             )
         )}

--- a/components/profile/ProfilePage.tsx
+++ b/components/profile/ProfilePage.tsx
@@ -3,7 +3,7 @@ import PageTitle from "../common/PageTitle";
 import ScrollTo from "../forms/ScrollTo";
 import DataSourceMsg from "../common/DataSourceMsg";
 import style from "../Common.module.scss";
-import { Fieldset } from "nhsuk-react-components";
+import { Fieldset, Legend } from "nhsuk-react-components";
 import { ProfilePanels } from "../profile/ProfilePanels";
 import { TraineeProfileName } from "../../models/TraineeProfile";
 
@@ -23,13 +23,14 @@ export function ProfilePage({
       <PageTitle title={title} />
       <ScrollTo />
       <Fieldset>
-        <Fieldset.Legend
+        <Legend
           isPageHeading
           className={style.fieldLegHeader}
           data-cy={`${profileName.toLowerCase()}Heading`}
+          size="xl"
         >
           {title}
-        </Fieldset.Legend>
+        </Legend>
       </Fieldset>
       <DataSourceMsg />
       <ProfilePanels

--- a/components/profile/ProfilePanels.tsx
+++ b/components/profile/ProfilePanels.tsx
@@ -54,9 +54,7 @@ export function ProfilePanels({
           </Details.Summary>
           <Details.Text>
             <WarningCallout>
-              <WarningCallout.Label visuallyHiddenText={false}>
-                Please note
-              </WarningCallout.Label>
+              <WarningCallout.Heading>Please note</WarningCallout.Heading>
               <p data-cy="futureWarningText">{warningText}</p>
             </WarningCallout>
             <PanelsCreator

--- a/components/programmes/Programmes.tsx
+++ b/components/programmes/Programmes.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { TraineeProfileName } from "../../models/TraineeProfile";
 import { ProfilePage } from "../profile/ProfilePage";
 import { getProfilePanelFutureWarningText } from "../../utilities/Constants";

--- a/components/programmes/trackers/OnboardingTracker.tsx
+++ b/components/programmes/trackers/OnboardingTracker.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Fieldset } from "nhsuk-react-components";
+import { Fieldset, Legend } from "nhsuk-react-components";
 import { useParams } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks/hooks";
 import { OnboardingTrackerActions } from "./OnboardingTrackerActions";
@@ -33,14 +33,15 @@ export function OnboardingTracker() {
       <ScrollToTop errors={[]} page={0} isPageDirty={false} />
       <FormBackLink text="Back to Programmes list" />
       <Fieldset>
-        <Fieldset.Legend
+        <Legend
           isPageHeading
           data-cy="onboardingTrackerHeading"
           tabIndex={0}
           style={{ color: "#005eb8" }}
+          size="xl"
         >
           {`Onboarding Tracker for ${panel?.programmeName}`}
-        </Fieldset.Legend>
+        </Legend>
       </Fieldset>
       <OnboardingTrackerActions panel={panel} />
     </>

--- a/components/support/Support.tsx
+++ b/components/support/Support.tsx
@@ -44,38 +44,52 @@ const Support = () => {
             <p>Click the link below to view FAQ&apos;s (opens a new window)</p>
           </Legend>
         </Fieldset>
-        <ActionLink
-          data-cy="supportCreateAccFaqsLink"
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://tis-support.hee.nhs.uk/trainees/when-i-sign-up/"
-        >
-          When I Create an Account
-        </ActionLink>
-        <ActionLink
-          data-cy="supportSignInFaqsLink"
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://tis-support.hee.nhs.uk/trainees/when-i-log-in/"
-        >
-          When I Sign In
-        </ActionLink>
-        <ActionLink
-          data-cy="supportFormRFaqsLink"
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://tis-support.hee.nhs.uk/trainees/form-r/"
-        >
-          Form R
-        </ActionLink>
-        <ActionLink
-          data-cy="supportChangesFaqsLink"
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://tis-support.hee.nhs.uk/trainees/changes-to-account/"
-        >
-          Changes to Account
-        </ActionLink>
+        <ul className="nhsuk-list">
+          <li>
+            <ActionLink
+              className="nhsuk-u-margin-bottom-0"
+              data-cy="supportCreateAccFaqsLink"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://tis-support.hee.nhs.uk/trainees/when-i-sign-up/"
+            >
+              When I Create an Account
+            </ActionLink>
+          </li>
+          <li>
+            <ActionLink
+              className="nhsuk-u-margin-bottom-0"
+              data-cy="supportSignInFaqsLink"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://tis-support.hee.nhs.uk/trainees/when-i-log-in/"
+            >
+              When I Sign In
+            </ActionLink>
+          </li>
+          <li>
+            <ActionLink
+              className="nhsuk-u-margin-bottom-0"
+              data-cy="supportFormRFaqsLink"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://tis-support.hee.nhs.uk/trainees/form-r/"
+            >
+              Form R
+            </ActionLink>
+          </li>
+          <li>
+            <ActionLink
+              className="nhsuk-u-margin-bottom-0"
+              data-cy="supportChangesFaqsLink"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://tis-support.hee.nhs.uk/trainees/changes-to-account/"
+            >
+              Changes to Account
+            </ActionLink>
+          </li>
+        </ul>
       </Card>
       <Card feature data-cy="loSupportLabel">
         <Card.Heading data-cy="loSupportHeading">

--- a/components/support/Support.tsx
+++ b/components/support/Support.tsx
@@ -1,4 +1,4 @@
-import { ActionLink, Card, Fieldset } from "nhsuk-react-components";
+import { ActionLink, Card, Fieldset, Legend } from "nhsuk-react-components";
 import PageTitle from "../common/PageTitle";
 import { useAppSelector } from "../../redux/hooks/hooks";
 import { selectTraineeProfile } from "../../redux/slices/traineeProfileSlice";
@@ -22,18 +22,19 @@ const Support = () => {
       <PageTitle title="Support" />
       <ScrollTo />
       <Fieldset>
-        <Fieldset.Legend
+        <Legend
           isPageHeading
           className={style.fieldLegHeader}
           data-cy="supportHeading"
+          size="xl"
         >
           Support
-        </Fieldset.Legend>
+        </Legend>
       </Fieldset>
       <Card feature data-cy="supportFaqs">
-        <Card.Content>
-          <Card.Heading data-cy="supportFaqsHeading">FAQ&apos;s</Card.Heading>
-          <Fieldset.Legend
+        <Card.Heading data-cy="supportFaqsHeading">FAQ&apos;s</Card.Heading>
+        <Fieldset>
+          <Legend
             data-cy="supportFaqsLegend"
             size="m"
             className="fieldset-legend__header"
@@ -41,47 +42,47 @@ const Support = () => {
             Please read our FAQ&apos;s to see if your query can be answered
             there.
             <p>Click the link below to view FAQ&apos;s (opens a new window)</p>
-          </Fieldset.Legend>
-          <ActionLink
-            data-cy="supportCreateAccFaqsLink"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://tis-support.hee.nhs.uk/trainees/when-i-sign-up/"
-          >
-            When I Create an Account
-          </ActionLink>
-          <ActionLink
-            data-cy="supportSignInFaqsLink"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://tis-support.hee.nhs.uk/trainees/when-i-log-in/"
-          >
-            When I Sign In
-          </ActionLink>
-          <ActionLink
-            data-cy="supportFormRFaqsLink"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://tis-support.hee.nhs.uk/trainees/form-r/"
-          >
-            Form R
-          </ActionLink>
-          <ActionLink
-            data-cy="supportChangesFaqsLink"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://tis-support.hee.nhs.uk/trainees/changes-to-account/"
-          >
-            Changes to Account
-          </ActionLink>
-        </Card.Content>
+          </Legend>
+        </Fieldset>
+        <ActionLink
+          data-cy="supportCreateAccFaqsLink"
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://tis-support.hee.nhs.uk/trainees/when-i-sign-up/"
+        >
+          When I Create an Account
+        </ActionLink>
+        <ActionLink
+          data-cy="supportSignInFaqsLink"
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://tis-support.hee.nhs.uk/trainees/when-i-log-in/"
+        >
+          When I Sign In
+        </ActionLink>
+        <ActionLink
+          data-cy="supportFormRFaqsLink"
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://tis-support.hee.nhs.uk/trainees/form-r/"
+        >
+          Form R
+        </ActionLink>
+        <ActionLink
+          data-cy="supportChangesFaqsLink"
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://tis-support.hee.nhs.uk/trainees/changes-to-account/"
+        >
+          Changes to Account
+        </ActionLink>
       </Card>
       <Card feature data-cy="loSupportLabel">
-        <Card.Content>
-          <Card.Heading data-cy="loSupportHeading">
-            Local Office support
-          </Card.Heading>
-          <Fieldset.Legend
+        <Card.Heading data-cy="loSupportHeading">
+          Local Office support
+        </Card.Heading>
+        <Fieldset>
+          <Legend
             data-cy="loSupportLegend"
             size="m"
             className="fieldset-legend__header"
@@ -90,16 +91,16 @@ const Support = () => {
             <p data-cy="loSupportDesc">
               (e.g. Editing a submitted form, incorrect data.)
             </p>
-          </Fieldset.Legend>
-          <LoSupport emailIds={emailIds} userAgentData={userAgentData} />
-        </Card.Content>
+          </Legend>
+        </Fieldset>
+        <LoSupport emailIds={emailIds} userAgentData={userAgentData} />
       </Card>
       <Card feature data-cy="techSupportLabel">
-        <Card.Content>
-          <Card.Heading data-cy="techSupportHeading">
-            Technical support
-          </Card.Heading>
-          <Fieldset.Legend
+        <Card.Heading data-cy="techSupportHeading">
+          Technical support
+        </Card.Heading>
+        <Fieldset>
+          <Legend
             data-cy="techSupportLegend"
             size="m"
             className="fieldset-legend__header"
@@ -108,9 +109,9 @@ const Support = () => {
             <p data-cy="techSupportDesc">
               (e.g. Error messages, Form R not saving.)
             </p>
-          </Fieldset.Legend>
-          <TechSupport emailIds={emailIds} userAgentData={userAgentData} />
-        </Card.Content>
+          </Legend>
+        </Fieldset>
+        <TechSupport emailIds={emailIds} userAgentData={userAgentData} />
       </Card>
     </>
   );

--- a/cypress/component/authentication/CreateTotp.cy.tsx
+++ b/cypress/component/authentication/CreateTotp.cy.tsx
@@ -9,7 +9,6 @@ import { updatedTempMfa } from "../../../redux/slices/userSlice";
 import store from "../../../redux/store/store";
 import CreateTotp from "../../../components/authentication/setMfa/totp/CreateTotp";
 import history from "../../../components/navigation/history";
-import React from "react";
 
 describe("CreateTotp sections", () => {
   it("should not render a totp section if NOMFA", () => {
@@ -46,7 +45,7 @@ describe("CreateTotp sections", () => {
       .should("exist")
       .should("include.text", "No");
     cy.get("[data-cy=appInstalledAlready0]").click();
-    cy.get(".nhsuk-warning-callout").should("exist");
+    cy.get("[data-cy=threeMinWarning]").should("exist");
     cy.get(".nhsuk-button")
       .should("exist")
       .should(
@@ -54,7 +53,7 @@ describe("CreateTotp sections", () => {
         "Add 'NHS TIS Self-Service' to your Authenticator App"
       );
     cy.get("[data-cy=appInstalledAlready1]").click();
-    cy.get(".nhsuk-warning-callout").should("not.exist");
+    cy.get("[data-cy=threeMinWarning]").should("not.exist");
 
     // progress to Install totp section
     cy.get(".nhsuk-button").should("exist").click();

--- a/cypress/component/forms/ltft/LtftForm.cy.tsx
+++ b/cypress/component/forms/ltft/LtftForm.cy.tsx
@@ -143,10 +143,12 @@ describe("LtftForm - draft", () => {
 
     // Part 5
     cy.get("h3").contains("Part 5 of 10 - Reason(s) for applying");
-    cy.get(
-      '[data-cy="WarningCallout-ltftReasonsInstructions-label"] > span'
-    ).contains("Important");
-    cy.get(".nhsuk-warning-callout > p").contains(ltftReasonsText1);
+    cy.get('[data-cy="WarningCallout-ltftReasonsInstructions-label"]').contains(
+      "Important"
+    );
+    cy.get(".nhsuk-card--warning .nhsuk-card__content > p").contains(
+      ltftReasonsText1
+    );
     cy.navNext();
     cy.get("#reasonsSelected-error").contains(ltftReasonsError);
     cy.get(".nhsuk-card__heading").contains("Reason(s) for applying");
@@ -177,15 +179,15 @@ describe("LtftForm - draft", () => {
     // Part 7
     cy.get("h3").contains("Part 7 of 10 - Pre-approver discussions");
     cy.get(
-      '[data-cy="WarningCallout-ltftDiscussionInstructions-label"] > span'
+      '[data-cy="WarningCallout-ltftDiscussionInstructions-label"]'
     ).should("exist");
-    cy.get(".nhsuk-warning-callout > :nth-child(3)").should(
+    cy.get(".nhsuk-card--warning .nhsuk-card__content > :nth-child(3)").should(
       "include.text",
       ltftDiscussionText2.slice(0, 100)
     );
-    cy.get(".nhsuk-warning-callout > :nth-child(4)").contains(
-      "For information on Professional support contact"
-    );
+    cy.get(
+      ".nhsuk-card--warning .nhsuk-card__content > :nth-child(4)"
+    ).contains("For information on Professional support contact");
     cy.get('[data-cy="tpdName-label"]').contains("Pre-approver name");
     cy.navNext();
     cy.get("#tpdName-error").contains("Pre-approver name is required");
@@ -213,7 +215,9 @@ describe("LtftForm - draft", () => {
 
     // part 9
     cy.get("h3").contains("Part 9 of 10 - Skilled Worker visa status");
-    cy.get(".nhsuk-warning-callout > p").contains(ltftTier2VisaImportantText1);
+    cy.get(".nhsuk-card--warning .nhsuk-card__content > p").contains(
+      ltftTier2VisaImportantText1
+    );
     cy.get('[data-cy="skilledVisaWorkerMoreInfoSummary"]').should("exist");
     cy.navNext();
     cy.get("#skilledWorkerVisaHolder-error").contains(LtftVisaError);

--- a/cypress/component/forms/ltft/LtftFormView.cy.tsx
+++ b/cypress/component/forms/ltft/LtftFormView.cy.tsx
@@ -191,7 +191,7 @@ describe("LTFT Form View - editable (DRAFT)", () => {
     cy.get("@updateLtftStub").should("have.been.called");
 
     // action modal
-    cy.get('[data-cy="warningLabel-Submit"] > span').should("exist");
+    cy.get('[data-cy="warningLabel-Submit"]').should("exist");
     cy.get('[data-cy="warningText-Submit"]').should("exist");
     cy.get('[data-cy="additionalInfo"]').should("exist");
     cy.get('[data-cy="modal-cancel-btn"]').should("exist");

--- a/cypress/component/navigation/TSSFooter.cy.tsx
+++ b/cypress/component/navigation/TSSFooter.cy.tsx
@@ -35,7 +35,10 @@ describe("Footer", () => {
   });
 
   it("Copyright notice should contain HEE text", () => {
-    cy.get("[data-cy=copyrightText]").should("contain.text", "NHS England");
+    cy.get(".nhsuk-footer__meta .nhsuk-body-s").should(
+      "contain.text",
+      "NHS England"
+    );
   });
 
   it("should have the correct version shown in the footer", () => {

--- a/cypress/component/navigation/TSSHeader.cy.tsx
+++ b/cypress/component/navigation/TSSHeader.cy.tsx
@@ -236,7 +236,9 @@ describe("Desktop Header with MFA set up", () => {
     });
 
     it("should not display any unexpected links", () => {
-      cy.get(".nhsuk-header__navigation-item:visible").should("not.exist");
+      cy.get(".nhsuk-header__navigation-item:visible")
+        .its("length")
+        .should("eq", navLinksBase.length);
     });
   });
 
@@ -263,7 +265,7 @@ describe("Desktop Header with MFA set up", () => {
     it("should not display any unexpected links", () => {
       cy.get(".nhsuk-header__navigation-item:visible")
         .its("length")
-        .should("eq", navLinksNonSpecialty.length - 2);
+        .should("eq", navLinksNonSpecialty.length);
     });
   });
 
@@ -296,7 +298,7 @@ describe("Desktop Header with MFA set up", () => {
     it("should not display any unexpected links", () => {
       cy.get(".nhsuk-header__navigation-item:visible")
         .its("length")
-        .should("eq", navLinksSpecialty.length - 2);
+        .should("eq", navLinksSpecialty.length);
     });
   });
 
@@ -329,7 +331,14 @@ describe("Desktop Header with MFA set up", () => {
     it("should not display any unexpected links", () => {
       cy.get(".nhsuk-header__navigation-item:visible")
         .its("length")
-        .should("eq", navLinksLtftPilot.length - 2);
+        .should("eq", navLinksLtftPilot.length - 3);
+      cy.get(".nhsuk-header__navigation-item:hidden")
+        .its("length")
+        .should("eq", 3);
+      cy.get("#toggle-menu").should("exist").click();
+      cy.get(".nhsuk-header__navigation-item:visible")
+        .its("length")
+        .should("eq", navLinksLtftPilot.length);
     });
   });
 });

--- a/cypress/component/navigation/TSSHeader.cy.tsx
+++ b/cypress/component/navigation/TSSHeader.cy.tsx
@@ -58,24 +58,19 @@ describe("Header with MFA set up", () => {
   });
 
   it("should contain header logo", () => {
-    cy.get("[data-cy=headerLogo] > a")
+    cy.get(".nhsuk-header__service-logo")
       .should("exist")
       .should("have.attr", "href", "/");
-    cy.get("[data-cy=tssName]").should(
+    cy.get(".nhsuk-header__service-name").should(
       "contain.text",
-      "TIS Self-Service (Private Beta)"
-    );
-    cy.get("[data-cy=tssName] > a").should(
-      "have.attr",
-      "href",
-      "https://architecture.digital.nhs.uk/information/glossary"
+      "TIS Self-Service"
     );
   });
 
   it("should contain menu and sign out buttons", () => {
-    cy.get(`[data-cy=menuToggleBtn]`)
+    cy.get(".nhsuk-header__menu-toggle")
       .should("exist")
-      .should("contain.text", "Menu");
+      .should("contain.text", "More");
     cy.get("[data-cy=signOutBtn]")
       .should("exist")
       .should("contain.text", "Sign out");
@@ -102,7 +97,7 @@ describe("Header with MFA set up", () => {
     });
 
     it("should not display any unexpected links", () => {
-      cy.get('[data-cy="nav-link-wrapper"]:not([hidden])')
+      cy.get(".nhsuk-header__navigation-item")
         .its("length")
         .should("eq", navLinksBase.length);
     });
@@ -129,7 +124,7 @@ describe("Header with MFA set up", () => {
     });
 
     it("should not display any unexpected links", () => {
-      cy.get('[data-cy="nav-link-wrapper"]:not([hidden])')
+      cy.get(".nhsuk-header__navigation-item")
         .its("length")
         .should("eq", navLinksNonSpecialty.length);
     });
@@ -162,7 +157,7 @@ describe("Header with MFA set up", () => {
     });
 
     it("should not display any unexpected links", () => {
-      cy.get('[data-cy="nav-link-wrapper"]:not([hidden])')
+      cy.get(".nhsuk-header__navigation-item")
         .its("length")
         .should("eq", navLinksSpecialty.length);
     });
@@ -195,7 +190,7 @@ describe("Header with MFA set up", () => {
     });
 
     it("should not display any unexpected links", () => {
-      cy.get('[data-cy="nav-link-wrapper"]:not([hidden])')
+      cy.get(".nhsuk-header__navigation-item")
         .its("length")
         .should("eq", navLinksLtftPilot.length);
     });
@@ -210,23 +205,23 @@ describe("Desktop Header with MFA set up", () => {
   });
 
   it("should contain header logo", () => {
-    cy.get("[data-cy=headerLogo] > a")
+    cy.get(".nhsuk-header__service-logo")
       .should("be.visible")
       .should("have.attr", "href", "/");
-    cy.get("[data-cy=tssName]").should("contain.text", "TIS Self-Service");
+    cy.get(".nhsuk-header__service-name").should(
+      "contain.text",
+      "TIS Self-Service"
+    );
   });
 
-  it("should contain top nav container", () => {
-    cy.get(".top-nav-container").should("be.visible");
-    cy.get('.top-nav-container > [data-cy="signOutBtn"]').should("be.visible");
-    cy.get('.top-nav-container > [data-cy="topNavSupport"]')
+  it("should contain account navigation", () => {
+    cy.get(".nhsuk-header__account").should("be.visible");
+    cy.get('[data-cy="profileLink"]')
       .should("be.visible")
-      .should("contain.text", "Support")
-      .should("have.attr", "href", "/support");
-    cy.get('.top-nav-container > [data-cy="topNavMfaSetup"]')
+      .should("have.attr", "href", "/profile");
+    cy.get('[data-cy="signOutBtn"]')
       .should("be.visible")
-      .should("contain.text", "MFA set-up")
-      .should("have.attr", "href", "/mfa");
+      .should("contain.text", "Sign out");
   });
 
   describe("When all features disabled", () => {
@@ -241,7 +236,7 @@ describe("Desktop Header with MFA set up", () => {
     });
 
     it("should not display any unexpected links", () => {
-      cy.get('[data-cy="nav-link-wrapper"]:visible').should("not.exist");
+      cy.get(".nhsuk-header__navigation-item:visible").should("not.exist");
     });
   });
 
@@ -266,7 +261,7 @@ describe("Desktop Header with MFA set up", () => {
     });
 
     it("should not display any unexpected links", () => {
-      cy.get('[data-cy="nav-link-wrapper"]:visible')
+      cy.get(".nhsuk-header__navigation-item:visible")
         .its("length")
         .should("eq", navLinksNonSpecialty.length - 2);
     });
@@ -299,7 +294,7 @@ describe("Desktop Header with MFA set up", () => {
     });
 
     it("should not display any unexpected links", () => {
-      cy.get('[data-cy="nav-link-wrapper"]:visible')
+      cy.get(".nhsuk-header__navigation-item:visible")
         .its("length")
         .should("eq", navLinksSpecialty.length - 2);
     });
@@ -332,7 +327,7 @@ describe("Desktop Header with MFA set up", () => {
     });
 
     it("should not display any unexpected links", () => {
-      cy.get('[data-cy="nav-link-wrapper"]:visible')
+      cy.get(".nhsuk-header__navigation-item:visible")
         .its("length")
         .should("eq", navLinksLtftPilot.length - 2);
     });

--- a/cypress/component/notifications/NotificationsTable.cy.tsx
+++ b/cypress/component/notifications/NotificationsTable.cy.tsx
@@ -115,7 +115,10 @@ describe("NotificationsTable with In-app notifications data", () => {
     cy.get('[data-cy="emailBtn"]').should("exist").should("not.be.disabled");
     cy.get('[data-cy="inAppBtn"]').should("exist").should("be.disabled");
     cy.get("#unreadCheck").should("exist").should("not.be.checked");
-    cy.get('[data-cy="checkboxLabel-Show UNREAD status only"]').should("exist");
+    cy.get('label[for="unreadCheck"]').should(
+      "include.text",
+      "Show UNREAD status only"
+    );
 
     // table columns
     cy.get(`[data-cy=notificationsTable]`).should("exist");
@@ -212,7 +215,10 @@ describe("NotificationsTable with Email notifications data", () => {
     cy.get('[data-cy="emailBtn"]').should("exist").should("be.disabled");
     cy.get('[data-cy="inAppBtn"]').should("exist").should("not.be.disabled");
     cy.get("#failedCheck").should("exist").should("not.be.checked");
-    cy.get('[data-cy="checkboxLabel-Show FAILED status only"]').should("exist");
+    cy.get('label[for="failedCheck"]').should(
+      "include.text",
+      "Show FAILED status only"
+    );
 
     // table columns
     cy.get('[data-cy="notificationsTable-status"]')

--- a/cypress/component/placements/Placements.cy.tsx
+++ b/cypress/component/placements/Placements.cy.tsx
@@ -17,7 +17,6 @@ import {
   mockPlacementNoSubSpecialtyPostNotAllows
 } from "../../../mock-data/trainee-profile";
 import history from "../../../components/navigation/history";
-import React from "react";
 import { MFAType, updatedPreferredMfa } from "../../../redux/slices/userSlice";
 import {
   updatedTraineeProfileData,
@@ -221,9 +220,8 @@ describe("Placements with MFA set up", () => {
   it("should show alternative text when no panel data available", () => {
     mountPlacementsWithMockData([], "SMS", "succeeded");
     cy.get('[data-cy="upcomingExpand"]').click();
-    cy.get(
-      '[data-cy="upcomingExpand"] > .nhsuk-details__text > .nhsuk-grid-row > .nhsuk-card > [data-cy="notAssignedplacements"]'
-    )
+    cy.get('[data-cy="upcomingExpand"]')
+      .find('[data-cy="notAssignedplacements"]')
       .should("exist")
       .should("contain.text", "You are not assigned to any placements");
   });

--- a/cypress/component/programmes/Programmes.cy.tsx
+++ b/cypress/component/programmes/Programmes.cy.tsx
@@ -100,6 +100,46 @@ describe("Programmes with MFA set up", () => {
     };
     return updatedProgrammeMemberships;
   };
+  it("should display context menu links when there are 2 or more current programmes", () => {
+    const updatedProgrammeMemberships = createUpdatedProgrammeMemberships(1);
+    mountProgrammesWithMockData(
+      "SMS",
+      "succeeded",
+      undefined,
+      updatedProgrammeMemberships
+    );
+    cy.get('[data-cy="currentExpand"]').click();
+    cy.get('[data-cy="programmeContents"]')
+      .should("exist")
+      .and("contain.text", "Cardiology")
+      .and("contain.text", "General Practice");
+
+    cy.contains('[data-cy="programmeContents"] a', "Cardiology").should(
+      "have.attr",
+      "href",
+      "#panel-cardiology"
+    );
+
+    cy.contains('[data-cy="programmeContents"] a', "General Practice").should(
+      "have.attr",
+      "href",
+      "#panel-general practice"
+    );
+  });
+
+  it("should'nt display content menu links when there are 1 or less current programmes", () => {
+    const updatedProgrammeMemberships = createUpdatedProgrammeMemberships(
+      1
+    ).slice(0, 1);
+    mountProgrammesWithMockData(
+      "SMS",
+      "succeeded",
+      undefined,
+      updatedProgrammeMemberships
+    );
+    cy.get('[data-cy="currentExpand"]').click();
+    cy.get('[data-cy="programmeContents"]').should("not.exist");
+  });
   it("should display current Programme but no Onboarding Tracker link when start date is not within a year", () => {
     const updatedProgrammeMemberships = createUpdatedProgrammeMemberships(1);
     mountProgrammesWithMockData(

--- a/cypress/component/programmes/Programmes.cy.tsx
+++ b/cypress/component/programmes/Programmes.cy.tsx
@@ -18,7 +18,6 @@ import {
   mockUserFeaturesSpecialty
 } from "../../../mock-data/trainee-profile";
 import history from "../../../components/navigation/history";
-import React from "react";
 import {
   MFAType,
   updatedPreferredMfa,
@@ -239,15 +238,14 @@ describe("Programmes with MFA set up", () => {
       "include.text",
       "Onboarding Tracker"
     );
-    cy.get(
-      '[data-cy="currentExpand"] > .nhsuk-details__text > .nhsuk-grid-row > .nhsuk-grid-column-one-half > .nhsuk-card > .nhsuk-summary-list > :nth-child(2) > .nhsuk-summary-list__value > p > a'
-    )
+    cy.get('[data-cy="currentExpand"]')
+      .find(".nhsuk-summary-list")
+      .contains("a", "Track your onboarding journey for this programme")
       .should(
         "have.attr",
         "href",
         "/programmes/7ab1aae3-83c2-4bb6-b1f3-99146e79b362/onboarding-tracker"
-      )
-      .and("include.text", "Track your onboarding journey for this programme");
+      );
   });
 
   it("should show alternative text when no Programme/ panel data available", () => {

--- a/cypress/e2e/formr-a/FormRA.spec.ts
+++ b/cypress/e2e/formr-a/FormRA.spec.ts
@@ -20,9 +20,9 @@ describe("Form R Part A - Draft form", () => {
       "contain.text",
       "Part 1 of 3 - Personal Details"
     );
-    cy.get(
-      '[data-cy="WarningCallout-formAImportantNotice-label"] > span'
-    ).contains("Important");
+    cy.get('[data-cy="WarningCallout-formAImportantNotice-label"]').contains(
+      "Important"
+    );
     cy.get('[data-cy="dataSourceSummary"]').should("exist").click();
     const immigrationTxt = "Refugee in the UK";
     cy.get('[data-cy="autosaveStatusMsg"]')

--- a/cypress/e2e/formr-b/FormRB.spec.ts
+++ b/cypress/e2e/formr-b/FormRB.spec.ts
@@ -22,7 +22,7 @@ describe("Form R (Part B) - Draft form deletion, autosave, start over", () => {
 
     cy.log("No autosave if no changes made");
     cy.get('[data-cy="homeLink"]').should("exist").click();
-    cy.get('[data-cy="menuToggleBtn"]').click();
+    cy.get(".nhsuk-header__menu-toggle").click();
     cy.get('[data-cy="Form R (B)"]').click();
     cy.get('[data-cy="Submit new form"]').scrollIntoView().click();
     cy.checkForFormLinkerAndComplete();
@@ -42,9 +42,9 @@ describe("Form R (Part B) - Draft form deletion, autosave, start over", () => {
       "Autosave status: Success"
     );
     cy.get('[data-cy="Support"]').scrollIntoView().click();
-    cy.get(".nhsuk-header__navigation-close > .nhsuk-icon").click();
+    cy.get(".nhsuk-header__menu-toggle").click();
     cy.get(".nhsuk-fieldset__heading").contains("Support");
-    cy.get('[data-cy="menuToggleBtn"]').click();
+    cy.get(".nhsuk-header__menu-toggle").click();
     cy.get('[data-cy="Form R (B)"]').should("exist").click();
     cy.checkElement("btn-Edit saved draft form").click();
     cy.log(

--- a/cypress/e2e/navbar/Navbar.spec.ts
+++ b/cypress/e2e/navbar/Navbar.spec.ts
@@ -23,17 +23,10 @@ describe("Desktop/ tablet header", () => {
         .should("exist")
         .contains(/Support/);
       cy.get(".nhsuk-header__navigation-link").should("exist").contains(/MFA/);
-      cy.get(".nhsuk-button")
+      cy.get('[data-cy="signOutBtn"]')
         .should("exist")
         .contains(/Sign out/);
-      if (size === mobileView) {
-        cy.get(".nhsuk-header__menu-toggle").should("exist").click();
-        cy.get('[data-cy="signOutBtn"]');
-      } else {
-        cy.get(
-          '.top-nav-container > .top-nav-container > [data-cy="signOutBtn"]'
-        ).click();
-      }
+      cy.get('[data-cy="signOutBtn"]').click();
     });
   });
 });

--- a/cypress/e2e/support/Support.spec.ts
+++ b/cypress/e2e/support/Support.spec.ts
@@ -4,7 +4,7 @@ describe("Support", () => {
   });
 
   it("should contact support", () => {
-    cy.get('[data-cy="menuToggleBtn"]').should("exist").click();
+    cy.get(".nhsuk-header__menu-toggle").should("exist").click();
     cy.get('[data-cy="Support"]').first().should("exist").click(); // Note: the first is chosen becuase card also has the same data-cy (oops)
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -167,12 +167,9 @@ Cypress.Commands.add("checkAndFillFormASection1", () => {
   // Header section
 
   const containedEls = [
+    ['[data-cy="WarningCallout-formAImportantNotice-label"]', "Important"],
     [
-      '[data-cy="WarningCallout-formAImportantNotice-label"] > span',
-      "Important"
-    ],
-    [
-      ".nhsuk-warning-callout > :nth-child(2)",
+      ".nhsuk-card--warning .nhsuk-card__content > :nth-child(2)",
       "This form has been pre-populated using the information available against your records"
     ],
     [
@@ -285,7 +282,7 @@ Cypress.Commands.add("checkAndFillFormASection1", () => {
 
 Cypress.Commands.add("checkAndFillFormASection2", () => {
   // Page 2
-  cy.get('[data-cy="WarningCallout-formAImportantNotice-label"] > span').should(
+  cy.get('[data-cy="WarningCallout-formAImportantNotice-label"]').should(
     "not.exist"
   );
 
@@ -356,7 +353,7 @@ Cypress.Commands.add("checkAndFillFormASection3", () => {
     "Part 3 of 3 - Programme Details"
   );
 
-  cy.get('[data-cy="WarningCallout-formAImportantNotice-label"] > span').should(
+  cy.get('[data-cy="WarningCallout-formAImportantNotice-label"]').should(
     "not.exist"
   );
 
@@ -411,7 +408,7 @@ Cypress.Commands.add("checkAndFillSection1", () => {
     "Personal Details"
   );
   cy.checkElement("WarningCallout-formBImportantNotice-label");
-  cy.get(".nhsuk-warning-callout > :nth-child(2)").should(
+  cy.get(".nhsuk-card--warning .nhsuk-card__content > :nth-child(2)").should(
     "include.text",
     "This form has been pre-populated using the information available against your records"
   );

--- a/cypress/support/component-index.html
+++ b/cypress/support/component-index.html
@@ -7,7 +7,7 @@
     <title>Components App</title>
     <div id="__next_css__DO_NOT_USE__"></div>
   </head>
-  <body>
+  <body class="nhsuk-frontend-supported">
     <div data-cy-root></div>
   </body>
 </html>

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -16,6 +16,7 @@
 // Import commands.js using ES2015 syntax:
 import "./commands";
 import "@cypress/code-coverage/support";
+import "react-phone-number-input/style.css";
 import "../../styles/globals.scss";
 
 // Alternatively you can use CommonJS syntax:

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,2 +1,41 @@
 import "@testing-library/jest-dom";
 import "@testing-library/jest-dom/extend-expect";
+
+jest.mock("nhsuk-react-components", () => {
+  const React = require("react");
+  const actual = jest.requireActual("nhsuk-react-components");
+
+  const Button = React.forwardRef(
+    (
+      {
+        as,
+        asElement,
+        className,
+        login,
+        preventDoubleClick,
+        reverse,
+        secondary,
+        secondarySolid,
+        small,
+        warning,
+        ...props
+      },
+      ref
+    ) => {
+      const Element = asElement ?? (as === "a" ? "a" : "button");
+
+      return React.createElement(Element, {
+        ...props,
+        className,
+        ref
+      });
+    }
+  );
+
+  Button.displayName = "MockNhsukButton";
+
+  return {
+    ...actual,
+    Button
+  };
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.146.3",
+  "version": "0.146.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.146.3",
+      "version": "0.146.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.11.1",
         "@cypress/code-coverage": "^3.12.1",
@@ -58,8 +58,8 @@
         "lucide-react": "^0.555.0",
         "material-ui-confirm": "^3.0.9",
         "next": "^13.0.7",
-        "nhsuk-frontend": "^6.1.2",
-        "nhsuk-react-components": "^2.2.2",
+        "nhsuk-frontend": "^10.5.2",
+        "nhsuk-react-components": "^6.0.1",
         "nyc": "^15.1.0",
         "prettier": "^2.8.1",
         "qrcode.react": "^3.1.0",
@@ -81,7 +81,7 @@
         "sass": "^1.57.1",
         "stylelint": "^14.16.0",
         "stylelint-prettier": "^2.0.0",
-        "typescript": "^4.9.4",
+        "typescript": "^5.9.3",
         "yup": "^0.32.11"
       }
     },
@@ -15423,23 +15423,49 @@
       }
     },
     "node_modules/nhsuk-frontend": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-6.2.0.tgz",
-      "integrity": "sha512-02eF0+LkqjxZy7wB2iQSkssoA6LgSey4r+fPgj20KWqDUVEpy2Zi4bmRUNdda5oFsJR6PHtr/G+9Rn0dBgsOMw==",
-      "license": "MIT"
-    },
-    "node_modules/nhsuk-react-components": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nhsuk-react-components/-/nhsuk-react-components-2.2.2.tgz",
-      "integrity": "sha512-jShzbw7Wi6Vb+KxFuBF9fWPHw9ZUxxUVaAWGsFsRrdc6+yBiA+q5x/DwxnGytq7+UFpN5on+kd8Q1jnrOkBn3A==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.5.2.tgz",
+      "integrity": "sha512-lTOmzSDJkEn8uhuEuj3NKAW5MYuG/5tqMRsp15An2oLKlpGEoEAoREp+tHYJ7DLOPDRp9Z/zmp6/pLea75ae1g==",
       "license": "MIT",
-      "dependencies": {
-        "classnames": "^2.2.6"
+      "engines": {
+        "node": "^20.9.0 || ^22.11.0 || >= 24.11.0"
       },
       "peerDependencies": {
-        "nhsuk-frontend": ">=4.0.0",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "@prettier/sync": "^0.6.0",
+        "highlight.js": "^11.0.0",
+        "nunjucks": "^3.0.0",
+        "outdent": "^0.8.0",
+        "slug": "^9.0.0 || ^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prettier/sync": {
+          "optional": true
+        },
+        "highlight.js": {
+          "optional": true
+        },
+        "nunjucks": {
+          "optional": true
+        },
+        "outdent": {
+          "optional": true
+        },
+        "slug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nhsuk-react-components": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/nhsuk-react-components/-/nhsuk-react-components-6.0.1.tgz",
+      "integrity": "sha512-xd1PuSV4DAMTluFhRPUlyeyUy55BBCVj71LPS8/Mp6VkgkLnflQm3Q5CC2vTH21T2ykb0uZtfAQ74GkpcgqBoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "classnames": ">=2.5.0",
+        "nhsuk-frontend": ">=10.3.0 <11.0.0",
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "tslib": ">=2.8.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -19216,16 +19242,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ulid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "@types/react-router-dom": "^5.3.3",
         "@types/react-test-renderer": "^18.0.2",
         "aws-amplify": "^6.14.4",
-        "babel-plugin-istanbul": "^6.1.1",
         "browser-update": "^3.3.44",
         "cypress": "^14.5.4",
         "cypress-localstorage-commands": "^2.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.146.1",
+  "version": "0.146.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.146.1",
+      "version": "0.146.4",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.11.1",
         "@cypress/code-coverage": "^3.12.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.146.0",
+  "version": "0.146.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.146.0",
+      "version": "0.146.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.11.1",
         "@cypress/code-coverage": "^3.12.1",
@@ -58,8 +58,8 @@
         "lucide-react": "^0.555.0",
         "material-ui-confirm": "^3.0.9",
         "next": "^13.0.7",
-        "nhsuk-frontend": "^6.1.2",
-        "nhsuk-react-components": "^2.2.2",
+        "nhsuk-frontend": "^10.5.2",
+        "nhsuk-react-components": "^6.0.1",
         "nyc": "^15.1.0",
         "prettier": "^2.8.1",
         "qrcode.react": "^3.1.0",
@@ -81,7 +81,7 @@
         "sass": "^1.57.1",
         "stylelint": "^14.16.0",
         "stylelint-prettier": "^2.0.0",
-        "typescript": "^4.9.4",
+        "typescript": "^5.9.3",
         "yup": "^0.32.11"
       }
     },
@@ -15426,23 +15426,49 @@
       }
     },
     "node_modules/nhsuk-frontend": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-6.2.0.tgz",
-      "integrity": "sha512-02eF0+LkqjxZy7wB2iQSkssoA6LgSey4r+fPgj20KWqDUVEpy2Zi4bmRUNdda5oFsJR6PHtr/G+9Rn0dBgsOMw==",
-      "license": "MIT"
-    },
-    "node_modules/nhsuk-react-components": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nhsuk-react-components/-/nhsuk-react-components-2.2.2.tgz",
-      "integrity": "sha512-jShzbw7Wi6Vb+KxFuBF9fWPHw9ZUxxUVaAWGsFsRrdc6+yBiA+q5x/DwxnGytq7+UFpN5on+kd8Q1jnrOkBn3A==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.5.2.tgz",
+      "integrity": "sha512-lTOmzSDJkEn8uhuEuj3NKAW5MYuG/5tqMRsp15An2oLKlpGEoEAoREp+tHYJ7DLOPDRp9Z/zmp6/pLea75ae1g==",
       "license": "MIT",
-      "dependencies": {
-        "classnames": "^2.2.6"
+      "engines": {
+        "node": "^20.9.0 || ^22.11.0 || >= 24.11.0"
       },
       "peerDependencies": {
-        "nhsuk-frontend": ">=4.0.0",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "@prettier/sync": "^0.6.0",
+        "highlight.js": "^11.0.0",
+        "nunjucks": "^3.0.0",
+        "outdent": "^0.8.0",
+        "slug": "^9.0.0 || ^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prettier/sync": {
+          "optional": true
+        },
+        "highlight.js": {
+          "optional": true
+        },
+        "nunjucks": {
+          "optional": true
+        },
+        "outdent": {
+          "optional": true
+        },
+        "slug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nhsuk-react-components": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/nhsuk-react-components/-/nhsuk-react-components-6.0.1.tgz",
+      "integrity": "sha512-xd1PuSV4DAMTluFhRPUlyeyUy55BBCVj71LPS8/Mp6VkgkLnflQm3Q5CC2vTH21T2ykb0uZtfAQ74GkpcgqBoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "classnames": ">=2.5.0",
+        "nhsuk-frontend": ">=10.3.0 <11.0.0",
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "tslib": ">=2.8.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -19219,16 +19245,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ulid": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/react-test-renderer": "^18.0.2",
     "aws-amplify": "^6.14.4",
-    "babel-plugin-istanbul": "^6.1.1",
     "browser-update": "^3.3.44",
     "cypress": "^14.5.4",
     "cypress-localstorage-commands": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.146.3",
+  "version": "0.146.4",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^6.11.1",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "lucide-react": "^0.555.0",
     "material-ui-confirm": "^3.0.9",
     "next": "^13.0.7",
-    "nhsuk-frontend": "^6.1.2",
-    "nhsuk-react-components": "^2.2.2",
+    "nhsuk-frontend": "^10.5.2",
+    "nhsuk-react-components": "^6.0.1",
     "nyc": "^15.1.0",
     "prettier": "^2.8.1",
     "qrcode.react": "^3.1.0",
@@ -76,7 +76,7 @@
     "sass": "^1.57.1",
     "stylelint": "^14.16.0",
     "stylelint-prettier": "^2.0.0",
-    "typescript": "^4.9.4",
+    "typescript": "^5.9.3",
     "yup": "^0.32.11"
   },
   "scripts": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,3 +1,4 @@
+import "react-phone-number-input/style.css";
 import "../styles/globals.scss";
 import type { AppProps } from "next/app";
 import React from "react";

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -13,7 +13,7 @@ export default function Document() {
         <meta name="robots" content="noindex,nofollow" />
         <link rel="shortcut icon" href="/favicon.ico" />
       </Head>
-      <body>
+      <body className="nhsuk-frontend-supported">
         <Main />
         <NextScript />
       </body>

--- a/pages/sw-foundation.tsx
+++ b/pages/sw-foundation.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import Head from "next/head";
 import { Footer, Header } from "nhsuk-react-components";
-import { NHSEnglandLogoWhite } from "../public/NHSEnglandLogoWhite";
 
 export default function SwFoundation() {
   const [isMounted, setIsMounted] = useState(false);
@@ -17,22 +16,12 @@ export default function SwFoundation() {
       <Head>
         <title>South West: Contacts for Foundation Doctors</title>
       </Head>
-      <Header>
-        <Header.Container>
-          <div className="nhsuk-header__logo" data-cy="headerLogo">
-            <a
-              href="/"
-              aria-label="TSS home page"
-              className="nhsuk-header__navigation-link header-logo-link"
-            >
-              <NHSEnglandLogoWhite />
-            </a>
-          </div>
-        </Header.Container>
-        <div className="nhsuk-width-container">
-          <span className="tss-name">TIS Self-Service</span>
-        </div>
-      </Header>
+      <Header
+        service={{
+          href: "/",
+          text: "TIS Self-Service"
+        }}
+      />
       <main className="nhsuk-width-container nhsuk-u-margin-top-5">
         <h1 className="nhsuk-heading-m" data-cy="tssOverview">
           South West: Contacts for Foundation Doctors

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,7 +1,5 @@
 @use "nhsuk-frontend" as *;
 
-@import "react-phone-number-input/style.css";
-
 $nhsFont: “Frutiger W01”, Arial, sans-serif;
 $nhsBlue: #005eb8;
 $nhsSuccess: #006400;
@@ -1135,29 +1133,6 @@ html:has(dialog[data-cy="formLinkerModal"][open]) {
 .checkbox-hint {
   margin-left: 3rem;
   padding-left: 0.25rem;
-}
-
-.nhsuk-checkboxes--small {
-  .nhsuk-checkboxes__input {
-    width: 28px;
-    height: 28px;
-  }
-
-  .nhsuk-checkboxes__label {
-    padding: 0;
-
-    &::before {
-      width: 28px;
-      height: 28px;
-    }
-
-    &::after {
-      width: 16px;
-      height: 9px;
-      top: 8px;
-      left: 6px;
-    }
-  }
 }
 
 time {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -196,6 +196,10 @@ body {
   background: none;
   border: none;
   cursor: pointer;
+
+  .nhsuk-icon--cross {
+    fill: #005eb8;
+  }
 }
 
 .recruit-link {
@@ -529,10 +533,6 @@ ol[type="a"] {
   box-sizing: border-box;
   border: solid #ffffff33 2px;
   padding: 16px;
-}
-
-.list-panel-header {
-  margin-bottom: 0;
 }
 
 .internal-link {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,5 +1,5 @@
-@import "~nhsuk-frontend/packages/nhsuk";
-@import "~nhsuk-frontend/packages/core/all";
+@use "nhsuk-frontend" as *;
+
 @import "react-phone-number-input/style.css";
 
 $nhsFont: “Frutiger W01”, Arial, sans-serif;
@@ -232,36 +232,6 @@ button:disabled {
 
 .nhsuk-header__navigation-list {
   justify-content: flex-start;
-}
-
-.nhsuk-header__navigation-link {
-  transition: all 200ms ease-in-out;
-  &.active,
-  &:hover,
-  &:focus,
-  &:focus:visited,
-  &:active,
-  &:active:visited {
-    background-color: darken(#005eb8, 7%) !important;
-    color: #fff;
-  }
-}
-
-.header-logo-link {
-  padding: 0 !important;
-}
-
-.nhsuk-header__menu-toggle {
-  &.closeMenu {
-    text-indent: -9999px;
-    line-height: 0; /* Collapse the original line */
-    &::after {
-      content: "Hide";
-      text-indent: 0;
-      display: block;
-      line-height: 24px; /* New content takes up original line height */
-    }
-  }
 }
 
 .hide-label {
@@ -595,32 +565,6 @@ ol[type="a"] {
   }
 }
 
-// nav header
-.tss-beta-link {
-  color: #fff !important; // needed to override NHSUK default
-  font-size: 1rem;
-}
-
-.tss-beta-link:focus:visited {
-  color: black !important;
-}
-
-.top-nav-container {
-  display: flex;
-  justify-content: space-between;
-  max-height: 3rem;
-}
-
-.top-nav-container a {
-  cursor: pointer;
-}
-
-@media (max-width: 989px) {
-  .top-nav-container {
-    display: none;
-  }
-}
-
 @media (min-width: 990px) {
   .mobile-only-nav {
     display: none;
@@ -698,40 +642,7 @@ ol[type="a"] {
   padding-top: 0.5em;
 }
 
-// ---- Notifications Icon ----
-
-.notification-btn {
-  margin: 0.3rem 0 0 1rem;
-  position: "relative";
-  padding: 0 1rem;
-  box-shadow: 0 1px 0 transparent;
-  background-color: transparent;
-  &:hover,
-  &:focus {
-    background-color: darken(#005eb8, 7%) !important;
-  }
-}
-
-.notification-btn:hover .notification-badge {
-  background-color: darken(#ed8b00, 7%);
-}
-
-.notification-badge {
-  position: absolute;
-  bottom: 45%;
-  left: 50%;
-  background-color: #ed8b00;
-  color: white;
-  min-height: 30%;
-  min-width: 30%;
-  border-radius: 16px;
-  padding: 2% 10%;
-  font-size: 10px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
+// Notifications table
 .notification-type-btn {
   margin: 0.3rem 1rem 1rem 0;
   padding: 0 1rem;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "es2021"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
Upgrade nhsuk-frontend library (v10) and nhsuk-react-components (v6) to LTS

This work includes
- upgrade TS from v4.9 to 5.9 for compatibility with the typings shipped by nhsuk-react-components v6.
- upgrade tsconfig.json to match TS: moduleResolution changed from node to bundler — the TS 5 resolution mode that mirrors how Next.js resolves packages, which will correctly resolve the exports-map entry points used by nhsuk-frontend v10 and nhsuk-react-components v6. Also, raise target from es5 to es2017; all browsers we support handle ES2017 natively, so no need to transpile down to ES5 (output is smaller and closer to source).
- replacing all deprecated or changed components to use the latest
- changing and replacing to be as close to the current version as possible with sensible and peer-reviewed changes where appropriate
- refactors current components to semantic HTML where trying to force library components to be the same as current involved too much specific CSS targeting

Also (bit of boy-scouting), remove custom Babel compiler config for prod (it only existed to apply the istanbul coverage plugin - think I had some grand ideas about including e2e test stats in code coverage reports!) and use Next JS's built-in (faster and actively maintained) SWC compiler instead.

TIS21-7717
TIS21-7950
TIS21-7951