### PR TITLE
fix: Update formB previousRevalDate validation

### DIFF
--- a/components/forms/form-builder/form-r/part-b/formBValidationSchema.ts
+++ b/components/forms/form-builder/form-r/part-b/formBValidationSchema.ts
@@ -168,6 +168,9 @@ export const formBValidationSchemaDefaultJson = {
       "prevRevalDate",
       " please choose a previous Revalidation date from the past",
       value => DateUtilities.IsPastDate(value)
+    )
+    .test("prevRevalDateMin", "The date cannot be before 01/01/1970", value =>
+      DateUtilities.IsNotBeforeUnixEpoch(value)
     ),
   dualSpecialty: yup.string(),
 

--- a/components/main/GlobalAlert.tsx
+++ b/components/main/GlobalAlert.tsx
@@ -109,6 +109,7 @@ function RecruitAlert({ onDismiss }: Readonly<{ onDismiss: () => void }>) {
         </ActionLink>
       </div>
       <button
+        type="button"
         className="recruit-alert-close"
         aria-label="Dismiss recruitment alert"
         title="Dismiss recruitment alert"

--- a/components/notifications/EmailsBtn.tsx
+++ b/components/notifications/EmailsBtn.tsx
@@ -10,6 +10,7 @@ export const EmailsBtn = () => {
   };
   return (
     <button
+      type="button"
       data-cy="emailBtn"
       data-tooltip-id="EmailCount"
       onClick={handleBtnClick}

--- a/components/notifications/NotificationsBtn.tsx
+++ b/components/notifications/NotificationsBtn.tsx
@@ -15,6 +15,7 @@ export const NotificationsBtn = ({
   };
   return (
     <button
+      type="button"
       data-cy="notificationBtn"
       data-tooltip-id="NotificationsCount"
       onClick={handleBtnClick}

--- a/cypress/component/forms/formr-part-b/FormB.cy.tsx
+++ b/cypress/component/forms/formr-part-b/FormB.cy.tsx
@@ -115,6 +115,35 @@ describe("FormRForm (Part B) - new form /new/create", () => {
     cy.get('[data-cy="forename-input"]').should("contain.value", "Billy");
     cy.get('[data-cy="surname-input"]').should("contain.value", "Ocean");
   });
+
+  it("allows a null prevRevalDate but errors when the date is before the UNIX epoch", () => {
+    store.dispatch(updatedFormB(draftFormRPartBWithNullCareerBreak));
+
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/formr-b/6e644647434834getee/create"]}>
+          <Route path="/formr-b/:id/create">
+            <FormRForm formType="B" />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    cy.get('[data-cy="prevRevalDate-input"]').should(
+      "contain.value",
+      "2020-04-22"
+    );
+    cy.get("#prevRevalDate-error").should("not.exist");
+
+    cy.clearAndType('[data-cy="prevRevalDate-input"]', "1969-12-31");
+    cy.get("#prevRevalDate-error").should(
+      "have.text",
+      "Error: The date cannot be before 01/01/1970"
+    );
+
+    cy.get('[data-cy="prevRevalDate-input"]').clear();
+    cy.get("#prevRevalDate-error").should("not.exist");
+  });
 });
 
 describe("FormRForm (Part A) - GMC/GDC conditional checkboxes for Public Health Non-Medic", () => {
@@ -133,29 +162,29 @@ describe("FormRForm (Part A) - GMC/GDC conditional checkboxes for Public Health 
         }
       })
     );
-  mount(
-        <Provider store={store}>
-          <MemoryRouter initialEntries={["/formr-a/new/create"]}>
-            <FormRForm formType="B" />
-          </MemoryRouter>
-        </Provider>
-      );
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/formr-a/new/create"]}>
+          <FormRForm formType="B" />
+        </MemoryRouter>
+      </Provider>
+    );
 
-      cy.get("dialog").should("be.visible");
-      cy.get('[data-cy="isArcp0"]').should("exist").click();
-      cy.get('button[data-cy="form-linker-submit-btn"]').should("be.disabled");
-      cy.clickSelect('[data-cy="programmeMembershipId"]');
+    cy.get("dialog").should("be.visible");
+    cy.get('[data-cy="isArcp0"]').should("exist").click();
+    cy.get('button[data-cy="form-linker-submit-btn"]').should("be.disabled");
+    cy.clickSelect('[data-cy="programmeMembershipId"]');
 
-      cy.get('button[data-cy="form-linker-submit-btn"]')
-        .should("not.be.disabled")
-        .click();
+    cy.get('button[data-cy="form-linker-submit-btn"]')
+      .should("not.be.disabled")
+      .click();
 
-      cy.get('[data-cy="progress-header"] > h3').should(
-        "contain.text",
-        "Part 1 of 10 - Personal Details"
-      );
-    });
-    
+    cy.get('[data-cy="progress-header"] > h3').should(
+      "contain.text",
+      "Part 1 of 10 - Personal Details"
+    );
+  });
+
   it("shows check GMC/GDC conditional checkboxes for Public Health Non-Medic", () => {
     cy.checkAndFillPhGmcGdc();
   });

--- a/cypress/e2e/formr-b/FormRB.spec.ts
+++ b/cypress/e2e/formr-b/FormRB.spec.ts
@@ -41,9 +41,6 @@ describe("Form R (Part B) - Draft form deletion, autosave, start over", () => {
       "include.text",
       "Autosave status: Success"
     );
-    cy.get('[data-cy="Support"]').scrollIntoView().click();
-    cy.get(".nhsuk-header__menu-toggle").click();
-    cy.get(".nhsuk-fieldset__heading").contains("Support");
     cy.get(".nhsuk-header__menu-toggle").click();
     cy.get('[data-cy="Form R (B)"]').should("exist").click();
     cy.checkElement("btn-Edit saved draft form").click();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.146.5",
+  "version": "0.146.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.146.5",
+      "version": "0.146.6",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.11.1",
         "@cypress/code-coverage": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.146.5",
+  "version": "0.146.6",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^6.11.1",

--- a/utilities/DateUtilities.ts
+++ b/utilities/DateUtilities.ts
@@ -111,6 +111,16 @@ export class DateUtilities {
     return true;
   }
 
+  public static IsNotBeforeUnixEpoch(value: DateType | undefined): boolean {
+    if (value) {
+      const dayDate = day(value);
+      return (
+        dayDate.isValid() && dayDate.isSameOrAfter(day("1970-01-01"), "day")
+      );
+    }
+    return true;
+  }
+
   public static IsPastDate(value: DateType | undefined): boolean {
     if (value) {
       const dayDate = day(value);

--- a/utilities/__test__/DateUtilities.test.ts
+++ b/utilities/__test__/DateUtilities.test.ts
@@ -50,6 +50,22 @@ describe("DateUtilities", () => {
     expect(DateUtilities.IsLegalAge(belowLegalAge)).toEqual(false);
   });
 
+  it("IsNotBeforeUnixEpoch should return true if date is null", () => {
+    expect(DateUtilities.IsNotBeforeUnixEpoch(null)).toEqual(true);
+  });
+
+  it("IsNotBeforeUnixEpoch should return true if date is the epoch date", () => {
+    expect(DateUtilities.IsNotBeforeUnixEpoch("1970-01-01")).toEqual(true);
+  });
+
+  it("IsNotBeforeUnixEpoch should return true if date is after the epoch date", () => {
+    expect(DateUtilities.IsNotBeforeUnixEpoch("1970-01-02")).toEqual(true);
+  });
+
+  it("IsNotBeforeUnixEpoch should return false if date is before the epoch date", () => {
+    expect(DateUtilities.IsNotBeforeUnixEpoch("1969-12-31")).toEqual(false);
+  });
+
   it("IsPastDate should return true if date is null", () => {
     expect(DateUtilities.IsPastDate(null)).toEqual(true);
   });


### PR DESCRIPTION
... to ensure it is not before agreed Unix epoch.

(Note DateUtilities.ts has been updated to include a new method IsNotBeforeUnixEpoch, but might be best (in follow-up) to look at re-engineering the existing hardcoded IsInsideDateRange and checking for any more overlapping logic). 

fix: FormRB.spec.ts (carry-over from previous commit).

TIS21-8851