### PR TITLE
feat(ltft): rework Start date page

### DIFF
--- a/.babelrc.coverage
+++ b/.babelrc.coverage
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": ["istanbul"]
+}

--- a/.github/workflows/pr-analysis.yml
+++ b/.github/workflows/pr-analysis.yml
@@ -32,6 +32,15 @@ jobs:
       - name: Test & code coverage report (Jest and Cypress CT)
         run: npm run coverage
 
+      - name: Create coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: coverage-report
+          path: |
+            coverage
+            .nyc_output
+
       - name: Get modified files
         id: changed-files
         uses: Ana06/get-changed-files@v2.2.0

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ next-env.d.ts
 #json-server for mock api
 db.json
 db-*.json
+
+# generated on the fly by the coverage script from .babelrc.coverage; committing it would disable SWC for the production build
+.babelrc

--- a/components/common/ExpanderMsg.tsx
+++ b/components/common/ExpanderMsg.tsx
@@ -290,9 +290,12 @@ export const ExpanderMsg = ({
               funding.
             </li>
             <li>
-              <strong>Late Applications</strong> may be declined or delayed,
-              though exceptional circumstances (e.g. sudden disability,
-              significant life changes) are reviewed on a case-by-case basis.
+              <strong>
+                Applications giving less than 16 weeks&apos; notice
+              </strong>{" "}
+              may be declined or delayed, though exceptional circumstances (e.g.
+              sudden disability, significant life changes) are reviewed on a
+              case-by-case basis.
             </li>
             <li>
               <strong>Check with your region</strong> for any specific

--- a/components/common/PageGateModal.tsx
+++ b/components/common/PageGateModal.tsx
@@ -1,0 +1,52 @@
+import { Button, WarningCallout } from "nhsuk-react-components";
+import { Modal } from "./Modal";
+import { PageGate } from "../../utilities/pageGates";
+
+type PageGateModalProps = {
+  isOpen: boolean;
+  gate?: PageGate;
+  onProceed: () => void;
+  onSkip: () => void;
+  onCancel: () => void;
+};
+
+// Note: unlike typical ActionModal this has 3 outcomes (proceed / skip / stay put), so wrapped Modal directly instead of a Formik form.
+export function PageGateModal({
+  isOpen,
+  gate,
+  onProceed,
+  onSkip,
+  onCancel
+}: Readonly<PageGateModalProps>) {
+  if (!gate) return null;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onCancel}
+      cancelBtnText={gate.cancelBtnText}
+    >
+      <WarningCallout data-cy="pageGateWarning">
+        <WarningCallout.Heading visuallyHiddenText="" data-cy="pageGateLabel">
+          {gate.warningLabel}
+        </WarningCallout.Heading>
+        <p data-cy="pageGateText">{gate.warningText}</p>
+      </WarningCallout>
+      <Button type="button" data-cy="gateProceedBtn" onClick={onProceed}>
+        {gate.proceedBtnText}
+      </Button>
+      <Button
+        type="button"
+        secondary
+        data-cy="gateSkipBtn"
+        aria-describedby="gateSkipHint"
+        onClick={onSkip}
+      >
+        {gate.skipBtnText}
+      </Button>
+      <p className="nhsuk-hint" id="gateSkipHint" data-cy="gateSkipHint">
+        {gate.skipHint}
+      </p>
+    </Modal>
+  );
+}

--- a/components/forms/__test__/ltftValidationSchema.test.ts
+++ b/components/forms/__test__/ltftValidationSchema.test.ts
@@ -23,59 +23,59 @@ const baseValid = {
     mobileNumber: "01234567890",
     email: "jo@example.com"
   },
+  canGiveCompliantStartDate: false,
   startDate: beyond16w,
   altStartDate: null,
+  exceptionalReasons: "A valid exceptional reason",
+  exceptionalReasonsDate: within16w,
   skilledWorkerVisaHolder: false,
   supportingInformation: "info"
 };
 
-describe("ltftValidationSchema - altStartDate (optional)", () => {
+describe("ltftValidationSchema - exceptionalReasonsDate (mandatory when exceptional)", () => {
   beforeAll(() => {
     store.dispatch(updatedTraineeProfileData(mockTraineeProfile));
   });
 
-  it("accepts a form with no altStartDate when startDate is more than 16 weeks away", async () => {
-    await expect(
-      ltftValidationSchema.validate({ ...baseValid, startDate: beyond16w })
-    ).resolves.toBeTruthy();
+  it("rejects a missing exceptionalReasonsDate", async () => {
+    const { exceptionalReasonsDate, ...withoutDate } = baseValid;
+    await expect(ltftValidationSchema.validate(withoutDate)).rejects.toThrow(
+      /provide the date you would like this change to begin/
+    );
   });
 
-  it("accepts a late startDate with no altStartDate provided", async () => {
+  it("rejects an exceptionalReasonsDate in the past", async () => {
     await expect(
       ltftValidationSchema.validate({
         ...baseValid,
-        startDate: within16w,
-        altStartDate: null
+        exceptionalReasonsDate: dayjs().subtract(1, "day").format("YYYY-MM-DD")
+      })
+    ).rejects.toThrow(/cannot be before today/);
+  });
+
+  it("rejects an exceptionalReasonsDate 16 or more weeks in the future", async () => {
+    await expect(
+      ltftValidationSchema.validate({
+        ...baseValid,
+        exceptionalReasonsDate: beyond16w
+      })
+    ).rejects.toThrow(/less than 16 weeks from today/);
+  });
+
+  it("accepts an exceptionalReasonsDate today", async () => {
+    await expect(
+      ltftValidationSchema.validate({
+        ...baseValid,
+        exceptionalReasonsDate: dayjs().format("YYYY-MM-DD")
       })
     ).resolves.toBeTruthy();
   });
 
-  it("treats an empty string as cleared (no typeError)", async () => {
+  it("accepts an exceptionalReasonsDate within 16 weeks", async () => {
     await expect(
       ltftValidationSchema.validate({
         ...baseValid,
-        startDate: within16w,
-        altStartDate: ""
-      })
-    ).resolves.toBeTruthy();
-  });
-
-  it("rejects an altStartDate that is itself within 16 weeks", async () => {
-    await expect(
-      ltftValidationSchema.validate({
-        ...baseValid,
-        startDate: within16w,
-        altStartDate: dayjs().add(8, "week").format("YYYY-MM-DD")
-      })
-    ).rejects.toThrow(/at least 16 weeks from today/);
-  });
-
-  it("accepts an altStartDate that is at least 16 weeks away", async () => {
-    await expect(
-      ltftValidationSchema.validate({
-        ...baseValid,
-        startDate: within16w,
-        altStartDate: dayjs().add(20, "week").format("YYYY-MM-DD")
+        exceptionalReasonsDate: within16w
       })
     ).resolves.toBeTruthy();
   });

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -31,6 +31,8 @@ import { ExpanderMsg, ExpanderNameType } from "../../common/ExpanderMsg";
 import { FormFieldBuilder } from "./FormFieldBuilder";
 import { useFormContext } from "./FormContext";
 import { SaveAndExitButton } from "../SaveAndExitButton";
+import { getPageGate, PageGateName } from "../../../utilities/pageGates";
+import { PageGateModal } from "../../common/PageGateModal";
 
 export type FieldType =
   | "text"
@@ -87,6 +89,7 @@ type Page = {
   pageName: string;
   importantTxtName?: string;
   expanderLinkName?: string;
+  gatedIf?: PageGateName; // Note: warn (and offer to skip) before this page can be navigated to.
   sections: Section[];
 };
 type Section = {
@@ -140,6 +143,7 @@ export default function FormBuilder({
 }: Readonly<FormBuilderProps>) {
   const {
     formData,
+    setFormData,
     isFormDirty,
     setIsFormDirty,
     currentPageFields,
@@ -161,6 +165,7 @@ export default function FormBuilder({
   const [currentPage, setCurrentPage] = useState(initialPageValue);
   const [formErrors, setFormErrors] = useState<any>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [pendingGatePage, setPendingGatePage] = useState<number | null>(null);
   const canEditStatusLtft = useAppSelector(state => state.ltft.canEdit);
   const location = useLocation<LocationState>();
 
@@ -185,6 +190,37 @@ export default function FormBuilder({
     }
   }, [formData, currentPageFields, validationSchema, isFormDirty]);
 
+  // Note: all main form page nav goes through here so a gated page cannot be entered without the trainee being warned first.
+  const goToPage = (targetPage: number) => {
+    if (targetPage < 0 || targetPage > lastPage) return;
+    const gate = getPageGate(pages[targetPage].gatedIf);
+    if (gate?.shouldGate(formData)) {
+      setPendingGatePage(targetPage);
+      return;
+    }
+    setCurrentPage(targetPage);
+  };
+
+  const handleGateProceed = () => {
+    if (pendingGatePage === null) return;
+    const gate = getPageGate(pages[pendingGatePage].gatedIf);
+    if (gate) setFormData(prevFormData => gate.onProceed(prevFormData));
+    const targetPage = pendingGatePage;
+    setPendingGatePage(null);
+    setCurrentPage(targetPage);
+  };
+
+  // Note: step over the gated page in the direction the trainee wants to navigate
+  const handleGateSkip = () => {
+    if (pendingGatePage === null) return;
+    const step = pendingGatePage > currentPage ? 1 : -1;
+    const targetPage = pendingGatePage + step;
+    setPendingGatePage(null);
+    goToPage(targetPage);
+  };
+
+  const handleGateCancel = () => setPendingGatePage(null);
+
   const handlePageChange = (
     e: { preventDefault: () => void },
     isShortcut?: boolean
@@ -204,7 +240,7 @@ export default function FormBuilder({
           );
           continueToConfirm(jsonFormName, formData);
         } else {
-          setCurrentPage(currentPage + 1);
+          goToPage(currentPage + 1);
         }
       })
       .catch((err: { inner: { path: string; message: string }[] }) => {
@@ -291,7 +327,7 @@ export default function FormBuilder({
                 onClick={() => {
                   setIsFormDirty(false);
                   setFormErrors({});
-                  setCurrentPage(currentPage - 1);
+                  goToPage(currentPage - 1);
                 }}
                 data-cy="navPrevious"
               >
@@ -362,6 +398,17 @@ export default function FormBuilder({
           ) : null}
         </Row>
       </Container>
+      <PageGateModal
+        isOpen={pendingGatePage !== null}
+        gate={
+          pendingGatePage !== null
+            ? getPageGate(pages[pendingGatePage].gatedIf)
+            : undefined
+        }
+        onProceed={handleGateProceed}
+        onSkip={handleGateSkip}
+        onCancel={handleGateCancel}
+      />
     </form>
   );
 }

--- a/components/forms/form-builder/FormBuilder.tsx
+++ b/components/forms/form-builder/FormBuilder.tsx
@@ -41,7 +41,8 @@ export type FieldType =
   | "phone"
   | "checkbox"
   | "array"
-  | "dto";
+  | "dto"
+  | "info";
 
 export type VisibilityMatcherName = "valueInList" | "lessThan16WeeksTest";
 
@@ -50,6 +51,8 @@ export type VisibilityCondition = {
   matcher: VisibilityMatcherName;
   values?: unknown[];
 };
+
+export type ComputedValueName = "ltft16WeeksNoticeDate";
 
 export type Field = {
   name: string;
@@ -62,12 +65,14 @@ export type Field = {
   placeholder?: string;
   warnings?: Warning[];
   canGrow?: boolean;
-  viewWhenEmpty?: boolean;
+  hideInViewWhenEmpty?: boolean; // Note: stops the "not provided" showing in view if the field is empty.
+  showInViewWhenPopulated?: boolean; // Note: overrides the input-form visibleIf to show the field in the read-only view if it has a value.
   objectFields?: Field[];
   width?: number;
   isNumberField?: boolean;
   contributesToTotal?: string;
   readOnly?: boolean;
+  computedValue?: ComputedValueName; // Note: e.g. derived LTFT 16-week start date
   rows?: number;
   isMultiSelect?: boolean;
   hint?: string;

--- a/components/forms/form-builder/FormContext.tsx
+++ b/components/forms/form-builder/FormContext.tsx
@@ -7,10 +7,10 @@ import React, {
 } from "react";
 import { Field, Form, FormData, ReturnedWidthData } from "./FormBuilder";
 import {
+  clearHiddenFieldValues,
   determineCurrentValue,
   getFieldWarningMsgs,
   setTextFieldWidth,
-  showFormField,
   sumFieldValues
 } from "../../../utilities/FormBuilderUtilities";
 import useFormAutosave from "../../../utilities/hooks/useFormAutosave";
@@ -170,18 +170,10 @@ export const FormProvider: React.FC<FormProviderProps> = ({
   }, [formData, currentPageFields]);
 
   useEffect(() => {
-    // remove child field value when depending parent field is unchecked
-    setFormData(prevFormData => {
-      let changed = false;
-      const cleaned = currentPageFields.reduce((acc, field) => {
-        if (!showFormField(field, acc) && acc[field.name] != null) {
-          changed = true;
-          return { ...acc, [field.name]: null };
-        }
-        return acc;
-      }, prevFormData);
-      return changed ? cleaned : prevFormData;
-    });
+    // Note: remove a field's value when it is no longer shown, e.g. a child field whose parent was unchecked, or the stamped startDate from a previous submission when trainee revisits the UNSUBMITTED form Start date page to edit it.
+    setFormData(prevFormData =>
+      clearHiddenFieldValues(currentPageFields, prevFormData)
+    );
   }, [formData, currentPageFields]);
 
   const handleChange = useCallback(

--- a/components/forms/form-builder/FormFieldBuilder.tsx
+++ b/components/forms/form-builder/FormFieldBuilder.tsx
@@ -4,6 +4,7 @@ import { FormDtoBuilder } from "./FormDtoBuilder";
 import { Text } from "./form-fields/Text";
 import { TextArea } from "./form-fields/TextArea";
 import { filteredOptions } from "../../../utilities/FormBuilderUtilities";
+import { InfoText } from "./form-fields/InfoText";
 import { Selector } from "./form-fields/Selector";
 import { Dates } from "./form-fields/Dates";
 import { Phone } from "./form-fields/Phone";
@@ -45,7 +46,8 @@ export function FormFieldBuilder({
     isMultiSelect,
     hint,
     maxDigits,
-    conditionalField
+    conditionalField,
+    computedValue
   } = field;
   const { arrayIndex, arrayName } = arrayDetails ?? {};
   const { currentPageFields, formData } = useFormContext();
@@ -162,6 +164,11 @@ export function FormFieldBuilder({
           dtoName={dtoName}
         />
       );
+    case "info":
+      return (
+        <InfoText name={name} label={label} computedValue={computedValue} />
+      );
+
     case "checkbox": {
       const childField = conditionalField
         ? currentPageFields.find(f => f.name === conditionalField)

--- a/components/forms/form-builder/FormViewBuilder.tsx
+++ b/components/forms/form-builder/FormViewBuilder.tsx
@@ -27,83 +27,103 @@ function VisibleField({
   jsonFormName,
   canEdit
 }: Readonly<VisibleFieldProps>) {
-  const isVisible = showFormField(field, formData);
-  if (isVisible) {
-    if (field.type === "dto") {
-      return (
-        <>
-          {field.objectFields?.map(nestedField => (
-            <VisibleField
-              key={nestedField.name}
-              field={nestedField}
-              formData={formData[field.name]}
-              formErrors={formErrors}
-              pageIndex={pageIndex}
-              jsonFormName={jsonFormName}
-              canEdit={canEdit}
-            />
-          ))}
-        </>
-      );
-    }
-    if (field.type === "array") {
-      return (
-        <div key={field.name}>
-          <h3
-            data-cy={`${field.name}-array-panel-header`}
-            className="nhsuk-heading-s nhsuk-u-margin-bottom-4"
-          >
-            {field.label}
-          </h3>
-          <ArrayFieldRenderer
-            fieldVal={formData[field.name]}
-            field={field}
-            canEdit={canEdit}
+  const viewState = getFieldViewState(field, formData);
+  // Note: info fields are UI-only to help form completion
+  if (viewState === "hidden" || field.type === "info") {
+    return null;
+  }
+  if (field.type === "dto") {
+    return (
+      <>
+        {field.objectFields?.map(nestedField => (
+          <VisibleField
+            key={nestedField.name}
+            field={nestedField}
+            formData={formData[field.name]}
+            formErrors={formErrors}
             pageIndex={pageIndex}
             jsonFormName={jsonFormName}
-            formErrors={formErrors}
+            canEdit={canEdit}
           />
-        </div>
-      );
-    }
-    const error = formErrors[field.name];
-    const errorMessage = typeof error === "string" ? error : null;
-
-    return (
-      <SummaryList className="nhsuk-u-margin-bottom-4">
-        <SummaryList.Row key={field.name}>
-          <SummaryList.Key data-cy={`${field.name}-label`} id={field.name}>
-            <span>{field.label}</span>
-            {errorMessage && (
-              <span className="nhsuk-error-message">
-                <span className="nhsuk-u-visually-hidden">Error:</span>{" "}
-                {errorMessage}
-              </span>
-            )}
-          </SummaryList.Key>
-          <SummaryList.Value data-cy={`${field.name}-value`}>
-            {formatEntryValue(
-              field.altDisplayVal
-                ? formData[field.altDisplayVal]
-                : formData[field.name],
-              field.type
-            )}
-          </SummaryList.Value>
-          {canEdit && (
-            <SummaryList.Action asElement="span">
-              <ChangeLink
-                targetField={field.name}
-                label={field.label ?? ""}
-                jsonFormName={jsonFormName}
-                pageIndex={pageIndex}
-              />
-            </SummaryList.Action>
-          )}
-        </SummaryList.Row>
-      </SummaryList>
+        ))}
+      </>
     );
   }
-  return null;
+  if (field.type === "array") {
+    return (
+      <div key={field.name}>
+        <h3
+          data-cy={`${field.name}-array-panel-header`}
+          className="nhsuk-heading-s nhsuk-u-margin-bottom-4"
+        >
+          {field.label}
+        </h3>
+        <ArrayFieldRenderer
+          fieldVal={formData[field.name]}
+          field={field}
+          canEdit={canEdit}
+          pageIndex={pageIndex}
+          jsonFormName={jsonFormName}
+          formErrors={formErrors}
+        />
+      </div>
+    );
+  }
+  const error = formErrors[field.name];
+  const errorMessage = typeof error === "string" ? error : null;
+
+  return (
+    <SummaryList className="nhsuk-u-margin-bottom-4">
+      <SummaryList.Row key={field.name}>
+        <SummaryList.Key data-cy={`${field.name}-label`} id={field.name}>
+          <span>{field.label}</span>
+          {errorMessage && (
+            <span className="nhsuk-error-message">
+              <span className="nhsuk-u-visually-hidden">Error:</span>{" "}
+              {errorMessage}
+            </span>
+          )}
+        </SummaryList.Key>
+        <SummaryList.Value data-cy={`${field.name}-value`}>
+          {formatEntryValue(
+            field.altDisplayVal
+              ? formData[field.altDisplayVal]
+              : formData[field.name],
+            field.type
+          )}
+        </SummaryList.Value>
+        {canEdit && viewState === "editable" && (
+          <SummaryList.Action asElement="span">
+            <ChangeLink
+              targetField={field.name}
+              label={field.label ?? ""}
+              jsonFormName={jsonFormName}
+              pageIndex={pageIndex}
+            />
+          </SummaryList.Action>
+        )}
+      </SummaryList.Row>
+    </SummaryList>
+  );
+}
+
+type FieldViewState = "hidden" | "editable" | "readOnly";
+
+function getFieldViewState(field: Field, formData: FormData): FieldViewState {
+  const fieldValue = formData[field.name];
+  const isPopulated =
+    fieldValue !== null && fieldValue !== undefined && fieldValue !== "";
+
+  if (field.hideInViewWhenEmpty && !isPopulated) {
+    return "hidden";
+  }
+  if (showFormField(field, formData)) {
+    return "editable";
+  }
+  if (field.showInViewWhenPopulated && isPopulated) {
+    return "readOnly"; // Note: field flagged showInViewWhenPopulated e.g. a startDate stamped at submission on the "No" path, which is not editable, so no change link is rendered.
+  }
+  return "hidden"; // Note: field flagged hideInViewWhenEmpty is hidden when no value
 }
 
 type FormViewBuilder = {
@@ -111,13 +131,15 @@ type FormViewBuilder = {
   formData: FormData;
   canEdit: boolean;
   formErrors: FormErrorsType;
+  pageNotices?: Record<string, React.ReactNode>;
 };
 
 export default function FormViewBuilder({
   jsonForm,
   formData,
   canEdit,
-  formErrors
+  formErrors,
+  pageNotices
 }: Readonly<FormViewBuilder>) {
   return (
     <div>
@@ -145,6 +167,7 @@ export default function FormViewBuilder({
                 ))}
               </div>
             ))}
+            {pageNotices?.[page.pageName]}
           </Card>
         </div>
       ))}

--- a/components/forms/form-builder/form-fields/InfoText.tsx
+++ b/components/forms/form-builder/form-fields/InfoText.tsx
@@ -1,0 +1,34 @@
+import { InsetText } from "nhsuk-react-components";
+import { computedValueGenerators } from "../../../../utilities/FormBuilderUtilities";
+import { ComputedValueName } from "../FormBuilder";
+import { DateUtilities } from "../../../../utilities/DateUtilities";
+
+type InfoTextProps = {
+  name: string;
+  label?: string;
+  computedValue?: ComputedValueName;
+};
+
+// Note: info text only (no input). Any "{value}" token in the label is replaced with the field's computed value (dates are shown as local dates).
+export const InfoText = ({ name, label, computedValue }: InfoTextProps) => {
+  const generatedValue = computedValue
+    ? computedValueGenerators[computedValue]()
+    : null;
+  const displayValue = generatedValue
+    ? DateUtilities.ToLocalDate(generatedValue)
+    : "";
+  const [before, after] = (label ?? "").split("{value}");
+  return (
+    <InsetText data-cy={`${name}-info`}>
+      <p>
+        {before}
+        {after !== undefined && (
+          <>
+            <strong>{displayValue}</strong>
+            {after}
+          </>
+        )}
+      </p>
+    </InsetText>
+  );
+};

--- a/components/forms/form-builder/form-fields/InfoText.tsx
+++ b/components/forms/form-builder/form-fields/InfoText.tsx
@@ -18,6 +18,12 @@ export const InfoText = ({ name, label, computedValue }: InfoTextProps) => {
     ? DateUtilities.ToLocalDate(generatedValue)
     : "";
   const [before, after] = (label ?? "").split("{value}");
+  if (after !== undefined && !displayValue) {
+    console.warn(
+      `InfoText "${name}": label contains a "{value}" token but couldn't generate a computed value so nothing rendered.`
+    ); // Note: Edge case so just warn dev of poss misconfiguration...
+    return null; // ... and return null to avoid broken sentence.
+  }
   return (
     <InsetText data-cy={`${name}-info`}>
       <p>

--- a/components/forms/form-builder/form-fields/__test__/InfoText.test.tsx
+++ b/components/forms/form-builder/form-fields/__test__/InfoText.test.tsx
@@ -1,0 +1,61 @@
+import { render } from "@testing-library/react";
+import dayjs from "dayjs";
+import { InfoText } from "../InfoText";
+import { DateUtilities } from "../../../../../utilities/DateUtilities";
+
+const getInset = (container: HTMLElement, name: string) =>
+  container.querySelector(`[data-cy="${name}-info"]`) as HTMLElement;
+
+describe("InfoText", () => {
+  it("renders an empty inset text when no label is provided", () => {
+    const { container } = render(<InfoText name="noLabel" />);
+
+    const inset = getInset(container, "noLabel");
+    expect(inset).toBeInTheDocument();
+    expect(inset.querySelector("p")).toBeEmptyDOMElement();
+    expect(inset.querySelector("strong")).not.toBeInTheDocument();
+  });
+
+  it("renders the label as-is when it contains no '{value}' token", () => {
+    const { container } = render(
+      <InfoText name="plain" label="Some plain info text." />
+    );
+
+    const inset = getInset(container, "plain");
+    expect(inset).toHaveTextContent("Some plain info text.");
+    expect(inset.querySelector("strong")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing and warns when '{value}' is present but no computedValue resolves (misconfiguration)", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { container } = render(
+      <InfoText name="tokenNoValue" label="You have until {value} to reply." />
+    );
+
+    expect(getInset(container, "tokenNoValue")).not.toBeInTheDocument();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('InfoText "tokenNoValue"')
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("replaces '{value}' with the computed value formatted as a local date", () => {
+    const { container } = render(
+      <InfoText
+        name="withValue"
+        label="You have until {value} to reply."
+        computedValue="ltft16WeeksNoticeDate"
+      />
+    );
+
+    const expectedDate = DateUtilities.ToLocalDate(
+      dayjs().add(16, "week").format("YYYY-MM-DD")
+    );
+
+    const inset = getInset(container, "withValue");
+    expect(inset.querySelector("strong")).toHaveTextContent(expectedDate);
+    expect(inset).toHaveTextContent(`You have until ${expectedDate} to reply.`);
+  });
+});

--- a/components/forms/form-builder/form-sections/ImportantText.tsx
+++ b/components/forms/form-builder/form-sections/ImportantText.tsx
@@ -308,11 +308,7 @@ const displayText: DisplayText = {
     </>
   ),
   ltftReasonsInstructions: <p>{ltftReasonsText1}</p>,
-  ltftStartDateImportantText: (
-    <>
-      <p>{ltftStartDateImportantText1}</p>
-    </>
-  ),
+  ltftStartDateImportantText: <p>{ltftStartDateImportantText1}</p>,
   ltftTier2VisaImportantText: (
     <>
       <p>{ltftTier2VisaImportantText1}</p>

--- a/components/forms/form-builder/form-sections/ImportantText.tsx
+++ b/components/forms/form-builder/form-sections/ImportantText.tsx
@@ -27,13 +27,7 @@ export const ltftReasonsText1 =
   "The reason(s) for applying will be used for reporting purposes and may inform the decision-making process. This will need to be discussed with your regional office.";
 
 export const ltftStartDateImportantText1 =
-  "A Less than full-time (LTFT) training request with less than 16 weeks’ notice or outside the application window (should a regional team manage applications within a window) is classed as a late application and will only be considered on an exceptional basis.";
-
-export const ltftStartDateImportantText2 =
-  "If applicable, should your late application not be approved, when choosing a late application start date below, you will also be asked to provide an alternative start date at least 16 weeks in advance. This will hopefully lessen any admin delays in approving your application.";
-
-export const ltftStartDateImportantText3 =
-  "A late application will also need additional supporting information (Part 6 of this form). This includes the reasons for no suitable alternative start date being given (if applicable).";
+  "A Less than full-time (LTFT) training request with less than 16 weeks’ notice or outside the application window (should a regional team manage applications within a window) is classed as an Exceptional Circumstances application and is much less likely to be approved than one that gives at least 16 weeks' notice.";
 
 export const ltftTier2VisaImportantText1 =
   "If you are a Skilled Worker (formerly a Tier 2 General work) visa holder, please make sure the proposed change to your full time working hours percentage (Part 3 of this application) complies with the requirements of your visa.";
@@ -317,8 +311,6 @@ const displayText: DisplayText = {
   ltftStartDateImportantText: (
     <>
       <p>{ltftStartDateImportantText1}</p>
-      <p>{ltftStartDateImportantText2}</p>
-      <p>{ltftStartDateImportantText3}</p>
     </>
   ),
   ltftTier2VisaImportantText: (

--- a/components/forms/ltft/LtftForm.tsx
+++ b/components/forms/ltft/LtftForm.tsx
@@ -4,7 +4,6 @@ import ErrorPage from "../../common/ErrorPage";
 import FormBuilder, { Form, FormName } from "../form-builder/FormBuilder";
 import { FormProvider } from "../form-builder/FormContext";
 import ltftJson from "./ltft.json";
-import { LtftStatusDetails } from "./LtftStatusDetails";
 import { ltftValidationSchema } from "./ltftValidationSchema";
 
 type LtftFormProps = {
@@ -55,9 +54,6 @@ export function LtftForm({ pmOptions }: LtftFormProps) {
   return formData?.declarations?.discussedWithTpd ? (
     <div>
       <h2>Application form</h2>
-      {formData.status?.current?.state !== "DRAFT" && (
-        <LtftStatusDetails {...formData} />
-      )}
       <FormProvider
         initialData={formData}
         initialPageFields={initialPageFields}

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -55,6 +55,8 @@ import {
 import history from "../../navigation/history";
 import { ltftValidationSchema } from "./ltftValidationSchema";
 
+const START_DATE_PAGE_NAME = "Start date";
+
 export const LtftFormView = () => {
   const dispatch = useAppDispatch();
   const { id } = useParams<{ id: string }>();
@@ -65,13 +67,6 @@ export const LtftFormView = () => {
   const formData = useSelectFormData(ltftJson.name as FormName) as LtftObjNew;
   const canEditStatus = useAppSelector(state => state.ltft.canEdit);
 
-  const latestSubmittedLtft = findLatestSubmissionDate(formData);
-
-  const derivedStartDate =
-    formData.canGiveCompliantStartDate === false && !formData.startDate
-      ? computedValueGenerators.ltft16WeeksNoticeDate()
-      : null; // Note: 16 weeks notice date that will be stamped on submission (if no compliant start date is set)
-
   const formJson = ltftJson as FormType;
   const [canSubmit, setCanSubmit] = useState(false);
   const [showModal, setShowModal] = useState(false);
@@ -80,9 +75,8 @@ export const LtftFormView = () => {
 
   const hasLegacyStartDate = hasLegacyStartDateData(formData);
   const startDatePageIndex = formJson.pages.findIndex(
-    page => page.pageName === "Start date"
+    page => page.pageName === START_DATE_PAGE_NAME
   );
-  const [isStartDateSectionValid, setIsStartDateSectionValid] = useState(true);
 
   useEffect(() => {
     if (id) {
@@ -90,17 +84,13 @@ export const LtftFormView = () => {
     }
   }, [id, dispatch]);
 
-  useEffect(() => {
-    // Note: This effect is to make sure a legacy start date page reset can't be left incomplete
-    const startDateFields = formJson.pages[startDatePageIndex].sections.flatMap(
-      section => section.fields
-    );
-    validateFields(startDateFields, formData, ltftValidationSchema)
-      .then(() => setIsStartDateSectionValid(true))
-      .catch(() => setIsStartDateSectionValid(false));
-  }, [formData, formJson, startDatePageIndex]);
+  const isStartDateSectionValid = useStartDateSectionValidity(
+    formJson,
+    startDatePageIndex,
+    formData
+  );
 
-  // Note: a legacy application can be re-submitted with its original (pre-rework) start date details untouched, so it is exempt from the completeness check.
+  // Note: a legacy application can be re-submitted with its original start date details (e.g. startDate <16wks; altStartDate) untouched, so it is exempt from the 'new page' validation.
   const isStartDateSectionSubmittable =
     hasLegacyStartDate || isStartDateSectionValid;
 
@@ -121,47 +111,14 @@ export const LtftFormView = () => {
   let startDatePageNotice: ReactNode;
   if (hasLegacyStartDate) {
     startDatePageNotice = (
-      <InsetText data-cy="legacyStartDateNote">
-        {canEditStatus ? (
-          <>
-            <p>
-              This application was started under the previous start date process
-              and is now handled differently. To change any start date details,
-              you&apos;ll need to complete the start date section again in the
-              updated format. Your originally submitted dates are shown in the
-              summary below.
-            </p>
-            <Button
-              type="button"
-              data-cy="updateLegacyStartDate"
-              onClick={() => setShowLegacyStartDateModal(true)}
-            >
-              Update start date section
-            </Button>
-          </>
-        ) : (
-          <p>
-            This application was submitted under the previous start date
-            process. The start dates are shown in the summary below.
-          </p>
-        )}
-      </InsetText>
+      <LegacyStartDateNotice
+        canEdit={canEditStatus}
+        onEditClick={() => setShowLegacyStartDateModal(true)}
+      />
     );
   } else if (canEditStatus && !isStartDateSectionValid) {
     startDatePageNotice = (
-      <InsetText data-cy="incompleteStartDateNote">
-        <p>
-          The start date section is incomplete. You need to complete it before
-          you can submit this application.
-        </p>
-        <Button
-          type="button"
-          data-cy="completeStartDateSection"
-          onClick={goToStartDatePage}
-        >
-          Complete start date section
-        </Button>
-      </InsetText>
+      <IncompleteStartDateNotice onCompleteClick={goToStartDatePage} />
     );
   }
 
@@ -255,85 +212,14 @@ export const LtftFormView = () => {
           formErrors={{}}
           pageNotices={
             startDatePageNotice
-              ? { "Start date": startDatePageNotice }
+              ? { [START_DATE_PAGE_NAME]: startDatePageNotice }
               : undefined
           }
         />
-        <Card style={{ border: "4px #005eb8 solid" }}>
-          <Card.Heading data-cy="completionDateChangeHeading">
-            Summary of changes to your {formData.pmName} Programme
-          </Card.Heading>
-          <SummaryList>
-            <SummaryList.Row>
-              <SummaryList.Key data-cy="completionDateChangePmKey">
-                Programme
-              </SummaryList.Key>
-              <SummaryList.Value data-cy="completionDateChangePmValue">
-                {formData.pmName}
-              </SummaryList.Value>
-            </SummaryList.Row>
-            <SummaryList.Row>
-              <SummaryList.Key data-cy="completionDateChangeCurrentCompletionDateKey">
-                Current completion date
-              </SummaryList.Key>
-              <SummaryList.Value data-cy="completionDateChangeCurrentCompletionDateValue">
-                {dayjs(formData.pmEndDate).format("DD/MM/YYYY")} (Programme end
-                date on TIS)
-              </SummaryList.Value>
-            </SummaryList.Row>
-            <SummaryList.Row>
-              <SummaryList.Key data-cy="completionDateChangeWtesKey">
-                Working hours percentage change
-              </SummaryList.Key>
-              <SummaryList.Value data-cy="completionDateChangeWtesValue">
-                {formData.wteBeforeChange}% → {formData.wte}%
-              </SummaryList.Value>
-            </SummaryList.Row>
-            <SummaryList.Row>
-              <SummaryList.Key data-cy="completionDateChangeStartDateKey">
-                LTFT Start date
-              </SummaryList.Key>
-              <SummaryList.Value data-cy="completionDateChangeStartDateValue">
-                {derivedStartDate ? (
-                  <>
-                    {dayjs(derivedStartDate).format("DD/MM/YYYY")}
-                    {
-                      " (16 weeks from today - this date will be set when you submit your application)"
-                    }
-                  </>
-                ) : (
-                  formData.startDate &&
-                  dayjs(formData.startDate).format("DD/MM/YYYY")
-                )}
-                {hasLegacyStartDate &&
-                  formData.startDate &&
-                  latestSubmittedLtft &&
-                  isDateWithin16WeeksOfFirstDate(
-                    formData.startDate,
-                    latestSubmittedLtft
-                  ) && (
-                    <FieldWarningMsg
-                      warningMsgs={[ltft16WeeksWarningTextSubmitted]}
-                    />
-                  )}
-              </SummaryList.Value>
-            </SummaryList.Row>
-            {formData.altStartDate && (
-              <SummaryList.Row>
-                <SummaryList.Key data-cy="altStartDateKey">
-                  Alternative start date
-                </SummaryList.Key>
-                <SummaryList.Value data-cy="altStartDateValue">
-                  {dayjs(formData.altStartDate).format("DD/MM/YYYY")}
-                </SummaryList.Value>
-              </SummaryList.Row>
-            )}
-          </SummaryList>
-          <CompletionDateChangeText
-            wteBeforeChange={formData.wteBeforeChange}
-            wte={formData.wte}
-          />
-        </Card>
+        <LtftChangeSummaryCard
+          formData={formData}
+          hasLegacyStartDate={hasLegacyStartDate}
+        />
         <WarningCallout>
           <WarningCallout.Heading>Declarations</WarningCallout.Heading>
 
@@ -343,43 +229,14 @@ export const LtftFormView = () => {
             formDeclarations={formJson.declarations}
           />
           {canEditStatus && (
-            <Formik
-              initialValues={{ name: formData.name ?? "" }}
+            <LtftPreSubForm
+              initialName={formData.name ?? ""}
+              currentState={formData.status?.current?.state}
+              isSubmitting={isSubmitting}
+              canSubmit={canSubmit}
+              isStartDateSectionSubmittable={isStartDateSectionSubmittable}
               onSubmit={handleSubClick}
-            >
-              {({ values }) => {
-                return (
-                  <Form>
-                    <TextInputField
-                      name="name"
-                      id="Name"
-                      label="Please give your LTFT application a name"
-                      placeholder="Type name here..."
-                      width="300px"
-                      readOnly={!canEditStatus}
-                    />
-
-                    <Button
-                      type="submit"
-                      disabled={
-                        !values.name.trim() ||
-                        !canSubmit ||
-                        isSubmitting ||
-                        !isStartDateSectionSubmittable
-                      }
-                      data-cy="BtnSubmit"
-                    >
-                      {(() => {
-                        if (isSubmitting) return "Saving...";
-                        if (formData.status?.current?.state === "UNSUBMITTED")
-                          return "Re-submit";
-                        return "Submit";
-                      })()}
-                    </Button>
-                  </Form>
-                );
-              }}
-            </Formik>
+            />
           )}
         </WarningCallout>
         {canEditStatus && (
@@ -435,6 +292,233 @@ export const LtftFormView = () => {
     );
   return null;
 };
+
+// Note: This check is to make sure a legacy start date page reset can't be left incomplete
+function useStartDateSectionValidity(
+  formJson: FormType,
+  startDatePageIndex: number,
+  formData: LtftObjNew
+) {
+  const [isStartDateSectionValid, setIsStartDateSectionValid] = useState(true);
+
+  useEffect(() => {
+    const startDateFields = formJson.pages[startDatePageIndex].sections.flatMap(
+      section => section.fields
+    );
+    validateFields(startDateFields, formData, ltftValidationSchema)
+      .then(() => setIsStartDateSectionValid(true))
+      .catch(() => setIsStartDateSectionValid(false));
+  }, [formData, formJson, startDatePageIndex]);
+
+  return isStartDateSectionValid;
+}
+
+function LegacyStartDateNotice({
+  canEdit,
+  onEditClick
+}: Readonly<{ canEdit: boolean; onEditClick: () => void }>) {
+  return (
+    <InsetText data-cy="legacyStartDateNote">
+      {canEdit ? (
+        <>
+          <p>
+            This application was started under the previous start date process
+            and is now handled differently. To change any start date details,
+            you&apos;ll need to complete the start date section again in the
+            updated format. Your originally submitted dates are shown in the
+            summary below.
+          </p>
+          <Button
+            type="button"
+            data-cy="updateLegacyStartDate"
+            onClick={onEditClick}
+          >
+            Update start date section
+          </Button>
+        </>
+      ) : (
+        <p>
+          This application was submitted under the previous start date process.
+          The start dates are shown in the summary below.
+        </p>
+      )}
+    </InsetText>
+  );
+}
+
+function IncompleteStartDateNotice({
+  onCompleteClick
+}: Readonly<{ onCompleteClick: () => void }>) {
+  return (
+    <InsetText data-cy="incompleteStartDateNote">
+      <p>
+        The start date section is incomplete. You need to complete it before you
+        can submit this application.
+      </p>
+      <Button
+        type="button"
+        data-cy="completeStartDateSection"
+        onClick={onCompleteClick}
+      >
+        Complete start date section
+      </Button>
+    </InsetText>
+  );
+}
+
+function LtftChangeSummaryCard({
+  formData,
+  hasLegacyStartDate
+}: Readonly<{ formData: LtftObjNew; hasLegacyStartDate: boolean }>) {
+  return (
+    <Card style={{ border: "4px #005eb8 solid" }}>
+      <Card.Heading data-cy="completionDateChangeHeading">
+        Summary of changes to your {formData.pmName} Programme
+      </Card.Heading>
+      <SummaryList>
+        <SummaryList.Row>
+          <SummaryList.Key data-cy="completionDateChangePmKey">
+            Programme
+          </SummaryList.Key>
+          <SummaryList.Value data-cy="completionDateChangePmValue">
+            {formData.pmName}
+          </SummaryList.Value>
+        </SummaryList.Row>
+        <SummaryList.Row>
+          <SummaryList.Key data-cy="completionDateChangeCurrentCompletionDateKey">
+            Current completion date
+          </SummaryList.Key>
+          <SummaryList.Value data-cy="completionDateChangeCurrentCompletionDateValue">
+            {dayjs(formData.pmEndDate).format("DD/MM/YYYY")} (Programme end date
+            on TIS)
+          </SummaryList.Value>
+        </SummaryList.Row>
+        <SummaryList.Row>
+          <SummaryList.Key data-cy="completionDateChangeWtesKey">
+            Working hours percentage change
+          </SummaryList.Key>
+          <SummaryList.Value data-cy="completionDateChangeWtesValue">
+            {formData.wteBeforeChange}% → {formData.wte}%
+          </SummaryList.Value>
+        </SummaryList.Row>
+        <SummaryList.Row>
+          <SummaryList.Key data-cy="completionDateChangeStartDateKey">
+            LTFT Start date
+          </SummaryList.Key>
+          <SummaryList.Value data-cy="completionDateChangeStartDateValue">
+            <StartDateSummaryValue
+              formData={formData}
+              hasLegacyStartDate={hasLegacyStartDate}
+            />
+          </SummaryList.Value>
+        </SummaryList.Row>
+        {formData.altStartDate && (
+          <SummaryList.Row>
+            <SummaryList.Key data-cy="altStartDateKey">
+              Alternative start date
+            </SummaryList.Key>
+            <SummaryList.Value data-cy="altStartDateValue">
+              {dayjs(formData.altStartDate).format("DD/MM/YYYY")}
+            </SummaryList.Value>
+          </SummaryList.Row>
+        )}
+      </SummaryList>
+      <CompletionDateChangeText
+        wteBeforeChange={formData.wteBeforeChange}
+        wte={formData.wte}
+      />
+    </Card>
+  );
+}
+
+function StartDateSummaryValue({
+  formData,
+  hasLegacyStartDate
+}: Readonly<{ formData: LtftObjNew; hasLegacyStartDate: boolean }>) {
+  // Note: 16 weeks notice date that will be stamped on submission (if no compliant start date is set)
+  const derivedStartDate =
+    formData.canGiveCompliantStartDate === false && !formData.startDate
+      ? computedValueGenerators.ltft16WeeksNoticeDate()
+      : null;
+
+  if (derivedStartDate) {
+    return (
+      <>
+        {dayjs(derivedStartDate).format("DD/MM/YYYY")}
+        {
+          " (16 weeks from today - this date will be set when you submit your application)"
+        }
+      </>
+    );
+  }
+
+  const latestSubmittedLtft = findLatestSubmissionDate(formData);
+  const showWithin16WeeksWarning =
+    hasLegacyStartDate &&
+    !!formData.startDate &&
+    !!latestSubmittedLtft &&
+    isDateWithin16WeeksOfFirstDate(formData.startDate, latestSubmittedLtft);
+
+  return (
+    <>
+      {formData.startDate && dayjs(formData.startDate).format("DD/MM/YYYY")}
+      {showWithin16WeeksWarning && (
+        <FieldWarningMsg warningMsgs={[ltft16WeeksWarningTextSubmitted]} />
+      )}
+    </>
+  );
+}
+
+function LtftPreSubForm({
+  initialName,
+  currentState,
+  isSubmitting,
+  canSubmit,
+  isStartDateSectionSubmittable,
+  onSubmit
+}: Readonly<{
+  initialName: string;
+  currentState: string | undefined;
+  isSubmitting: boolean;
+  canSubmit: boolean;
+  isStartDateSectionSubmittable: boolean;
+  onSubmit: (values: { name: string }) => Promise<void>;
+}>) {
+  return (
+    <Formik initialValues={{ name: initialName }} onSubmit={onSubmit}>
+      {({ values }) => (
+        <Form>
+          <TextInputField
+            name="name"
+            id="Name"
+            label="Please give your LTFT application a name"
+            placeholder="Type name here..."
+            width="300px"
+          />
+
+          <Button
+            type="submit"
+            disabled={
+              !values.name.trim() ||
+              !canSubmit ||
+              isSubmitting ||
+              !isStartDateSectionSubmittable
+            }
+            data-cy="BtnSubmit"
+          >
+            {getSubmitBtnText(isSubmitting, currentState)}
+          </Button>
+        </Form>
+      )}
+    </Formik>
+  );
+}
+
+function getSubmitBtnText(isSubmitting: boolean, currentState?: string) {
+  if (isSubmitting) return "Saving...";
+  if (currentState === "UNSUBMITTED") return "Re-submit";
+  return "Submit";
+}
 
 function CompletionDateChangeText({
   wteBeforeChange,

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -9,7 +9,7 @@ import { useSelectFormData } from "../../../utilities/hooks/useSelectFormData";
 import { Form as FormType, FormName } from "../form-builder/FormBuilder";
 import ltftJson from "./ltft.json";
 import FormViewBuilder from "../form-builder/FormViewBuilder";
-import { useEffect, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import {
   Button,
   Card,
@@ -26,7 +26,8 @@ import {
   computedValueGenerators,
   isDateWithin16WeeksOfFirstDate,
   saveDraftForm,
-  setEditPageNumber
+  setEditPageNumber,
+  validateFields
 } from "../../../utilities/FormBuilderUtilities";
 import { useSubmitting } from "../../../utilities/hooks/useSubmitting";
 import TextInputField from "../TextInputField";
@@ -48,9 +49,11 @@ import { ltft16WeeksWarningTextSubmitted } from "../../../utilities/Constants";
 import {
   clearStartDateSection,
   findLatestSubmissionDate,
+  hasLegacyStartDateData,
   stampLtftStartDateOnSubmit
 } from "../../../utilities/ltftUtilities";
 import history from "../../navigation/history";
+import { ltftValidationSchema } from "./ltftValidationSchema";
 
 export const LtftFormView = () => {
   const dispatch = useAppDispatch();
@@ -75,7 +78,11 @@ export const LtftFormView = () => {
   const [showLegacyStartDateModal, setShowLegacyStartDateModal] =
     useState(false);
 
-  const isLegacyStartDate = formData.canGiveCompliantStartDate === null;
+  const hasLegacyStartDate = hasLegacyStartDateData(formData);
+  const startDatePageIndex = formJson.pages.findIndex(
+    page => page.pageName === "Start date"
+  );
+  const [isStartDateSectionValid, setIsStartDateSectionValid] = useState(true);
 
   useEffect(() => {
     if (id) {
@@ -83,46 +90,80 @@ export const LtftFormView = () => {
     }
   }, [id, dispatch]);
 
-  const handleLegacyStartDateEditConfirm = () => {
-    dispatch(updatedLtft(clearStartDateSection(formData)));
-    const startDatePageIndex = formJson.pages.findIndex(
-      page => page.pageName === "Start date"
+  useEffect(() => {
+    // Note: This effect is to make sure a legacy start date page reset can't be left incomplete
+    const startDateFields = formJson.pages[startDatePageIndex].sections.flatMap(
+      section => section.fields
     );
+    validateFields(startDateFields, formData, ltftValidationSchema)
+      .then(() => setIsStartDateSectionValid(true))
+      .catch(() => setIsStartDateSectionValid(false));
+  }, [formData, formJson, startDatePageIndex]);
+
+  // Note: a legacy application can be re-submitted with its original (pre-rework) start date details untouched, so it is exempt from the completeness check.
+  const isStartDateSectionSubmittable =
+    hasLegacyStartDate || isStartDateSectionValid;
+
+  const goToStartDatePage = () => {
     setEditPageNumber(formJson.name, startDatePageIndex);
-    setShowLegacyStartDateModal(false);
     history.push({
       pathname: "/ltft/create",
       state: { fieldName: "canGiveCompliantStartDate" }
     });
   };
 
-  const legacyStartDateNotice = isLegacyStartDate ? (
-    <InsetText data-cy="legacyStartDateNote">
-      {canEditStatus ? (
-        <>
+  const handleLegacyStartDateEditConfirm = () => {
+    dispatch(updatedLtft(clearStartDateSection(formData)));
+    setShowLegacyStartDateModal(false);
+    goToStartDatePage();
+  };
+
+  let startDatePageNotice: ReactNode;
+  if (hasLegacyStartDate) {
+    startDatePageNotice = (
+      <InsetText data-cy="legacyStartDateNote">
+        {canEditStatus ? (
+          <>
+            <p>
+              This application was started under the previous start date process
+              and is now handled differently. To change any start date details,
+              you&apos;ll need to complete the start date section again in the
+              updated format. Your originally submitted dates are shown in the
+              summary below.
+            </p>
+            <Button
+              type="button"
+              data-cy="updateLegacyStartDate"
+              onClick={() => setShowLegacyStartDateModal(true)}
+            >
+              Update start date section
+            </Button>
+          </>
+        ) : (
           <p>
-            This application was started under the previous start date process
-            and is now handled differently. To change any start date details,
-            you&apos;ll need to complete the start date section again in the
-            updated format. Your originally submitted dates are shown in the
-            summary below.
+            This application was submitted under the previous start date
+            process. The start dates are shown in the summary below.
           </p>
-          <Button
-            type="button"
-            data-cy="updateLegacyStartDate"
-            onClick={() => setShowLegacyStartDateModal(true)}
-          >
-            Update start date section
-          </Button>
-        </>
-      ) : (
+        )}
+      </InsetText>
+    );
+  } else if (canEditStatus && !isStartDateSectionValid) {
+    startDatePageNotice = (
+      <InsetText data-cy="incompleteStartDateNote">
         <p>
-          This application was submitted under the previous start date process.
-          The start dates are shown in the summary below.
+          The start date section is incomplete. You need to complete it before
+          you can submit this application.
         </p>
-      )}
-    </InsetText>
-  ) : undefined;
+        <Button
+          type="button"
+          data-cy="completeStartDateSection"
+          onClick={goToStartDatePage}
+        >
+          Complete start date section
+        </Button>
+      </InsetText>
+    );
+  }
 
   const handleSubClick = async (values: { name: string }) => {
     setAction("Submit", "", formJson.name);
@@ -213,8 +254,8 @@ export const LtftFormView = () => {
           canEdit={canEditStatus}
           formErrors={{}}
           pageNotices={
-            legacyStartDateNotice
-              ? { "Start date": legacyStartDateNotice }
+            startDatePageNotice
+              ? { "Start date": startDatePageNotice }
               : undefined
           }
         />
@@ -264,7 +305,7 @@ export const LtftFormView = () => {
                   formData.startDate &&
                   dayjs(formData.startDate).format("DD/MM/YYYY")
                 )}
-                {isLegacyStartDate &&
+                {hasLegacyStartDate &&
                   formData.startDate &&
                   latestSubmittedLtft &&
                   isDateWithin16WeeksOfFirstDate(
@@ -321,7 +362,10 @@ export const LtftFormView = () => {
                     <Button
                       type="submit"
                       disabled={
-                        !values.name.trim() || !canSubmit || isSubmitting
+                        !values.name.trim() ||
+                        !canSubmit ||
+                        isSubmitting ||
+                        !isStartDateSectionSubmittable
                       }
                       data-cy="BtnSubmit"
                     >

--- a/components/forms/ltft/LtftFormView.tsx
+++ b/components/forms/ltft/LtftFormView.tsx
@@ -2,6 +2,7 @@ import { useAppDispatch, useAppSelector } from "../../../redux/hooks/hooks";
 import { useParams } from "react-router-dom";
 import {
   loadSavedLtft,
+  updatedLtft,
   updatedLtftSaveStatus
 } from "../../../redux/slices/ltftSlice";
 import { useSelectFormData } from "../../../utilities/hooks/useSelectFormData";
@@ -14,6 +15,7 @@ import {
   Card,
   Col,
   Container,
+  InsetText,
   Row,
   SummaryList,
   WarningCallout
@@ -21,8 +23,10 @@ import {
 import Declarations from "../Declarations";
 import { StartOverButton } from "../StartOverButton";
 import {
+  computedValueGenerators,
   isDateWithin16WeeksOfFirstDate,
-  saveDraftForm
+  saveDraftForm,
+  setEditPageNumber
 } from "../../../utilities/FormBuilderUtilities";
 import { useSubmitting } from "../../../utilities/hooks/useSubmitting";
 import TextInputField from "../TextInputField";
@@ -40,11 +44,13 @@ import dayjs from "dayjs";
 import FieldWarningMsg from "../FieldWarningMsg";
 import { LtftStatusDetails } from "./LtftStatusDetails";
 import store from "../../../redux/store/store";
+import { ltft16WeeksWarningTextSubmitted } from "../../../utilities/Constants";
 import {
-  ltft16WeeksWarningText,
-  ltft16WeeksWarningTextSubmitted
-} from "../../../utilities/Constants";
-import { findLatestSubmissionDate } from "../../../utilities/ltftUtilities";
+  clearStartDateSection,
+  findLatestSubmissionDate,
+  stampLtftStartDateOnSubmit
+} from "../../../utilities/ltftUtilities";
+import history from "../../navigation/history";
 
 export const LtftFormView = () => {
   const dispatch = useAppDispatch();
@@ -58,15 +64,65 @@ export const LtftFormView = () => {
 
   const latestSubmittedLtft = findLatestSubmissionDate(formData);
 
+  const derivedStartDate =
+    formData.canGiveCompliantStartDate === false && !formData.startDate
+      ? computedValueGenerators.ltft16WeeksNoticeDate()
+      : null; // Note: 16 weeks notice date that will be stamped on submission (if no compliant start date is set)
+
   const formJson = ltftJson as FormType;
   const [canSubmit, setCanSubmit] = useState(false);
   const [showModal, setShowModal] = useState(false);
+  const [showLegacyStartDateModal, setShowLegacyStartDateModal] =
+    useState(false);
+
+  const isLegacyStartDate = formData.canGiveCompliantStartDate === null;
 
   useEffect(() => {
     if (id) {
       dispatch(loadSavedLtft(id));
     }
   }, [id, dispatch]);
+
+  const handleLegacyStartDateEditConfirm = () => {
+    dispatch(updatedLtft(clearStartDateSection(formData)));
+    const startDatePageIndex = formJson.pages.findIndex(
+      page => page.pageName === "Start date"
+    );
+    setEditPageNumber(formJson.name, startDatePageIndex);
+    setShowLegacyStartDateModal(false);
+    history.push({
+      pathname: "/ltft/create",
+      state: { fieldName: "canGiveCompliantStartDate" }
+    });
+  };
+
+  const legacyStartDateNotice = isLegacyStartDate ? (
+    <InsetText data-cy="legacyStartDateNote">
+      {canEditStatus ? (
+        <>
+          <p>
+            This application was started under the previous start date process
+            and is now handled differently. To change any start date details,
+            you&apos;ll need to complete the start date section again in the
+            updated format. Your originally submitted dates are shown in the
+            summary below.
+          </p>
+          <Button
+            type="button"
+            data-cy="updateLegacyStartDate"
+            onClick={() => setShowLegacyStartDateModal(true)}
+          >
+            Update start date section
+          </Button>
+        </>
+      ) : (
+        <p>
+          This application was submitted under the previous start date process.
+          The start dates are shown in the summary below.
+        </p>
+      )}
+    </InsetText>
+  ) : undefined;
 
   const handleSubClick = async (values: { name: string }) => {
     setAction("Submit", "", formJson.name);
@@ -104,7 +160,12 @@ export const LtftFormView = () => {
 
   const handleModalFormSubmit = async () => {
     startSubmitting();
-    await saveDraftForm(formJson, formData, false, true);
+    await saveDraftForm(
+      formJson,
+      stampLtftStartDateOnSubmit(formData),
+      false,
+      true
+    );
     stopSubmitting();
     setShowModal(false);
     resetAction();
@@ -151,6 +212,11 @@ export const LtftFormView = () => {
           formData={formData}
           canEdit={canEditStatus}
           formErrors={{}}
+          pageNotices={
+            legacyStartDateNotice
+              ? { "Start date": legacyStartDateNotice }
+              : undefined
+          }
         />
         <Card style={{ border: "4px #005eb8 solid" }}>
           <Card.Heading data-cy="completionDateChangeHeading">
@@ -187,8 +253,19 @@ export const LtftFormView = () => {
                 LTFT Start date
               </SummaryList.Key>
               <SummaryList.Value data-cy="completionDateChangeStartDateValue">
-                {dayjs(formData.startDate).format("DD/MM/YYYY")}
-                {formData.startDate &&
+                {derivedStartDate ? (
+                  <>
+                    {dayjs(derivedStartDate).format("DD/MM/YYYY")}
+                    {
+                      " (16 weeks from today - this date will be set when you submit your application)"
+                    }
+                  </>
+                ) : (
+                  formData.startDate &&
+                  dayjs(formData.startDate).format("DD/MM/YYYY")
+                )}
+                {isLegacyStartDate &&
+                  formData.startDate &&
                   latestSubmittedLtft &&
                   isDateWithin16WeeksOfFirstDate(
                     formData.startDate,
@@ -197,11 +274,6 @@ export const LtftFormView = () => {
                     <FieldWarningMsg
                       warningMsgs={[ltft16WeeksWarningTextSubmitted]}
                     />
-                  )}
-                {formData.startDate &&
-                  !latestSubmittedLtft &&
-                  isDateWithin16WeeksOfFirstDate(formData.startDate) && (
-                    <FieldWarningMsg warningMsgs={[ltft16WeeksWarningText]} />
                   )}
               </SummaryList.Value>
             </SummaryList.Row>
@@ -304,6 +376,16 @@ export const LtftFormView = () => {
           submittingBtnText={currentAction.submittingText}
           isSubmitting={isSubmitting}
           additionalInfo={currentAction.additionalInfo}
+        />
+        <ActionModal
+          onSubmit={handleLegacyStartDateEditConfirm}
+          isOpen={showLegacyStartDateModal}
+          onClose={() => setShowLegacyStartDateModal(false)}
+          cancelBtnText="Cancel"
+          warningLabel="Start date process updated"
+          warningText="Editing the start date section will clear the start date details you gave under the previous process. You'll need to complete this section again in the updated format."
+          submittingBtnText=""
+          isSubmitting={false}
         />
       </LtftViewWrapper>
     );

--- a/components/forms/ltft/__test__/LtftFormView.test.tsx
+++ b/components/forms/ltft/__test__/LtftFormView.test.tsx
@@ -115,6 +115,11 @@ describe("LtftFormView - Modal Display Tests", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Note: the module is auto-mocked, so validateFields returns undefined and the Start date section check would throw on .then - give it a promise to chain off.
+
+    (FormBuilderUtilities.validateFields as jest.Mock).mockResolvedValue(
+      undefined
+    );
     mockStoreState = {
       ltft: { canEdit: true, saveStatus: "idle" }
     };

--- a/components/forms/ltft/ltft.json
+++ b/components/forms/ltft/ltft.json
@@ -75,33 +75,86 @@
     {
       "pageName": "Start date",
       "importantTxtName": "ltftStartDateImportantText",
-      "expanderLinkName": "",
+      "expanderLinkName": "ltft16WeeksNotice",
       "sections": [
         {
           "sectionHeader": "Start date for change to your working hours",
           "fields": [
             {
+              "name": "canGiveCompliantStartDate",
+              "label": "Are you giving at least 16 weeks' notice to change your working hours?",
+              "type": "radio",
+              "optionsKey": "yesNo",
+              "visible": true,
+              "hideInViewWhenEmpty": true
+            },
+            {
+              "name": "earliestStartDateInfo",
+              "type": "info",
+              "label": "The earliest date this change to your working hours can begin is {value} (16 weeks from today).",
+              "visible": false,
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "canGiveCompliantStartDate",
+                "values": [true]
+              },
+              "computedValue": "ltft16WeeksNoticeDate"
+            },
+            {
               "name": "startDate",
               "label": "When should this change to your working hours begin?",
               "type": "date",
-              "visible": true,
-              "warnings": [
-                {
-                  "matcher": "ltft16WeeksTest",
-                  "msgText": "Warning: The start date you have chosen (within 16 weeks) is classed as a late application and will be considered on an exceptional basis. You will be prompted in Part 6 to provide your reason(s) for this."
-                }
-              ]
+              "visible": false,
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "canGiveCompliantStartDate",
+                "values": [true]
+              },
+              "showInViewWhenPopulated": true
+            },
+            {
+              "name": "startDateInfo",
+              "type": "info",
+              "label": "Unless your exceptional circumstances are accepted, the earliest your change to working hours can start is {value} (16 weeks from today). If you submit your form today, this date will be set as your LTFT start date.",
+              "visible": false,
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "canGiveCompliantStartDate",
+                "values": [false]
+              },
+              "computedValue": "ltft16WeeksNoticeDate"
+            },
+            {
+              "name": "exceptionalReasons",
+              "label": "Please give the exceptional reason(s) why you cannot give 16 weeks' notice to change your working hours.",
+              "placeholder": "type here...",
+              "type": "textArea",
+              "visible": false,
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "canGiveCompliantStartDate",
+                "values": [false]
+              },
+              "hint": "Exceptional circumstances include such things as sudden disability, significant life changes (see the '16 weeks notice period' guidance above)."
+            },
+            {
+              "name": "exceptionalReasonsDate",
+              "label": "When would you like this change to your working hours to begin?",
+              "hint": "This must be a date from today up to 16 weeks from today. An earlier start date is not guaranteed and will be considered as part of your exceptional circumstances.",
+              "type": "date",
+              "visible": false,
+              "visibleIf": {
+                "matcher": "valueInList",
+                "field": "canGiveCompliantStartDate",
+                "values": [false]
+              }
             },
             {
               "name": "altStartDate",
               "label": "If you have an alternative start date that gives at least 16 weeks notice, please enter it here.",
               "hint": "Leave blank if there is no suitable alternative",
               "type": "date",
-              "visible": false,
-              "visibleIf": {
-                "matcher": "lessThan16WeeksTest",
-                "field": "startDate"
-              }
+              "visible": false
             }
           ]
         }
@@ -157,14 +210,7 @@
               "hint": "This helps us understand your circumstances and proposed arrangements.",
               "placeholder": "Example:\n'I would like to apply for 60% LTFT from March 2026 due to ongoing caring responsibilities. I plan to work three days per week and would appreciate flexibility around clinic days.'",
               "type": "textArea",
-              "visible": true,
-              "warnings": [
-                {
-                  "matcher": "ltft16WeeksTest",
-                  "msgText": "Please include supporting information for why you are making a late application (less than 16 weeks notice) and why no suitable alternative start date is given (if applicable).",
-                  "conditionalField": "startDate"
-                }
-              ]
+              "visible": true
             }
           ]
         }

--- a/components/forms/ltft/ltft.json
+++ b/components/forms/ltft/ltft.json
@@ -76,6 +76,7 @@
       "pageName": "Start date",
       "importantTxtName": "ltftStartDateImportantText",
       "expanderLinkName": "ltft16WeeksNotice",
+      "gatedIf": "ltftLegacyStartDate",
       "sections": [
         {
           "sectionHeader": "Start date for change to your working hours",

--- a/components/forms/ltft/ltftValidationSchema.ts
+++ b/components/forms/ltft/ltftValidationSchema.ts
@@ -10,6 +10,10 @@ import { isDateWithin16WeeksOfFirstDate } from "../../../utilities/FormBuilderUt
 export const LtftVisaError =
   "Please select Yes or No for Skilled Worker visa status";
 export const ltftReasonsError = "At least one reason is required";
+export const ltftNoticeError =
+  "Please select Yes or No for whether you will provide a start date at least 16 weeks from today";
+export const ltftExceptionalReasonsError =
+  "Please give your exceptional reason(s) for not being able to give 16 weeks' notice to change your working hours";
 
 const emailValidation = yup
   .string()
@@ -45,7 +49,7 @@ const isOnOrBeforeProgrammeEnd = (
 
 const changeStartDateValidation = yup
   .date()
-  .typeError("Start Date is not a valid date")
+  .typeError("Please provide a valid Start Date")
   .required("Start Date is required")
   .test(
     "is-on-or-after-today",
@@ -65,24 +69,34 @@ const changeStartDateValidation = yup
     function (value) {
       return isOnOrBeforeProgrammeEnd(value, this.parent.pmId);
     }
-  );
-
-const altStartDateValidation = yup
-  .date()
-  .nullable()
-  .transform((value, originalValue) => (originalValue === "" ? null : value))
-  .typeError("Alternative start date is not a valid date")
-  .test(
-    "alt-at-least-16-weeks",
-    "Alternative start date must be at least 16 weeks from today",
-    value => !value || !isDateWithin16WeeksOfFirstDate(value)
   )
   .test(
-    "alt-before-programme-end",
-    "Alternative start date cannot be after the programme end date",
+    "is-at-least-16-weeks",
+    "Change cannot begin less than 16 weeks from today",
     function (value) {
-      return isOnOrBeforeProgrammeEnd(value, this.parent.pmId);
+      if (!value || this.parent.canGiveCompliantStartDate !== true) return true;
+      return !isDateWithin16WeeksOfFirstDate(value);
     }
+  );
+
+const exceptionalReasonsDateValidation = yup
+  .date()
+  .typeError("Please provide a valid date")
+  .required("Please provide the date you would like this change to begin")
+  .test(
+    "exceptional-on-or-after-today",
+    "The date cannot be before today",
+    function (value) {
+      if (!value) return true;
+      const exceptionalDate = dayjs(value).startOf("day");
+      const today = dayjs().startOf("day");
+      return exceptionalDate.isSame(today) || exceptionalDate.isAfter(today);
+    }
+  )
+  .test(
+    "exceptional-less-than-16-weeks",
+    "The date must be less than 16 weeks from today",
+    value => !value || isDateWithin16WeeksOfFirstDate(value)
   );
 
 const DiscussionsValidationSchema = yup.object().shape({
@@ -130,8 +144,17 @@ export const ltftValidationSchema = yup.object({
     .required(ltftReasonsError)
     .nullable(),
   personalDetails: personalDetailsDtoValidationSchema,
+  canGiveCompliantStartDate: yup
+    .boolean()
+    .typeError(ltftNoticeError)
+    .required(ltftNoticeError)
+    .nullable(),
   startDate: changeStartDateValidation,
-  altStartDate: altStartDateValidation,
+  exceptionalReasons: yup
+    .string()
+    .required(ltftExceptionalReasonsError)
+    .nullable(),
+  exceptionalReasonsDate: exceptionalReasonsDateValidation,
   skilledWorkerVisaHolder: yup
     .boolean()
     .typeError(LtftVisaError)

--- a/cypress/component/forms/ltft/LtftForm.cy.tsx
+++ b/cypress/component/forms/ltft/LtftForm.cy.tsx
@@ -2,11 +2,7 @@ import store from "../../../../redux/store/store";
 import { mount } from "cypress/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import {
-  mockLtftNewFormObj,
-  mockLtftSubmittedFormObj,
-  mockLtftUnsubmittedFormObj
-} from "../../../../mock-data/mock-ltft-data";
+import { mockLtftNewFormObj } from "../../../../mock-data/mock-ltft-data";
 import { LtftForm } from "../../../../components/forms/ltft/LtftForm";
 import { updatedLtft } from "../../../../redux/slices/ltftSlice";
 import {
@@ -18,12 +14,15 @@ import { LtftObjNew } from "../../../../models/LtftTypes";
 import { makeValidProgrammeOptions } from "../../../../utilities/ltftUtilities";
 import {
   mockProgrammeMemberships,
-  mockTraineeProfile
+  mockTraineeProfile,
+  mockUserFeaturesLtftPilot
 } from "../../../../mock-data/trainee-profile";
 import { updatedUserFeatures } from "../../../../redux/slices/userSlice";
 import { updatedTraineeProfileData } from "../../../../redux/slices/traineeProfileSlice";
 import dayjs from "dayjs";
 import {
+  ltftExceptionalReasonsError,
+  ltftNoticeError,
   ltftReasonsError,
   LtftVisaError
 } from "../../../../components/forms/ltft/ltftValidationSchema";
@@ -32,16 +31,7 @@ const mountLtftWithMockData = (mockLtftObj: LtftObjNew) => {
   store.dispatch(updatedLtft(mockLtftObj));
   store.dispatch(updatedTraineeProfileData(mockTraineeProfile));
   const qualifyingProgrammes = ["7ab1aae3-83c2-4bb6-b1f3-99146e79b362"];
-  store.dispatch(
-    updatedUserFeatures({
-      forms: {
-        ltft: {
-          qualifyingProgrammes: qualifyingProgrammes,
-          enabled: true
-        }
-      }
-    } as any)
-  );
+  store.dispatch(updatedUserFeatures(mockUserFeaturesLtftPilot));
 
   const pmOptions = makeValidProgrammeOptions(
     mockProgrammeMemberships,
@@ -88,7 +78,8 @@ describe("LtftForm - draft", () => {
     cy.get('[data-cy="wteBeforeChange-hint"]').should("exist");
     cy.get('[data-cy="wteBeforeChange-input"]').type("1.a");
     cy.get('[data-cy="wteBeforeChange-input"]').should("have.value", "1");
-    cy.get('[data-cy="wteBeforeChange-input"]').clear().type("1000");
+    cy.get('[data-cy="wteBeforeChange-input"]').clear();
+    cy.get('[data-cy="wteBeforeChange-input"]').type("1000");
     cy.get('[data-cy="wteBeforeChange-input"]').should("have.value", "100");
     cy.navNext();
 
@@ -119,27 +110,48 @@ describe("LtftForm - draft", () => {
     cy.get("#wte-error").contains(
       "Your proposed change must be different from the percentage you gave in Part 2"
     );
-    cy.get('[data-cy="wte-input"]').clear().type("80");
+    cy.get('[data-cy="wte-input"]').clear();
+    cy.get('[data-cy="wte-input"]').type("80");
     cy.get("#wte-error").should("not.exist");
     cy.get(".field-warning-container").should("not.exist");
     cy.navNext();
 
-    // part 4
+    // part 4 - Start date (Yes / compliant path)
     cy.get("h3").contains("Part 4 of 10 - Start date");
+    cy.get('[data-cy="startDate-input"]').should("not.exist");
+    cy.get('[data-cy="exceptionalReasons-text-area-input"]').should(
+      "not.exist"
+    );
+    cy.get('[data-cy="exceptionalReasonsDate-input"]').should("not.exist");
+    cy.navNext();
+    cy.get("#canGiveCompliantStartDate-error").contains(ltftNoticeError);
+    cy.get('[data-cy="canGiveCompliantStartDate-Yes-input"]').check();
+    cy.get("#canGiveCompliantStartDate-error").should("not.exist");
+    cy.get('[data-cy="earliestStartDateInfo-info"]')
+      .should("be.visible")
+      .contains("16 weeks from today");
+    cy.get('[data-cy="exceptionalReasons-text-area-input"]').should(
+      "not.exist"
+    );
+    cy.get('[data-cy="exceptionalReasonsDate-input"]').should("not.exist");
+    cy.navNext(true);
+    cy.get("#startDate-error").contains("Please provide a valid Start Date");
     const dateWithin16WeeksOfToday = dayjs()
       .startOf("day")
       .add(16, "weeks")
       .subtract(1, "day")
       .format("YYYY-MM-DD");
-    cy.clearAndType('[data-cy="startDate-input"]', "1000-05-01");
-    cy.get("#startDate-error").contains("Change cannot begin before today");
     cy.clearAndType('[data-cy="startDate-input"]', dateWithin16WeeksOfToday);
-    cy.get(".field-warning-msg").contains(
-      "Warning: The start date you have chosen (within 16 weeks) is classed as a late application and will be considered on an exceptional basis. You will be prompted in Part 6 to provide your reason(s) for this."
+    cy.get("#startDate-error").contains(
+      "Change cannot begin less than 16 weeks from today"
     );
+    const compliantStartDate = dayjs()
+      .startOf("day")
+      .add(16, "weeks")
+      .format("YYYY-MM-DD");
+    cy.clearAndType('[data-cy="startDate-input"]', compliantStartDate);
     cy.get("#startDate-error").should("not.exist");
-    cy.get('[data-cy="altStartDate-input"]').should("be.visible");
-    cy.navNext();
+    cy.navNext(true);
 
     // Part 5
     cy.get("h3").contains("Part 5 of 10 - Reason(s) for applying");
@@ -149,7 +161,7 @@ describe("LtftForm - draft", () => {
     cy.get(".nhsuk-card--warning .nhsuk-card__content > p").contains(
       ltftReasonsText1
     );
-    cy.navNext();
+    cy.navNext(true);
     cy.get("#reasonsSelected-error").contains(ltftReasonsError);
     cy.get(".nhsuk-card__heading").contains("Reason(s) for applying");
     cy.get('[data-cy="reasonsSelected-label"]').should("exist");
@@ -164,17 +176,14 @@ describe("LtftForm - draft", () => {
 
     // Part 6
     cy.get("h3").contains("Part 6 of 10 - Supporting information");
-    cy.navNext();
+    cy.navNext(true);
     cy.get("#supportingInformation-error").contains(
       "Supporting information is required"
     );
     cy.get('[data-cy="supportingInformation-text-area-input"]').type(
       "This is my supporting information"
     );
-    cy.get(".field-warning-msg").contains(
-      "Please include supporting information for why you are making a late application (less than 16 weeks notice) and why no suitable alternative start date is given (if applicable)."
-    );
-    cy.navNext();
+    cy.navNext(true);
 
     // Part 7
     cy.get("h3").contains("Part 7 of 10 - Pre-approver discussions");
@@ -189,7 +198,7 @@ describe("LtftForm - draft", () => {
       ".nhsuk-card--warning .nhsuk-card__content > :nth-child(4)"
     ).contains("For information on Professional support contact");
     cy.get('[data-cy="tpdName-label"]').contains("Pre-approver name");
-    cy.navNext();
+    cy.navNext(true);
     cy.get("#tpdName-error").contains("Pre-approver name is required");
     cy.get('[data-cy="tpdName-input"]').type("Dr. TPD");
     cy.get("#tpdName-error").should("not.exist");
@@ -203,7 +212,7 @@ describe("LtftForm - draft", () => {
     cy.get('[data-cy="navNext"]').should("have.class", "disabled-link");
     cy.get('[data-cy="tpdEmail-label"]').contains("Pre-approver email");
     cy.get('[data-cy="tpdEmail-input"]').type("tpd@e.mail");
-    cy.navNext();
+    cy.navNext(true);
 
     // Part 8
     cy.get("h3").contains("Part 8 of 10 - Other discussions");
@@ -211,7 +220,7 @@ describe("LtftForm - draft", () => {
     cy.clearAndType('[data-cy="name-input"]', "Mr AN Other");
     cy.clearAndType('[data-cy="email-input"]', "mr@an.other");
     cy.clickSelect('[data-cy="role"]');
-    cy.navNext();
+    cy.navNext(true);
 
     // part 9
     cy.get("h3").contains("Part 9 of 10 - Skilled Worker visa status");
@@ -231,101 +240,123 @@ describe("LtftForm - draft", () => {
   });
 });
 
-describe("LtftForm - alternative start date validation", () => {
-  const navigateToStartDateWithAltVisible = () => {
+describe("LtftForm - start date exceptions (No / exceptional path)", () => {
+  const navigateToStartDatePage = () => {
     cy.clickSelect('[data-cy="pmId"]');
     cy.navNext();
     cy.clearAndType('[data-cy="wteBeforeChange-input"]', "100");
     cy.navNext();
     cy.clearAndType('[data-cy="wte-input"]', "80");
     cy.navNext();
-    // Part 4 - Start date
     cy.get("h3").contains("Part 4 of 10 - Start date");
-    const startDateWithin16Weeks = dayjs()
-      .startOf("day")
-      .add(16, "weeks")
-      .subtract(1, "day")
-      .format("YYYY-MM-DD");
-    cy.clearAndType('[data-cy="startDate-input"]', startDateWithin16Weeks);
-    cy.get('[data-cy="altStartDate-input"]').should("be.visible");
   };
 
-  it("errors when the alternative start date is less than 16 weeks from today (alt-at-least-16-weeks)", () => {
+  it("does not capture a start date (it is stamped at submission) and requires exceptional reasons plus a date when 16 weeks' notice cannot be given", () => {
     mountLtftWithMockData(mockLtftNewFormObj);
-    navigateToStartDateWithAltVisible();
-    const altDateWithin16Weeks = dayjs()
+    navigateToStartDatePage();
+    cy.get('[data-cy="canGiveCompliantStartDate-No-input"]').check();
+    cy.get('[data-cy="startDate-input"]').should("not.exist"); //Note: stamped at submission
+    cy.get('[data-cy="earliestStartDateInfo-info"]').should("not.exist");
+    cy.get('[data-cy="startDateInfo-info"]')
+      .should("be.visible")
+      .contains("16 weeks from today");
+    cy.get('[data-cy="exceptionalReasons-text-area-input"]').should(
+      "be.visible"
+    );
+    cy.get('[data-cy="exceptionalReasonsDate-input"]').should("be.visible");
+    cy.navNext(true);
+    cy.get("#exceptionalReasons-error").contains(ltftExceptionalReasonsError);
+    cy.get("#exceptionalReasonsDate-error").contains(
+      "Please provide a valid date"
+    );
+    cy.get('[data-cy="exceptionalReasons-text-area-input"]').type(
+      "My exceptional reason"
+    );
+    cy.get("#exceptionalReasons-error").should("not.exist");
+
+    const yesterday = dayjs()
       .startOf("day")
-      .add(16, "weeks")
       .subtract(1, "day")
       .format("YYYY-MM-DD");
-    cy.clearAndType('[data-cy="altStartDate-input"]', altDateWithin16Weeks);
-    cy.get("#altStartDate-error").contains(
-      "Alternative start date must be at least 16 weeks from today"
+    cy.clearAndType('[data-cy="exceptionalReasonsDate-input"]', yesterday);
+    cy.get("#exceptionalReasonsDate-error").contains(
+      "The date cannot be before today"
     );
-    const altDateExactly16Weeks = dayjs()
+    const sixteenWeeks = dayjs()
       .startOf("day")
       .add(16, "weeks")
       .format("YYYY-MM-DD");
-    cy.clearAndType('[data-cy="altStartDate-input"]', altDateExactly16Weeks);
-    cy.get("#altStartDate-error").should("not.exist");
-  });
-
-  it("errors when the alternative start date is after the programme end date (alt-before-programme-end)", () => {
-    mountLtftWithMockData(mockLtftNewFormObj);
-    navigateToStartDateWithAltVisible();
-    const altDateAfterProgrammeEnd = dayjs()
-      .startOf("day")
-      .add(3, "years")
-      .add(1, "day")
-      .format("YYYY-MM-DD");
-    cy.clearAndType('[data-cy="altStartDate-input"]', altDateAfterProgrammeEnd);
-    cy.get("#altStartDate-error").contains(
-      "Alternative start date cannot be after the programme end date"
+    cy.clearAndType('[data-cy="exceptionalReasonsDate-input"]', sixteenWeeks);
+    cy.get("#exceptionalReasonsDate-error").contains(
+      "The date must be less than 16 weeks from today"
     );
 
-    const altDateBeforeProgrammeEnd = dayjs()
+    const withinSixteenWeeks = dayjs()
       .startOf("day")
-      .add(16, "weeks")
+      .add(8, "weeks")
       .format("YYYY-MM-DD");
     cy.clearAndType(
-      '[data-cy="altStartDate-input"]',
-      altDateBeforeProgrammeEnd
+      '[data-cy="exceptionalReasonsDate-input"]',
+      withinSixteenWeeks
     );
-    cy.get("#altStartDate-error").should("not.exist");
+    cy.get("#exceptionalReasonsDate-error").should("not.exist");
+    cy.navNext();
+    cy.get("h3").contains("Part 5 of 10 - Reason(s) for applying");
   });
-});
 
-describe("LtftForm - submitted", () => {
-  it("should render status details section", () => {
-    mountLtftWithMockData(mockLtftSubmittedFormObj);
-    cy.get('[data-cy="SUBMITTED-header"]')
-      .should("exist")
-      .contains("Submitted application");
-    cy.get('[data-cy="ltftName"]').contains("my submitted ltft application");
-    cy.get('[data-cy="ltftCreated"]').should("exist");
-    cy.get('[data-cy="ltftModified"]').should("exist");
-    cy.get('[data-cy="ltftRef"]').contains("ltft_47165_001");
-    cy.get('[data-cy="progress-header"] > h3').contains(
-      "Part 1 of 10 - Your Programme"
+  it("switches between the compliant and exceptional fields as the notice answer changes", () => {
+    mountLtftWithMockData(mockLtftNewFormObj);
+    navigateToStartDatePage();
+    cy.get('[data-cy="canGiveCompliantStartDate-No-input"]').check();
+    cy.get('[data-cy="exceptionalReasons-text-area-input"]').should(
+      "be.visible"
     );
+    cy.get('[data-cy="exceptionalReasonsDate-input"]').should("be.visible");
+    cy.get('[data-cy="startDate-input"]').should("not.exist");
+    cy.get('[data-cy="canGiveCompliantStartDate-Yes-input"]').check();
+    cy.get('[data-cy="startDate-input"]')
+      .should("be.visible")
+      .and("not.have.attr", "readonly");
+    cy.get('[data-cy="exceptionalReasons-text-area-input"]').should(
+      "not.exist"
+    );
+    cy.get('[data-cy="exceptionalReasonsDate-input"]').should("not.exist");
   });
-});
 
-describe("LtftForm - unsubmitted", () => {
-  it("should render status details section", () => {
-    mountLtftWithMockData(mockLtftUnsubmittedFormObj);
-    cy.get('[data-cy="UNSUBMITTED-header"]')
-      .should("exist")
-      .contains("Unsubmitted application");
-    cy.get('[data-cy="ltftName"]').contains("my Unsubmitted LTFT");
-    cy.get('[data-cy="ltftCreated"]').should("exist");
-    cy.get('[data-cy="ltftModified"]').should("exist");
-    cy.get('[data-cy="ltftModifiedBy"]').contains("TIS Admin");
-    cy.get('[data-cy="ltfReason"]').contains("Change WTE percentage");
-    cy.get('[data-cy="ltftMessage"]').contains("status reason message");
-    cy.get('[data-cy="ltftRef"]').contains("ltft_47165_001");
-    cy.get('[data-cy="progress-header"] > h3').contains(
-      "Part 1 of 10 - Your Programme"
+  it("clears the previous path's answers when the 'can give...' answer is changed, so stale data from the other path is not carried forward", () => {
+    mountLtftWithMockData(mockLtftNewFormObj);
+    navigateToStartDatePage();
+
+    cy.get('[data-cy="canGiveCompliantStartDate-No-input"]').check();
+    cy.get('[data-cy="exceptionalReasons-text-area-input"]').type(
+      "My exceptional reason"
     );
+    const withinSixteenWeeks = dayjs()
+      .startOf("day")
+      .add(8, "weeks")
+      .format("YYYY-MM-DD");
+    cy.clearAndType(
+      '[data-cy="exceptionalReasonsDate-input"]',
+      withinSixteenWeeks
+    );
+
+    // Switch to Yes
+    cy.get('[data-cy="canGiveCompliantStartDate-Yes-input"]').check();
+    const compliantStartDate = dayjs()
+      .startOf("day")
+      .add(16, "weeks")
+      .format("YYYY-MM-DD");
+    cy.clearAndType('[data-cy="startDate-input"]', compliantStartDate);
+
+    // Back to No
+    cy.get('[data-cy="canGiveCompliantStartDate-No-input"]').check();
+    cy.get('[data-cy="exceptionalReasons-text-area-input"]').should(
+      "have.value",
+      ""
+    );
+    cy.get('[data-cy="exceptionalReasonsDate-input"]').should("have.value", "");
+
+    cy.get('[data-cy="canGiveCompliantStartDate-Yes-input"]').check();
+    cy.get('[data-cy="startDate-input"]').should("have.value", "");
   });
 });

--- a/cypress/component/forms/ltft/LtftForm.cy.tsx
+++ b/cypress/component/forms/ltft/LtftForm.cy.tsx
@@ -2,9 +2,15 @@ import store from "../../../../redux/store/store";
 import { mount } from "cypress/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { mockLtftNewFormObj } from "../../../../mock-data/mock-ltft-data";
+import {
+  mockLtftNewFormObj,
+  mockLtftUnsubmittedFormObj
+} from "../../../../mock-data/mock-ltft-data";
 import { LtftForm } from "../../../../components/forms/ltft/LtftForm";
-import { updatedLtft } from "../../../../redux/slices/ltftSlice";
+import {
+  updatedEditPageNumberLtft,
+  updatedLtft
+} from "../../../../redux/slices/ltftSlice";
 import {
   ltftDiscussionText2,
   ltftReasonsText1,
@@ -26,6 +32,11 @@ import {
   ltftReasonsError,
   LtftVisaError
 } from "../../../../components/forms/ltft/ltftValidationSchema";
+import {
+  ltftLegacyStartDateGateCancelBtn,
+  ltftLegacyStartDateGateLabel,
+  ltftLegacyStartDateGateSkipHint
+} from "../../../../utilities/Constants";
 
 const mountLtftWithMockData = (mockLtftObj: LtftObjNew) => {
   store.dispatch(updatedLtft(mockLtftObj));
@@ -358,5 +369,134 @@ describe("LtftForm - start date exceptions (No / exceptional path)", () => {
 
     cy.get('[data-cy="canGiveCompliantStartDate-Yes-input"]').check();
     cy.get('[data-cy="startDate-input"]').should("have.value", "");
+  });
+});
+
+describe("LtftForm - legacy Start date page gate", () => {
+  const legacyStartDate = dayjs().add(20, "week").format("YYYY-MM-DD");
+  const legacyAltStartDate = dayjs().add(30, "week").format("YYYY-MM-DD");
+
+  const mockLegacyUnsubmitted: LtftObjNew = {
+    ...mockLtftUnsubmittedFormObj,
+    canGiveCompliantStartDate: null,
+    startDate: legacyStartDate,
+    altStartDate: legacyAltStartDate,
+    exceptionalReasons: null,
+    exceptionalReasonsDate: null
+  };
+
+  const mountAtPageBeforeStartDate = (mockLtftObj: LtftObjNew) => {
+    store.dispatch(updatedEditPageNumberLtft(2));
+    mountLtftWithMockData(mockLtftObj);
+    cy.get("h3").contains(
+      "Part 3 of 10 - Proposed change to your working hours"
+    );
+  };
+
+  it("warns instead of entering the Start date page when navigating forward into it", () => {
+    mountAtPageBeforeStartDate(mockLegacyUnsubmitted);
+    cy.navNext();
+
+    cy.get('[data-cy="pageGateWarning"]').should("exist");
+    cy.get('[data-cy="pageGateLabel"]').should(
+      "contain.text",
+      ltftLegacyStartDateGateLabel
+    );
+    cy.get('[data-cy="pageGateText"]').should(
+      "contain.text",
+      "your start date information will be reset"
+    );
+    cy.get('[data-cy="gateSkipHint"]').should(
+      "contain.text",
+      ltftLegacyStartDateGateSkipHint
+    );
+    cy.get('[data-cy="gateSkipBtn"]').should(
+      "have.attr",
+      "aria-describedby",
+      "gateSkipHint"
+    );
+    cy.get("h3").contains(
+      "Part 3 of 10 - Proposed change to your working hours"
+    );
+  });
+
+  it("Proceed clears the legacy answers, opens the Start date page, and does not warn again", () => {
+    mountAtPageBeforeStartDate(mockLegacyUnsubmitted);
+    cy.navNext();
+    cy.get('[data-cy="gateProceedBtn"]').click();
+
+    cy.get('[data-cy="pageGateWarning"]').should("not.exist");
+    cy.get("h3").contains("Part 4 of 10 - Start date");
+    cy.get('[data-cy="canGiveCompliantStartDate-Yes-input"]').should(
+      "not.be.checked"
+    );
+    cy.get('[data-cy="canGiveCompliantStartDate-No-input"]').should(
+      "not.be.checked"
+    );
+
+    cy.get('[data-cy="navPrevious"]').click();
+    cy.get("h3").contains(
+      "Part 3 of 10 - Proposed change to your working hours"
+    );
+    cy.navNext();
+    cy.get('[data-cy="pageGateWarning"]').should("not.exist");
+    cy.get("h3").contains("Part 4 of 10 - Start date");
+  });
+
+  it("Skip steps over the Start date page and keeps the legacy answers, so the gate still fires on the way back", () => {
+    mountAtPageBeforeStartDate(mockLegacyUnsubmitted);
+    cy.navNext();
+    cy.get('[data-cy="gateSkipBtn"]').click();
+
+    cy.get('[data-cy="pageGateWarning"]').should("not.exist");
+    cy.get("h3").contains("Part 5 of 10 - Reason(s) for applying");
+
+    cy.get('[data-cy="navPrevious"]').click();
+    cy.get('[data-cy="pageGateWarning"]').should("exist");
+    cy.get("h3").contains("Part 5 of 10 - Reason(s) for applying");
+  });
+
+  it("Skip steps back over the Start date page when travelling backwards", () => {
+    store.dispatch(updatedEditPageNumberLtft(4));
+    mountLtftWithMockData(mockLegacyUnsubmitted);
+    cy.get("h3").contains("Part 5 of 10 - Reason(s) for applying");
+
+    cy.get('[data-cy="navPrevious"]').click();
+    cy.get('[data-cy="pageGateWarning"]').should("exist");
+    cy.get('[data-cy="gateSkipBtn"]').click();
+
+    cy.get('[data-cy="pageGateWarning"]').should("not.exist");
+    cy.get("h3").contains(
+      "Part 3 of 10 - Proposed change to your working hours"
+    );
+  });
+
+  it("the cancel option leaves the trainee where they are with nothing cleared", () => {
+    mountAtPageBeforeStartDate(mockLegacyUnsubmitted);
+    cy.navNext();
+    cy.get('[data-cy="modal-cancel-btn"]')
+      .should("contain.text", ltftLegacyStartDateGateCancelBtn)
+      .click();
+
+    cy.get('[data-cy="pageGateWarning"]').should("not.exist");
+    cy.get("h3").contains(
+      "Part 3 of 10 - Proposed change to your working hours"
+    );
+
+    cy.navNext();
+    cy.get('[data-cy="pageGateWarning"]').should("exist");
+  });
+
+  it("does not gate a new form that simply has not reached the Start date page yet", () => {
+    mountAtPageBeforeStartDate({
+      ...mockLtftNewFormObj,
+      pmId: mockLtftUnsubmittedFormObj.pmId,
+      wteBeforeChange: 100,
+      wte: 80
+    });
+    cy.navNext();
+
+    cy.get('[data-cy="pageGateWarning"]').should("not.exist");
+    cy.get("h3").contains("Part 4 of 10 - Start date");
   });
 });

--- a/cypress/component/forms/ltft/LtftFormView.cy.tsx
+++ b/cypress/component/forms/ltft/LtftFormView.cy.tsx
@@ -598,3 +598,79 @@ describe("LTFT Form View - legacy: read-only display & Update migration", () => 
     cy.get("h3").contains("Part 5 of 10 - Reason(s) for applying");
   });
 });
+
+describe("LTFT Form View - incomplete Start date section", () => {
+  const makeSectionReset = (base: LtftObjNew): LtftObjNew => ({
+    ...base,
+    canGiveCompliantStartDate: null,
+    startDate: null,
+    altStartDate: null,
+    exceptionalReasons: null,
+    exceptionalReasonsDate: null
+  });
+
+  beforeEach(() => {
+    store.dispatch(updatedLtftStatus("idle"));
+    store.dispatch(updatedCanEditLtft(true));
+  });
+
+  it("UNSUBMITTED: shows the incomplete notice, not the legacy one, and blocks re-submission", () => {
+    mountLtftViewWithMockData(makeSectionReset(mockLtftUnsubmittedFormObj));
+
+    cy.get('[data-cy="legacyStartDateNote"]').should("not.exist");
+    cy.get('[data-cy="incompleteStartDateNote"]')
+      .should("exist")
+      .and("contain.text", "The start date section is incomplete");
+    cy.get('[data-cy="completeStartDateSection"]').should("exist");
+
+    cy.get('[data-cy="informationIsCorrect"]').check();
+    cy.get('[data-cy="notGuaranteed"]').check();
+    cy.get('[data-cy="name"]').clear();
+    cy.get('[data-cy="name"]').type("my re-submitted ltft application");
+    cy.get('[data-cy="BtnSubmit"]').should("have.attr", "disabled");
+  });
+
+  it("UNSUBMITTED: blocks re-submission when the Yes path was answered but no start date was given", () => {
+    mountLtftViewWithMockData({
+      ...makeSectionReset(mockLtftUnsubmittedFormObj),
+      canGiveCompliantStartDate: true
+    });
+
+    cy.get('[data-cy="incompleteStartDateNote"]').should("exist");
+    cy.get('[data-cy="informationIsCorrect"]').check();
+    cy.get('[data-cy="notGuaranteed"]').check();
+    cy.get('[data-cy="name"]').clear();
+    cy.get('[data-cy="name"]').type("my re-submitted ltft application");
+    cy.get('[data-cy="BtnSubmit"]').should("have.attr", "disabled");
+  });
+
+  it("UNSUBMITTED legacy: still allows re-submission of untouched pre-rework start date details", () => {
+    mountLtftViewWithMockData({
+      ...mockLtftUnsubmittedFormObj,
+      canGiveCompliantStartDate: null,
+      startDate: startDate,
+      altStartDate: dayjs().add(30, "week").format("YYYY-MM-DD"),
+      exceptionalReasons: null,
+      exceptionalReasonsDate: null
+    });
+
+    cy.get('[data-cy="legacyStartDateNote"]').should("exist");
+    cy.get('[data-cy="incompleteStartDateNote"]').should("not.exist");
+
+    cy.get('[data-cy="informationIsCorrect"]').check();
+    cy.get('[data-cy="notGuaranteed"]').check();
+    cy.get('[data-cy="name"]').clear();
+    cy.get('[data-cy="name"]').type("my re-submitted ltft application");
+    cy.get('[data-cy="BtnSubmit"]').should("not.have.attr", "disabled");
+  });
+
+  it("SUBMITTED (read-only): shows neither notice and offers no submit action", () => {
+    store.dispatch(updatedLtftStatus("succeeded"));
+    store.dispatch(updatedCanEditLtft(false));
+    mountLtftViewWithMockData(makeSectionReset(mockLtftSubmittedFormObj));
+
+    cy.get('[data-cy="legacyStartDateNote"]').should("not.exist");
+    cy.get('[data-cy="incompleteStartDateNote"]').should("not.exist");
+    cy.get('[data-cy="BtnSubmit"]').should("not.exist");
+  });
+});

--- a/cypress/component/forms/ltft/LtftFormView.cy.tsx
+++ b/cypress/component/forms/ltft/LtftFormView.cy.tsx
@@ -88,9 +88,12 @@ describe("LTFT Form View - new flow: Yes path (>= 16 weeks' notice)", () => {
         ...mockLtftDraftFirstSuccessSaveResponseDto,
         change: {
           ...mockLtftDraftFirstSuccessSaveResponseDto.change,
-          isExceptional: false,
           startDate: draftStartDate,
           cctDate: new Date()
+        },
+        exceptionalReasons: {
+          ...mockLtftDraftFirstSuccessSaveResponseDto.exceptionalReasons,
+          exceptional: false
         }
       }
     };
@@ -316,9 +319,12 @@ describe("LTFT Form View - new flow: No path (exceptional)", () => {
         ...mockLtftDraftFirstSuccessSaveResponseDto,
         change: {
           ...mockLtftDraftFirstSuccessSaveResponseDto.change,
-          isExceptional: true,
           startDate: null,
           cctDate: new Date()
+        },
+        exceptionalReasons: {
+          ...mockLtftDraftFirstSuccessSaveResponseDto.exceptionalReasons,
+          exceptional: true
         }
       }
     };

--- a/cypress/component/forms/ltft/LtftFormView.cy.tsx
+++ b/cypress/component/forms/ltft/LtftFormView.cy.tsx
@@ -1,14 +1,18 @@
 import { mount } from "cypress/react";
 import { Provider } from "react-redux";
-import { Router } from "react-router-dom";
+import { Route, Router, Switch } from "react-router-dom";
 import store from "../../../../redux/store/store";
 import history from "../../../../components/navigation/history";
 import {
   updatedCanEditLtft,
+  updatedEditPageNumberLtft,
   updatedLtft,
   updatedLtftStatus
 } from "../../../../redux/slices/ltftSlice";
 import { LtftFormView } from "../../../../components/forms/ltft/LtftFormView";
+import { LtftForm } from "../../../../components/forms/ltft/LtftForm";
+import { makeValidProgrammeOptions } from "../../../../utilities/ltftUtilities";
+import { updatedUserFeatures } from "../../../../redux/slices/userSlice";
 import { LtftObjNew } from "../../../../models/LtftTypes";
 import {
   mockLtftSubmittedFormObj,
@@ -17,12 +21,18 @@ import {
   wte,
   wteBeforeChange,
   startDate,
+  compliantStartDate,
+  exceptionalRequestedDate,
   mockLtftDraftFirstSuccessSaveResponseDto
 } from "../../../../mock-data/mock-ltft-data";
 import dayjs from "dayjs";
 import { FormsService } from "../../../../services/FormsService";
 import { updatedTraineeProfileData } from "../../../../redux/slices/traineeProfileSlice";
-import { mockTraineeProfile } from "../../../../mock-data/trainee-profile";
+import {
+  mockProgrammeMemberships,
+  mockTraineeProfile,
+  mockUserFeaturesLtftPilot
+} from "../../../../mock-data/trainee-profile";
 
 const mountLtftViewWithMockData = (mockLtftObj: LtftObjNew) => {
   store.dispatch(updatedLtft(mockLtftObj));
@@ -37,7 +47,22 @@ const mountLtftViewWithMockData = (mockLtftObj: LtftObjNew) => {
   );
 };
 
-describe("LTFT Form View - editable (DRAFT)", () => {
+// A (never-submitted) DRAFT
+const draftStatus: LtftObjNew["status"] = {
+  current: {
+    state: "DRAFT",
+    detail: { reason: null, message: null },
+    modifiedBy: { name: null, email: null, role: "TRAINEE" },
+    timestamp: "2026-01-14T15:45:49.952Z",
+    revision: 0
+  },
+  history: []
+};
+
+const ddmmyyyy = (date: string | Date) => dayjs(date).format("DD/MM/YYYY");
+
+describe("LTFT Form View - new flow: Yes path (>= 16 weeks' notice)", () => {
+  const draftStartDate = dayjs().add(20, "week").format("YYYY-MM-DD");
   before(() => {
     store.dispatch(updatedLtftStatus("idle"));
     store.dispatch(updatedCanEditLtft(true));
@@ -45,36 +70,26 @@ describe("LTFT Form View - editable (DRAFT)", () => {
       ...mockLtftSubmittedFormObj,
       formRef: "",
       name: "",
+      canGiveCompliantStartDate: true,
+      startDate: draftStartDate,
+      exceptionalReasons: null,
+      exceptionalReasonsDate: null,
       declarations: {
         discussedWithTpd: true,
         informationIsCorrect: null,
         notGuaranteed: null
       },
-      status: {
-        current: {
-          state: "DRAFT",
-          detail: {
-            reason: null,
-            message: null
-          },
-          modifiedBy: {
-            name: null,
-            email: null,
-            role: "TRAINEE"
-          },
-          timestamp: "2026-01-14T15:45:49.952Z",
-          revision: 0
-        },
-        history: []
-      }
+      status: draftStatus
     });
   });
-  it("should render LTFT form in edit mode", () => {
+  it("renders the review page with the captured startDate and submits", () => {
     const baseResponse = {
       data: {
         ...mockLtftDraftFirstSuccessSaveResponseDto,
         change: {
           ...mockLtftDraftFirstSuccessSaveResponseDto.change,
+          isExceptional: false,
+          startDate: draftStartDate,
           cctDate: new Date()
         }
       }
@@ -120,10 +135,11 @@ describe("LTFT Form View - editable (DRAFT)", () => {
     ).should("exist");
     cy.get('[data-cy="wte-value"]').should("include.text", wte.toString());
     cy.get('[data-cy="edit-wte"]').should("exist");
+
     cy.get('[data-cy="pageHeader-Start date"]').should("exist");
     cy.get('[data-cy="startDate-value"]').should(
       "include.text",
-      dayjs(startDate).format("DD/MM/YYYY")
+      ddmmyyyy(draftStartDate)
     );
     cy.get('[data-cy="edit-startDate"]').should("exist");
 
@@ -154,7 +170,7 @@ describe("LTFT Form View - editable (DRAFT)", () => {
     cy.get('[data-cy="edit-gdcNumber"]').should("exist");
     cy.get('[data-cy="edit-publicHealthNumber"]').should("exist");
 
-    // change box
+    // change summary box
     cy.get('[data-cy="completionDateChangeHeading"]').should("exist");
     cy.get('[data-cy="completionDateChangePmKey"]').should("exist");
     cy.get('[data-cy="completionDateChangePmValue"]').contains("Cardiology");
@@ -166,16 +182,14 @@ describe("LTFT Form View - editable (DRAFT)", () => {
     cy.get('[data-cy="completionDateChangeStartDateKey"]').should("exist");
     cy.get('[data-cy="completionDateChangeStartDateValue"]').should(
       "include.text",
-      dayjs(startDate).format("DD/MM/YYYY")
+      ddmmyyyy(draftStartDate)
     );
-    cy.get(".field-warning-msg").should("exist");
+    cy.get(".field-warning-msg").should("not.exist");
     cy.get(
       '[data-cy="completionDateChangeCurrentCompletionDateValue"]'
-    ).contains(
-      `${dayjs(pmEndDate).format("DD/MM/YYYY")} (Programme end date on TIS)`
-    );
+    ).contains(`${ddmmyyyy(pmEndDate)} (Programme end date on TIS)`);
 
-    // declarations
+    // declarations + submit flow
     cy.get('[data-cy="BtnSaveDraft"]').should("not.be.disabled");
     cy.get('[data-cy="startOverButton"]').should("not.be.disabled");
     cy.get('[data-cy="informationIsCorrect"]').check();
@@ -197,24 +211,79 @@ describe("LTFT Form View - editable (DRAFT)", () => {
     cy.get('[data-cy="modal-cancel-btn"]').should("exist");
     cy.get('[data-cy="submitBtn-Submit"]').should("exist").click();
     cy.get("@submitLtftStub").should("have.been.called");
+    cy.get("@submitLtftStub").should("have.been.calledWithMatch", {
+      change: { startDate: draftStartDate }
+    });
   });
 });
 
-describe("LTFT Form View - not editable (SUBMITTED)", () => {
-  before(() => {
+describe("LTFT Form View - new flow: No path (exceptional)", () => {
+  it("editable DRAFT before submission: shows the exceptional answers and the derived 16-week preview, with no stamped startDate yet", () => {
+    store.dispatch(updatedLtftStatus("idle"));
+    store.dispatch(updatedCanEditLtft(true));
+    // Note: No path, still draft: startDate has not been stamped yet.
+    mountLtftViewWithMockData({
+      ...mockLtftSubmittedFormObj,
+      canGiveCompliantStartDate: false,
+      startDate: null,
+      declarations: {
+        discussedWithTpd: true,
+        informationIsCorrect: null,
+        notGuaranteed: null
+      },
+      status: draftStatus
+    });
+
+    // Note: Start date section: the 'can give...' answer and the exceptional short-notice answers are shown; startDate is NOT (it holds no value yet).
+    cy.get('[data-cy="canGiveCompliantStartDate-value"]').should(
+      "include.text",
+      "No"
+    );
+    cy.get('[data-cy="exceptionalReasons-value"]').should(
+      "include.text",
+      "My exceptional reason"
+    );
+    cy.get('[data-cy="exceptionalReasonsDate-value"]').should(
+      "include.text",
+      ddmmyyyy(exceptionalRequestedDate)
+    );
+    cy.get('[data-cy="startDate-value"]').should("not.exist");
+
+    // Note: Summary card previews the compliant date that will be stamped at submit.
+    cy.get('[data-cy="completionDateChangeStartDateValue"]')
+      .should("include.text", ddmmyyyy(compliantStartDate))
+      .and("include.text", "will be set when you submit your application");
+    cy.get(".field-warning-msg").should("not.exist");
+  });
+
+  it("submitted (read-only): shows the stamped compliant startDate and the requested short-notice date.", () => {
     store.dispatch(updatedLtftStatus("succeeded"));
     store.dispatch(updatedCanEditLtft(false));
     mountLtftViewWithMockData(mockLtftSubmittedFormObj);
-  });
-  it("should render submitted LTFT form in read-only mode", () => {
+
     cy.get('[data-cy="backLink-to-back-to-ltft-home"]').should("exist");
     cy.get('[data-cy="savePdfBtn"]').should("not.be.disabled");
     cy.get('[data-cy="SUBMITTED-header"]').should("exist");
     cy.get('[data-cy="ltftName"]').contains("my submitted ltft application");
-    cy.get('[data-cy="pageHeader-Your Programme"]').should("exist");
-    cy.get('[data-cy="edit-pmId"]').should("not.exist");
+
+    // Note: The Start date section shows the stamped startDate (via showInViewWhenPopulated, since its input-form visibleIf hides it here)...
+    cy.get('[data-cy="startDate-value"]').should(
+      "include.text",
+      ddmmyyyy(compliantStartDate)
+    );
+    cy.get('[data-cy="exceptionalReasonsDate-value"]').should(
+      "include.text",
+      ddmmyyyy(exceptionalRequestedDate)
+    );
+    // ...and the summary card repeats the compliant start date.
     cy.get('[data-cy="completionDateChangeStartDateKey"]').should("exist");
+    cy.get('[data-cy="completionDateChangeStartDateValue"]').should(
+      "include.text",
+      ddmmyyyy(compliantStartDate)
+    );
     cy.get(".field-warning-msg").should("not.exist");
+
+    cy.get('[data-cy="edit-pmId"]').should("not.exist");
     cy.get('[data-cy="informationIsCorrect"]')
       .should("be.checked")
       .and("have.attr", "readonly");
@@ -224,51 +293,160 @@ describe("LTFT Form View - not editable (SUBMITTED)", () => {
     cy.get('[data-cy="BtnSaveDraft"]').should("not.exist");
     cy.get('[data-cy="startOverButton"]').should("not.exist");
   });
+
+  it("stamps the derived 16-week startDate onto the form when a No-path draft is submitted", () => {
+    store.dispatch(updatedLtftStatus("idle"));
+    store.dispatch(updatedCanEditLtft(true));
+    mountLtftViewWithMockData({
+      ...mockLtftSubmittedFormObj,
+      formRef: "",
+      name: "",
+      canGiveCompliantStartDate: false,
+      startDate: null,
+      declarations: {
+        discussedWithTpd: true,
+        informationIsCorrect: null,
+        notGuaranteed: null
+      },
+      status: draftStatus
+    });
+
+    const baseResponse = {
+      data: {
+        ...mockLtftDraftFirstSuccessSaveResponseDto,
+        change: {
+          ...mockLtftDraftFirstSuccessSaveResponseDto.change,
+          isExceptional: true,
+          startDate: null,
+          cctDate: new Date()
+        }
+      }
+    };
+    const updateLtftStub = cy
+      .stub(FormsService.prototype, "updateLtft")
+      .resolves(baseResponse);
+    const submitLtftStub = cy
+      .stub(FormsService.prototype, "submitLtft")
+      .resolves({
+        data: {
+          ...baseResponse.data,
+          status: {
+            ...mockLtftDraftFirstSuccessSaveResponseDto.status,
+            current: {
+              ...mockLtftDraftFirstSuccessSaveResponseDto.status.current,
+              state: "SUBMITTED"
+            }
+          }
+        }
+      });
+    cy.wrap(updateLtftStub).as("updateLtftStub");
+    cy.wrap(submitLtftStub).as("submitLtftStub");
+
+    cy.get('[data-cy="informationIsCorrect"]').check();
+    cy.get('[data-cy="notGuaranteed"]').check();
+    cy.get('[data-cy="name"]').type("my submitted ltft application");
+    cy.get('[data-cy="BtnSubmit').click();
+    // Note: pre-modal draft save persists the form as-is (startDate still null).
+    cy.get("@updateLtftStub").should("have.been.called");
+
+    // note: Modal confirm stamps the 16-week notice date as startDate.
+    cy.get('[data-cy="submitBtn-Submit"]').should("exist").click();
+    cy.get("@submitLtftStub").should("have.been.calledWithMatch", {
+      change: { startDate: compliantStartDate }
+    });
+  });
+
+  it("editable UNSUBMITTED with a stamped startDate: shows it read-only with no Change link", () => {
+    store.dispatch(updatedLtftStatus("idle"));
+    store.dispatch(updatedCanEditLtft(true));
+    // Note: No path, previously stamped, now editable again after an unsubmit.
+    mountLtftViewWithMockData(mockLtftUnsubmittedFormObj);
+
+    cy.get('[data-cy="startDate-value"]').should(
+      "include.text",
+      ddmmyyyy(compliantStartDate)
+    );
+    // Note: no Change link for startDate on No path cos deadend (not inputted by user)
+    cy.get('[data-cy="edit-startDate"]').should("not.exist");
+    // Note: the boolean question the trainee CAN edit still has its link
+    cy.get('[data-cy="edit-canGiveCompliantStartDate"]').should("exist");
+  });
+
+  it("editable UNSUBMITTED after the stamped startDate was cleared on edit: re-shows the derived 16-week preview", () => {
+    store.dispatch(updatedLtftStatus("idle"));
+    store.dispatch(updatedCanEditLtft(true));
+    mountLtftViewWithMockData({
+      ...mockLtftUnsubmittedFormObj,
+      canGiveCompliantStartDate: false,
+      startDate: null
+    });
+
+    // Note: No stamped date to show read-only...
+    cy.get('[data-cy="startDate-value"]').should("not.exist");
+    // ...and the summary card previews the compliant date that will be re-stamped on the next submit (via derivedStartDate).
+    cy.get('[data-cy="completionDateChangeStartDateValue"]')
+      .should("include.text", ddmmyyyy(compliantStartDate))
+      .and("include.text", "will be set when you submit your application");
+    cy.get(".field-warning-msg").should("not.exist");
+    cy.get('[data-cy="edit-canGiveCompliantStartDate"]').should("exist");
+  });
 });
 
-describe("LTFT Form View - start date warnings", () => {
-  const shortNoticeDate = dayjs().add(2, "week").toDate();
-  const longNoticeDate = dayjs().add(17, "week").toDate();
+describe("LTFT Form View - new flow: 'can give...' answer", () => {
+  it("SUBMITTED (read-only): shows the 'can give' answer and no legacy note", () => {
+    store.dispatch(updatedLtftStatus("succeeded"));
+    store.dispatch(updatedCanEditLtft(false));
+    mountLtftViewWithMockData(mockLtftSubmittedFormObj);
 
-  it("should show warning when start date is within 16 weeks and NO previous submission", () => {
-    store.dispatch(updatedLtftStatus("idle"));
-    store.dispatch(updatedCanEditLtft(true));
-    mountLtftViewWithMockData({
-      ...mockLtftUnsubmittedFormObj,
-      startDate: shortNoticeDate
-    });
-
-    cy.get('[data-cy="completionDateChangeStartDateValue"]').should("exist");
-    cy.get(".field-warning-msg")
-      .should("exist")
-      .and("contain.text", "classed as a late application");
+    cy.get('[data-cy="canGiveCompliantStartDate-value"]').should("exist");
+    cy.get('[data-cy="legacyStartDateNote"]').should("not.exist");
+    cy.get('[data-cy="updateLegacyStartDate"]').should("not.exist");
   });
 
-  it("should NOT show warning when start date is more than 16 weeks away and NO previous submission", () => {
+  it("UNSUBMITTED (editable): shows the 'can give' answer with an edit link, editable declarations and no legacy note", () => {
     store.dispatch(updatedLtftStatus("idle"));
     store.dispatch(updatedCanEditLtft(true));
-    mountLtftViewWithMockData({
-      ...mockLtftUnsubmittedFormObj,
-      startDate: longNoticeDate
-    });
+    mountLtftViewWithMockData(mockLtftUnsubmittedFormObj);
 
-    cy.get('[data-cy="completionDateChangeStartDateValue"]').should("exist");
-    cy.get(".field-warning-msg").should("not.exist");
+    cy.get('[data-cy="UNSUBMITTED-header"]').should("exist");
+    cy.get('[data-cy="ltftName"]').contains("my Unsubmitted LTFT");
+    cy.get('[data-cy="pageHeader-Your Programme"]').should("exist");
+    cy.get('[data-cy="edit-pmId"]').should("exist");
+
+    cy.get('[data-cy="canGiveCompliantStartDate-value"]').should("exist");
+    cy.get('[data-cy="edit-canGiveCompliantStartDate"]').should("exist");
+    cy.get('[data-cy="legacyStartDateNote"]').should("not.exist");
+
+    cy.get('[data-cy="informationIsCorrect"]')
+      .should("not.be.checked")
+      .and("not.have.attr", "readonly");
+    cy.get('[data-cy="notGuaranteed"]')
+      .should("not.be.checked")
+      .and("not.have.attr", "readonly");
+    cy.get('[data-cy="BtnSaveDraft"]').should("not.be.disabled");
+    cy.get('[data-cy="startOverButton"]').should("not.exist");
   });
+});
 
-  it("should show warning when start date is within 16 weeks of LATEST submission", () => {
-    const submissionDate = dayjs().subtract(1, "week").toISOString();
-    const shortNoticeStartDate = dayjs(submissionDate).add(15, "week").toDate();
+// Note Legacy forms pre-date the "16 weeks' notice" question, so canGiveCompliantStartDate is null while startDate/altStartDate hold the old answers.
+describe("LTFT Form View - legacy: retrospective 16-week warning", () => {
+  const submissionDate = dayjs().subtract(1, "week").toISOString();
+  const lateStartDate = dayjs(submissionDate).add(15, "week").toDate();
+  const compliantLegacyStartDate = dayjs(submissionDate)
+    .add(20, "week")
+    .toDate();
 
+  const mountWarningCase = (changeStartDate: Date) => {
     store.dispatch(updatedLtftStatus("idle"));
     store.dispatch(updatedCanEditLtft(true));
     mountLtftViewWithMockData({
       ...mockLtftUnsubmittedFormObj,
-      startDate: shortNoticeStartDate,
+      canGiveCompliantStartDate: null,
+      startDate: changeStartDate,
       status: {
         current: {
           ...mockLtftUnsubmittedFormObj.status.current,
-          state: "DRAFT"
+          state: "UNSUBMITTED"
         },
         history: [
           {
@@ -281,36 +459,142 @@ describe("LTFT Form View - start date warnings", () => {
         ]
       }
     });
+  };
+
+  it("warns for a legacy form whose start date is within 16 weeks of its submission", () => {
+    mountWarningCase(lateStartDate);
 
     cy.get('[data-cy="completionDateChangeStartDateValue"]').should("exist");
     cy.get(".field-warning-msg")
       .should("exist")
       .and("contain.text", "This application was submitted within 16 weeks");
   });
+
+  it("does NOT warn for a legacy form whose start date is at least 16 weeks after submission", () => {
+    mountWarningCase(compliantLegacyStartDate);
+
+    cy.get('[data-cy="completionDateChangeStartDateValue"]').should("exist");
+    cy.get(".field-warning-msg").should("not.exist");
+  });
 });
 
-describe("LTFT Form View - editable (UNSUBMITTED)", () => {
-  before(() => {
+describe("LTFT Form View - legacy: read-only display & Update migration", () => {
+  const legacyAltStartDate = dayjs().add(30, "week").format("YYYY-MM-DD");
+  const makeLegacy = (base: LtftObjNew): LtftObjNew => ({
+    ...base,
+    canGiveCompliantStartDate: null,
+    startDate: startDate,
+    altStartDate: legacyAltStartDate,
+    exceptionalReasons: null,
+    exceptionalReasonsDate: null
+  });
+
+  it("SUBMITTED (read-only): hides the 'can give' question, shows a read-only legacy note, displays dates read-only", () => {
+    store.dispatch(updatedLtftStatus("succeeded"));
+    store.dispatch(updatedCanEditLtft(false));
+    mountLtftViewWithMockData(makeLegacy(mockLtftSubmittedFormObj));
+
+    cy.get('[data-cy="pageHeader-Start date"]').should("exist");
+    // Note: for legacy, test that the 'can give' question is hidden rather than shown as "Not provided"
+    cy.get('[data-cy="canGiveCompliantStartDate-value"]').should("not.exist");
+    cy.get('[data-cy="legacyStartDateNote"]')
+      .should("exist")
+      .and("contain.text", "previous start date process");
+    cy.get('[data-cy="updateLegacyStartDate"]').should("not.exist");
+    // Note: original submitted dates still display in the summary card
+    cy.get('[data-cy="completionDateChangeStartDateValue"]').should(
+      "include.text",
+      ddmmyyyy(startDate)
+    );
+    cy.get('[data-cy="altStartDateValue"]').should(
+      "include.text",
+      ddmmyyyy(legacyAltStartDate)
+    );
+  });
+
+  it("UNSUBMITTED (editable): hides the 'can give' question and its edit link, shows the Update action, no per-field edit links", () => {
     store.dispatch(updatedLtftStatus("idle"));
     store.dispatch(updatedCanEditLtft(true));
-    mountLtftViewWithMockData(mockLtftUnsubmittedFormObj);
+    mountLtftViewWithMockData(makeLegacy(mockLtftUnsubmittedFormObj));
+
+    cy.get('[data-cy="canGiveCompliantStartDate-value"]').should("not.exist");
+    cy.get('[data-cy="edit-canGiveCompliantStartDate"]').should("not.exist");
+    cy.get('[data-cy="legacyStartDateNote"]').should("exist");
+    cy.get('[data-cy="updateLegacyStartDate"]').should("exist");
+    // Note: dates display read-only in the summary card (no per-field edit links)
+    cy.get('[data-cy="completionDateChangeStartDateValue"]').should("exist");
+    cy.get('[data-cy="altStartDateValue"]').should("exist");
+    cy.get('[data-cy="edit-legacy-startDate"]').should("not.exist");
+    cy.get('[data-cy="edit-legacy-altStartDate"]').should("not.exist");
   });
-  it("should render LTFT form in edit mode", () => {
-    cy.get('[data-cy="backLink-to-back-to-ltft-home"]').should("exist");
-    cy.get('[data-cy="savePdfBtn"]').should("not.be.disabled");
-    cy.get('[data-cy="UNSUBMITTED-header"]').should("exist");
-    cy.get('[data-cy="ltftName"]').contains("my Unsubmitted LTFT");
-    cy.get('[data-cy="pageHeader-Your Programme"]').should("exist");
-    cy.get('[data-cy="edit-pmId"]').should("exist");
 
-    cy.get('[data-cy="informationIsCorrect"]')
-      .should("not.be.checked")
-      .and("not.have.attr", "readonly");
-    cy.get('[data-cy="notGuaranteed"]')
-      .should("not.be.checked")
-      .and("not.have.attr", "readonly");
+  // Note: Integration test across the route: LtftFormView -> ActionModal -> LtftForm
+  const qualifyingProgrammes = ["7ab1aae3-83c2-4bb6-b1f3-99146e79b362"];
+  const mountLegacyEditJourney = (mockLtftObj: LtftObjNew) => {
+    store.dispatch(updatedLtft(mockLtftObj));
+    store.dispatch(updatedTraineeProfileData(mockTraineeProfile));
 
-    cy.get('[data-cy="BtnSaveDraft"]').should("not.be.disabled");
-    cy.get('[data-cy="startOverButton"]').should("not.exist");
+    store.dispatch(updatedEditPageNumberLtft(0));
+    store.dispatch(updatedUserFeatures(mockUserFeaturesLtftPilot));
+    const pmOptions = makeValidProgrammeOptions(
+      mockProgrammeMemberships,
+      qualifyingProgrammes
+    );
+    history.push("/ltft/confirm");
+    mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <Switch>
+            <Route exact path="/ltft/confirm" render={() => <LtftFormView />} />
+            <Route
+              exact
+              path="/ltft/create"
+              render={() => <LtftForm pmOptions={pmOptions} />}
+            />
+          </Switch>
+        </Router>
+      </Provider>
+    );
+  };
+
+  it("UNSUBMITTED: confirming the Update lands the trainee on the LtftForm Start date page with the section cleared, ready to re-answer from scratch", () => {
+    store.dispatch(updatedLtftStatus("idle"));
+    store.dispatch(updatedCanEditLtft(true));
+    mountLegacyEditJourney(makeLegacy(mockLtftUnsubmittedFormObj));
+
+    cy.get('[data-cy="updateLegacyStartDate"]').click();
+    cy.get('[data-cy="warningLabel-Start date process updated"]').should(
+      "exist"
+    );
+    cy.get('[data-cy="submitBtn-Start date process updated"]').click();
+
+    cy.get("h3").contains("Part 4 of 10 - Start date");
+
+    cy.get('[data-cy="canGiveCompliantStartDate-Yes-input"]').should(
+      "not.be.checked"
+    );
+    cy.get('[data-cy="canGiveCompliantStartDate-No-input"]').should(
+      "not.be.checked"
+    );
+    cy.get('[data-cy="startDate-input"]').should("not.exist");
+    cy.get('[data-cy="exceptionalReasons-text-area-input"]').should(
+      "not.exist"
+    );
+
+    cy.get('[data-cy="canGiveCompliantStartDate-No-input"]').check();
+    cy.get('[data-cy="exceptionalReasons-text-area-input"]')
+      .should("have.value", "")
+      .type("A fresh exceptional reason");
+    const withinSixteenWeeks = dayjs()
+      .startOf("day")
+      .add(8, "weeks")
+      .format("YYYY-MM-DD");
+    cy.get('[data-cy="exceptionalReasonsDate-input"]').should("have.value", "");
+    cy.clearAndType(
+      '[data-cy="exceptionalReasonsDate-input"]',
+      withinSixteenWeeks
+    );
+    cy.navNext();
+    cy.get("h3").contains("Part 5 of 10 - Reason(s) for applying");
   });
 });

--- a/cypress/component/forms/ltft/LtftFormView.cy.tsx
+++ b/cypress/component/forms/ltft/LtftFormView.cy.tsx
@@ -351,7 +351,7 @@ describe("LTFT Form View - new flow: No path (exceptional)", () => {
     cy.get('[data-cy="informationIsCorrect"]').check();
     cy.get('[data-cy="notGuaranteed"]').check();
     cy.get('[data-cy="name"]').type("my submitted ltft application");
-    cy.get('[data-cy="BtnSubmit').click();
+    cy.get('[data-cy="BtnSubmit"]').click();
     // Note: pre-modal draft save persists the form as-is (startDate still null).
     cy.get("@updateLtftStub").should("have.been.called");
 

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -5,7 +5,11 @@ export const pmStartDate = dayjs().subtract(3, "year").format("YYYY-MM-DD");
 export const pmEndDate = dayjs(pmStartDate).add(6, "year").format("YYYY-MM-DD");
 export const wteBeforeChange = 100;
 export const wte = 80;
-export const startDate = dayjs().add(15, "week").format("YYYY-MM-DD");
+export const startDate = dayjs().add(15, "week").format("YYYY-MM-DD"); // A late/legacy start date, within 16 weeks of today.
+export const compliantStartDate = dayjs().add(16, "week").format("YYYY-MM-DD"); // The compliant date stamped onto a "No" (canGiveCompliantStartDate === false) form at submission at least 16 weeks away.
+export const exceptionalRequestedDate = dayjs()
+  .add(8, "week")
+  .format("YYYY-MM-DD");
 
 // Summary list
 export const mockLtftDraftList: LtftSummaryObj[] = [
@@ -161,8 +165,11 @@ export const mockLtftNewFormObj: LtftObjNew = {
   reasonsOtherDetail: null,
   reasonsSelected: null,
   skilledWorkerVisaHolder: null,
+  canGiveCompliantStartDate: null,
   startDate: null,
   altStartDate: null,
+  exceptionalReasons: null,
+  exceptionalReasonsDate: null,
   status: {
     current: {
       state: "DRAFT",
@@ -206,8 +213,11 @@ export const mockLtftDraftUpdatedPmFormDtoFirstSavePayload: LtftDto = {
   name: null,
   change: {
     type: "LTFT",
+    isExceptional: null,
     startDate: null,
     altStartDate: null,
+    exceptionalReasons: null,
+    exceptionalReasonsDate: null,
     wte: 0,
     id: null
   },
@@ -371,8 +381,11 @@ export const mockLtftFormObjAfterFirstSave: LtftObjNew = {
   reasonsOtherDetail: "",
   reasonsSelected: [],
   skilledWorkerVisaHolder: null,
+  canGiveCompliantStartDate: null,
   startDate: null,
   altStartDate: null,
+  exceptionalReasons: null,
+  exceptionalReasonsDate: null,
   status: {
     current: {
       detail: { message: null, reason: null },
@@ -412,8 +425,11 @@ export const mockLtftSubmittedFormObj: LtftObjNew = {
   designatedBodyCode: "",
   managingDeanery: "East of England",
   type: "LTFT",
-  startDate: startDate,
+  canGiveCompliantStartDate: false,
+  startDate: compliantStartDate,
   altStartDate: null,
+  exceptionalReasons: "My exceptional reason for a late application",
+  exceptionalReasonsDate: exceptionalRequestedDate,
   wteBeforeChange: wteBeforeChange,
   wte: wte,
   declarations: {

--- a/mock-data/mock-ltft-data.ts
+++ b/mock-data/mock-ltft-data.ts
@@ -213,11 +213,8 @@ export const mockLtftDraftUpdatedPmFormDtoFirstSavePayload: LtftDto = {
   name: null,
   change: {
     type: "LTFT",
-    isExceptional: null,
     startDate: null,
     altStartDate: null,
-    exceptionalReasons: null,
-    exceptionalReasonsDate: null,
     wte: 0,
     id: null
   },
@@ -249,6 +246,11 @@ export const mockLtftDraftUpdatedPmFormDtoFirstSavePayload: LtftDto = {
     managingDeanery: "East of England"
   },
   reasons: { selected: [], otherDetail: "", supportingInformation: null },
+  exceptionalReasons: {
+    exceptional: null,
+    supportingInformation: null,
+    startDate: null
+  },
   status: {
     current: {
       state: "DRAFT",
@@ -313,6 +315,11 @@ export const mockLtftDraftFirstSuccessSaveResponseDto: LtftDto = {
     selected: [],
     otherDetail: "",
     supportingInformation: null
+  },
+  exceptionalReasons: {
+    exceptional: null,
+    supportingInformation: null,
+    startDate: null
   },
   tpdEmailStatus: null,
   status: {

--- a/models/LtftTypes.ts
+++ b/models/LtftTypes.ts
@@ -16,11 +16,14 @@ export type LtftChange = {
   type: CctType;
   startDate: Date | string | null;
   altStartDate?: Date | string | null;
-  isExceptional?: boolean | null;
-  exceptionalReasons?: string | null;
-  exceptionalReasonsDate?: Date | string | null;
   endDate?: Date | string | null;
   wte: number;
+};
+
+export type LtftExceptionalReasons = {
+  exceptional: boolean | null;
+  supportingInformation: string | null;
+  startDate: Date | string | null;
 };
 
 export type LtftDeclarations = {
@@ -184,6 +187,7 @@ export type LtftDto = {
     otherDetail?: string;
     supportingInformation: string | null;
   };
+  exceptionalReasons: LtftExceptionalReasons;
   tpdEmailStatus?: unknown;
   status: {
     current: StatusInfo;

--- a/models/LtftTypes.ts
+++ b/models/LtftTypes.ts
@@ -187,7 +187,7 @@ export type LtftDto = {
     otherDetail?: string;
     supportingInformation: string | null;
   };
-  exceptionalReasons: LtftExceptionalReasons;
+  exceptionalReasons: LtftExceptionalReasons | null;
   tpdEmailStatus?: unknown;
   status: {
     current: StatusInfo;

--- a/models/LtftTypes.ts
+++ b/models/LtftTypes.ts
@@ -16,6 +16,9 @@ export type LtftChange = {
   type: CctType;
   startDate: Date | string | null;
   altStartDate?: Date | string | null;
+  isExceptional?: boolean | null;
+  exceptionalReasons?: string | null;
+  exceptionalReasonsDate?: Date | string | null;
   endDate?: Date | string | null;
   wte: number;
 };
@@ -93,8 +96,11 @@ export type LtftObjNew = {
 
   // change: LtftChange
   type: CctType;
+  canGiveCompliantStartDate: boolean | null;
   startDate: Date | string | null;
   altStartDate: Date | string | null;
+  exceptionalReasons: string | null;
+  exceptionalReasonsDate: Date | string | null;
   wteBeforeChange: number | null; // currently belongs to PM but needed here for ease of use
   wte: number | null;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@types/react-router-dom": "^5.3.3",
         "@types/react-test-renderer": "^18.0.2",
         "aws-amplify": "^6.14.4",
+        "babel-plugin-istanbul": "^6.1.1",
         "browser-update": "^3.3.44",
         "cypress": "^14.5.4",
         "cypress-localstorage-commands": "^2.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.146.8",
+  "version": "0.147.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trainee-ui-app",
-      "version": "0.146.8",
+      "version": "0.147.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.11.1",
         "@cypress/code-coverage": "^3.12.1",
@@ -8959,9 +8959,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -10267,9 +10267,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -11348,9 +11348,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -12431,9 +12431,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -15006,9 +15006,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/react-test-renderer": "^18.0.2",
     "aws-amplify": "^6.14.4",
+    "babel-plugin-istanbul": "^6.1.1",
     "browser-update": "^3.3.44",
     "cypress": "^14.5.4",
     "cypress-localstorage-commands": "^2.2.3",
@@ -91,10 +92,10 @@
     "ct:headless": "cypress run --component",
     "cypress": "cypress open --e2e",
     "cypress:headless": "cypress run --e2e",
-    "cover-jest": "nyc --silent npm run test",
-    "cover-cypress-ct": "nyc --silent --no-clean npm run ct:headless",
+    "cover-jest": "npm run test",
+    "cover-cypress-ct": "npm run ct:headless",
     "cover:report": "nyc report --reporter=lcov --reporter=text",
-    "coverage": "npm run cover-jest && npm run cover-cypress-ct && npm run cover:report"
+    "coverage": "rm -rf .nyc_output coverage && trap 'rm -f .babelrc' EXIT INT TERM && cp .babelrc.coverage .babelrc && npm run cover-jest && mkdir -p .nyc_output && cp coverage/coverage-final.json .nyc_output/jest-coverage.json && npm run cover-cypress-ct && npm run cover:report"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.146.8",
+  "version": "0.147.0",
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^6.11.1",

--- a/redux/slices/__test__/ltftSlice.test.ts
+++ b/redux/slices/__test__/ltftSlice.test.ts
@@ -332,6 +332,9 @@ describe("ltftSlice - loadSavedLtft thunk", () => {
     (ltftUtilities.mapLtftDtoToObj as jest.Mock).mockReturnValue(
       mockMappedLtft
     );
+    (ltftUtilities.resetLegacyStartDateSection as jest.Mock).mockImplementation(
+      (obj: LtftObjNew) => obj
+    );
   });
 
   test("should handle successful form loading", async () => {

--- a/redux/slices/ltftSlice.ts
+++ b/redux/slices/ltftSlice.ts
@@ -2,7 +2,8 @@ import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { CctCalculation } from "./cctSlice";
 import {
   mapLtftDtoToObj,
-  mapLtftObjToDto
+  mapLtftObjToDto,
+  resetLegacyStartDateSection
 } from "../../utilities/ltftUtilities";
 import { FormsService } from "../../services/FormsService";
 import { SaveStatusProps } from "../../components/forms/AutosaveMessage";
@@ -123,7 +124,7 @@ export const loadSavedLtft = createAsyncThunk(
   async (id: string) => {
     const formsService = new FormsService();
     const response = await formsService.getLtftFormById(id);
-    return mapLtftDtoToObj(response.data);
+    return resetLegacyStartDateSection(mapLtftDtoToObj(response.data));
   }
 );
 

--- a/utilities/Constants.tsx
+++ b/utilities/Constants.tsx
@@ -604,15 +604,15 @@ export const onboardingTrackerInfoText: Record<TrackerActionType, JSX.Element> =
     ),
     PLACEMENT_CONFIRMATION: (
       <p>
-        The 'Placement Confirmation' email is sent to the email address you use
-        to sign in to TIS Self-Service.
+        The &apos;Placement Confirmation&apos; email is sent to the email
+        address you use to sign in to TIS Self-Service.
       </p>
     ),
     REVIEW_PLACEMENT: (
       <>
         <p>
-          When you receive the 'Placement Confirmation' email 12 weeks before
-          your start date, your Placement should be in{" "}
+          When you receive the &apos;Placement Confirmation&apos; email 12 weeks
+          before your start date, your Placement should be in{" "}
           <Link to="/placements">Upcoming Placements</Link> for you to review.
         </p>
         <p>
@@ -624,8 +624,8 @@ export const onboardingTrackerInfoText: Record<TrackerActionType, JSX.Element> =
     ),
     DAY_ONE_EMAIL: (
       <p>
-        The 'Day One' email is sent to email address you use to sign in to TIS
-        Self-Service.
+        The &apos;Day One&apos; email is sent to email address you use to sign
+        in to TIS Self-Service.
       </p>
     ),
     DAY_ONE: (
@@ -649,8 +649,8 @@ export const failedEmailInfoText: Record<string, any> = {
   ),
   "Bounce: Permanent - General": (
     <p>
-      The email couldn't be delivered to your address due to a permanent issue.
-      Please check that your email address is correct or contact{" "}
+      The email couldn&apos;t be delivered to your address due to a permanent
+      issue. Please check that your email address is correct or contact{" "}
       <Link to="/support">Local Office support</Link> if you want to update your
       email.
     </p>
@@ -666,8 +666,8 @@ export const failedEmailInfoText: Record<string, any> = {
   ),
   "Bounce: Transient - MessageTooLarge": (
     <p>
-      The email was too large for your mail system. We're working to optimize
-      email sizes. Please contact{" "}
+      The email was too large for your mail system. We&apos;re working to
+      optimize email sizes. Please contact{" "}
       <Link to="/support">Local Office support</Link> if this issue persists.
     </p>
   ),
@@ -680,14 +680,14 @@ export const failedEmailInfoText: Record<string, any> = {
   "Complaint: abuse": (
     <p>
       The email was flagged as spam or abuse by your email system. If you want
-      to receive our emails, please check your spam folder and mark us as 'Not
-      Spam', or contact your Local Office support team.
+      to receive our emails, please check your spam folder and mark us as
+      &apos;Not Spam&apos;, or contact your Local Office support team.
     </p>
   ),
   "No email address available.": (
     <p>
-      We couldn't send an email because there was no valid address found. Please
-      check that your email address is correct or contact{" "}
+      We couldn&apos;t send an email because there was no valid address found.
+      Please check that your email address is correct or contact{" "}
       <Link to="/support">Local Office support</Link> if you want to update your
       email.
     </p>
@@ -789,9 +789,6 @@ export const ltft16WeeksNotice = (
     </p>
   </>
 );
-
-export const ltft16WeeksWarningText =
-  "Warning: Giving less than 16 weeks notice to change your working hours is classed as a late application and will only be considered on an exceptional basis.";
 
 export const ltft16WeeksWarningTextSubmitted =
   "This application was submitted within 16 weeks of the intended Start date. Late applications are only considered on an exceptional basis.";

--- a/utilities/Constants.tsx
+++ b/utilities/Constants.tsx
@@ -793,6 +793,15 @@ export const ltft16WeeksNotice = (
 export const ltft16WeeksWarningTextSubmitted =
   "This application was submitted within 16 weeks of the intended Start date. Late applications are only considered on an exceptional basis.";
 
+export const ltftLegacyStartDateGateLabel = "Start date page has been updated";
+export const ltftLegacyStartDateGateText =
+  "Since you submitted this application, the Start date page has been reworked. If you proceed, your start date information will be reset and you will need to complete this page again.";
+export const ltftLegacyStartDateGateProceedBtn = "Proceed";
+export const ltftLegacyStartDateGateSkipBtn = "Skip";
+export const ltftLegacyStartDateGateSkipHint =
+  "Skipping the Start date page keeps your original start date information intact for re-submission.";
+export const ltftLegacyStartDateGateCancelBtn = "Stay on this page";
+
 export const tier2SkilledWorkerVisaInfo = (
   <>
     Please be aware that there are minimum requirements and conditions attached

--- a/utilities/FormBuilderUtilities.ts
+++ b/utilities/FormBuilderUtilities.ts
@@ -13,6 +13,7 @@ import {
 } from "../redux/slices/formASlice";
 import store from "../redux/store/store";
 import type {
+  ComputedValueName,
   Field,
   Form,
   FormData,
@@ -399,10 +400,7 @@ export interface DraftFormProps {
 }
 
 export function setDraftFormRProps(forms: IFormR[]): DraftFormProps | null {
-  if (
-    forms.length === 0 ||
-    forms.every(form => form.lifecycleState === LifeCycleState.Submitted)
-  )
+  if (forms.every(form => form.lifecycleState === LifeCycleState.Submitted))
     return null;
 
   const unsubmittedForm = forms.find(
@@ -676,6 +674,8 @@ export function validateFields(
   let finalValidationSchema = Yup.object().shape({});
   finalValidationSchema = fields.reduce((schema, field) => {
     const fieldSchema = validationSchema.fields[field.name];
+    // info-type (and other schema-less) fields have nothing to validate
+    if (!fieldSchema) return schema;
     const isVisible = showFormField(field, values);
     if (isVisible) {
       if (field.type === "array" && values[field.name]?.length > 0) {
@@ -752,6 +752,27 @@ export function showFormField(field: Field, formData: FormData) {
   if (!matcher) return false;
   return matcher(formData[field.visibleIf.field], field.visibleIf);
 }
+
+export function clearHiddenFieldValues(
+  fields: Field[],
+  formData: FormData
+): FormData {
+  const valsToClear = fields.filter(
+    field => !showFormField(field, formData) && formData[field.name] != null
+  );
+  if (valsToClear.length === 0) return formData;
+
+  const cleaned = { ...formData };
+  for (const field of valsToClear) {
+    cleaned[field.name] = null;
+  }
+  return cleaned;
+}
+
+export const computedValueGenerators: Record<ComputedValueName, () => string> =
+  {
+    ltft16WeeksNoticeDate: () => dayjs().add(16, "week").format("YYYY-MM-DD")
+  };
 
 // Bug fix to also reset the option to empty string where no match against filtered curriculum data e.g. programmeSpecialty field.
 export function isValidOption(

--- a/utilities/__test__/FormBuilderUtilities.test.ts
+++ b/utilities/__test__/FormBuilderUtilities.test.ts
@@ -11,6 +11,7 @@ import store from "../../redux/store/store";
 import {
   BtnLocation,
   checkPush,
+  clearHiddenFieldValues,
   getDraftFormId,
   handleSaveRedirect,
   isDateWithin16WeeksOfFirstDate,
@@ -20,6 +21,7 @@ import {
   transformReferenceData
 } from "../FormBuilderUtilities";
 import formAJson from "../../components/forms/form-builder/form-r/part-a/formA.json";
+import ltftJson from "../../components/forms/ltft/ltft.json";
 import { formANew } from "../../mock-data/draft-formr-parta";
 import {
   Field,
@@ -368,6 +370,77 @@ describe("showFormField", () => {
       expect(showFormField(field, { startDate: "" })).toBe(false);
       expect(showFormField(field, { startDate: null })).toBe(false);
       expect(showFormField(field, {})).toBe(false);
+    });
+  });
+});
+
+describe("clearHiddenFieldValues", () => {
+  const makeField = (overrides: Partial<Field>): Field => ({
+    name: "fieldUnderTest",
+    type: "text",
+    visible: false,
+    ...overrides
+  });
+
+  const otherDetailField = makeField({
+    name: "reasonsOtherDetail",
+    visibleIf: {
+      matcher: "valueInList",
+      field: "reasonsSelected",
+      values: ["other"]
+    }
+  });
+
+  it("nulls a field that is no longer shown but still holds a value", () => {
+    const result = clearHiddenFieldValues([otherDetailField], {
+      reasonsSelected: "caring",
+      reasonsOtherDetail: "stale detail"
+    });
+    expect(result.reasonsOtherDetail).toBeNull();
+  });
+
+  it("keeps the value of a field that is still shown", () => {
+    const formData = {
+      reasonsSelected: "other",
+      reasonsOtherDetail: "keep me"
+    };
+    expect(clearHiddenFieldValues([otherDetailField], formData)).toEqual(
+      formData
+    );
+  });
+
+  it("returns the same object reference when nothing needs clearing", () => {
+    const formData = { reasonsSelected: "caring", reasonsOtherDetail: null };
+    expect(clearHiddenFieldValues([otherDetailField], formData)).toBe(formData);
+  });
+
+  describe("LTFT No-path startDate (clear-on-edit)", () => {
+    const startDatePage = (ltftJson as Form).pages.find(
+      page => page.pageName === "Start date"
+    );
+    const startDateFields = startDatePage
+      ? startDatePage.sections.flatMap(section => section.fields)
+      : [];
+
+    it("clears a stamped startDate when a No-path form revisits the Start date page", () => {
+      const stamped = dayjs().add(16, "week").format("YYYY-MM-DD");
+      const result = clearHiddenFieldValues(startDateFields, {
+        canGiveCompliantStartDate: false,
+        startDate: stamped,
+        exceptionalReasonsDate: dayjs().add(8, "week").format("YYYY-MM-DD")
+      });
+      expect(result.startDate).toBeNull();
+      // the No-path answers the trainee is actually editing are left in place
+      expect(result.exceptionalReasonsDate).not.toBeNull();
+    });
+
+    it("keeps startDate on the Yes path, where its visibleIf passes", () => {
+      const entered = dayjs().add(20, "week").format("YYYY-MM-DD");
+      const result = clearHiddenFieldValues(startDateFields, {
+        canGiveCompliantStartDate: true,
+        startDate: entered
+      });
+      expect(result.startDate).toBe(entered);
     });
   });
 });

--- a/utilities/__test__/LtftUtilities.test.ts
+++ b/utilities/__test__/LtftUtilities.test.ts
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import { mockPersonalDetails } from "../../mock-data/trainee-profile";
+import { LtftDto } from "../../models/LtftTypes";
 import {
   findLatestSubmissionDate,
   hasLegacyStartDateData,
@@ -55,28 +56,42 @@ describe("mapLtftObjToDto", () => {
     expect(mappedDto.change.altStartDate).toBeNull();
   });
 
-  it("maps the No path (canGiveCompliantStartDate false) to isExceptional true", () => {
+  it("maps the No path (canGiveCompliantStartDate false) to exceptional true", () => {
     const noPath = {
       ...mockLtftDraftUpdatedPmFormObjNoSave,
       canGiveCompliantStartDate: false
     };
-    expect(mapLtftObjToDto(noPath).change.isExceptional).toBe(true);
+    expect(mapLtftObjToDto(noPath).exceptionalReasons.exceptional).toBe(true);
   });
 
-  it("maps the Yes path (canGiveCompliantStartDate true) to isExceptional false", () => {
+  it("maps the Yes path (canGiveCompliantStartDate true) to exceptional false", () => {
     const yesPath = {
       ...mockLtftDraftUpdatedPmFormObjNoSave,
       canGiveCompliantStartDate: true
     };
-    expect(mapLtftObjToDto(yesPath).change.isExceptional).toBe(false);
+    expect(mapLtftObjToDto(yesPath).exceptionalReasons.exceptional).toBe(false);
   });
 
-  it("maps a legacy null through to isExceptional null (no inversion)", () => {
+  it("maps a legacy null through to exceptional null (no inversion)", () => {
     const legacy = {
       ...mockLtftDraftUpdatedPmFormObjNoSave,
       canGiveCompliantStartDate: null
     };
-    expect(mapLtftObjToDto(legacy).change.isExceptional).toBeNull();
+    expect(mapLtftObjToDto(legacy).exceptionalReasons.exceptional).toBeNull();
+  });
+
+  it("maps the exceptional reasons text and date into the nested sub-object", () => {
+    const noPath = {
+      ...mockLtftDraftUpdatedPmFormObjNoSave,
+      canGiveCompliantStartDate: false,
+      exceptionalReasons: "Sudden disability",
+      exceptionalReasonsDate: "2026-03-01"
+    };
+    expect(mapLtftObjToDto(noPath).exceptionalReasons).toEqual({
+      exceptional: true,
+      supportingInformation: "Sudden disability",
+      startDate: "2026-03-01"
+    });
   });
 });
 
@@ -86,33 +101,56 @@ describe("mapDtoToLtftObj", () => {
     expect(ltftObj).toEqual(mockLtftFormObjAfterFirstSave);
   });
 
-  it("maps isExceptional true back to canGiveCompliantStartDate false (No path)", () => {
+  it("maps exceptional true back to canGiveCompliantStartDate false (No path)", () => {
     const dto = {
       ...mockLtftDraftFirstSuccessSaveResponseDto,
-      change: {
-        ...mockLtftDraftFirstSuccessSaveResponseDto.change,
-        isExceptional: true
+      exceptionalReasons: {
+        ...mockLtftDraftFirstSuccessSaveResponseDto.exceptionalReasons,
+        exceptional: true
       }
     };
     expect(mapLtftDtoToObj(dto).canGiveCompliantStartDate).toBe(false);
   });
 
-  it("maps isExceptional false back to canGiveCompliantStartDate true (Yes path)", () => {
+  it("maps exceptional false back to canGiveCompliantStartDate true (Yes path)", () => {
     const dto = {
       ...mockLtftDraftFirstSuccessSaveResponseDto,
-      change: {
-        ...mockLtftDraftFirstSuccessSaveResponseDto.change,
-        isExceptional: false
+      exceptionalReasons: {
+        ...mockLtftDraftFirstSuccessSaveResponseDto.exceptionalReasons,
+        exceptional: false
       }
     };
     expect(mapLtftDtoToObj(dto).canGiveCompliantStartDate).toBe(true);
   });
 
-  it("maps a missing/null isExceptional to canGiveCompliantStartDate null (legacy)", () => {
+  it("maps a missing/null exceptional to canGiveCompliantStartDate null (legacy)", () => {
     expect(
       mapLtftDtoToObj(mockLtftDraftFirstSuccessSaveResponseDto)
         .canGiveCompliantStartDate
     ).toBeNull();
+  });
+
+  it("maps the nested sub-object back onto the flat FE fields", () => {
+    const dto = {
+      ...mockLtftDraftFirstSuccessSaveResponseDto,
+      exceptionalReasons: {
+        exceptional: true,
+        supportingInformation: "Sudden disability",
+        startDate: "2026-03-01"
+      }
+    };
+    const ltftObj = mapLtftDtoToObj(dto);
+    expect(ltftObj.exceptionalReasons).toBe("Sudden disability");
+    expect(ltftObj.exceptionalReasonsDate).toBe("2026-03-01");
+  });
+
+  it("survives the BE omitting the exceptionalReasons sub-object entirely", () => {
+    const { exceptionalReasons: _omitted, ...dtoWithout } =
+      mockLtftDraftFirstSuccessSaveResponseDto;
+    const ltftObj = mapLtftDtoToObj(dtoWithout as LtftDto);
+    expect(ltftObj.canGiveCompliantStartDate).toBeNull();
+    expect(ltftObj.exceptionalReasons).toBeNull();
+    expect(ltftObj.exceptionalReasonsDate).toBeNull();
   });
 });
 

--- a/utilities/__test__/LtftUtilities.test.ts
+++ b/utilities/__test__/LtftUtilities.test.ts
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import { mockPersonalDetails } from "../../mock-data/trainee-profile";
 import {
   findLatestSubmissionDate,
+  hasLegacyStartDateData,
   mapLtftDtoToObj,
   mapLtftObjToDto,
   populateLtftDraftNew,
@@ -112,6 +113,57 @@ describe("mapDtoToLtftObj", () => {
       mapLtftDtoToObj(mockLtftDraftFirstSuccessSaveResponseDto)
         .canGiveCompliantStartDate
     ).toBeNull();
+  });
+});
+
+describe("hasLegacyStartDateData", () => {
+  it("is true when canGiveCompliantStartDate is null and a startDate was given", () => {
+    expect(
+      hasLegacyStartDateData({
+        ...mockLtftNewFormObj,
+        startDate: "2026-01-01"
+      })
+    ).toBe(true);
+  });
+
+  it("is true when canGiveCompliantStartDate is null and only an altStartDate was given", () => {
+    expect(
+      hasLegacyStartDateData({
+        ...mockLtftNewFormObj,
+        altStartDate: "2026-06-01"
+      })
+    ).toBe(true);
+  });
+
+  it("is false for a new form that has not reached the Start date page yet", () => {
+    expect(hasLegacyStartDateData(mockLtftNewFormObj)).toBe(false);
+  });
+
+  it("is false once the legacy section has been reset, so the trainee is not warned twice", () => {
+    const reset = {
+      ...mockLtftNewFormObj,
+      startDate: null,
+      altStartDate: null,
+      status: {
+        ...mockLtftNewFormObj.status,
+        current: {
+          ...mockLtftNewFormObj.status.current,
+          state: "UNSUBMITTED" as const
+        }
+      }
+    };
+
+    expect(hasLegacyStartDateData(reset)).toBe(false);
+  });
+
+  it("is false once canGiveCompliantStartDate has been answered", () => {
+    expect(
+      hasLegacyStartDateData({
+        ...mockLtftNewFormObj,
+        canGiveCompliantStartDate: true,
+        startDate: "2026-06-01"
+      })
+    ).toBe(false);
   });
 });
 

--- a/utilities/__test__/LtftUtilities.test.ts
+++ b/utilities/__test__/LtftUtilities.test.ts
@@ -1,6 +1,5 @@
 import dayjs from "dayjs";
 import { mockPersonalDetails } from "../../mock-data/trainee-profile";
-import { LtftDto } from "../../models/LtftTypes";
 import {
   findLatestSubmissionDate,
   hasLegacyStartDateData,
@@ -61,7 +60,7 @@ describe("mapLtftObjToDto", () => {
       ...mockLtftDraftUpdatedPmFormObjNoSave,
       canGiveCompliantStartDate: false
     };
-    expect(mapLtftObjToDto(noPath).exceptionalReasons.exceptional).toBe(true);
+    expect(mapLtftObjToDto(noPath).exceptionalReasons?.exceptional).toBe(true);
   });
 
   it("maps the Yes path (canGiveCompliantStartDate true) to exceptional false", () => {
@@ -69,7 +68,9 @@ describe("mapLtftObjToDto", () => {
       ...mockLtftDraftUpdatedPmFormObjNoSave,
       canGiveCompliantStartDate: true
     };
-    expect(mapLtftObjToDto(yesPath).exceptionalReasons.exceptional).toBe(false);
+    expect(mapLtftObjToDto(yesPath).exceptionalReasons?.exceptional).toBe(
+      false
+    );
   });
 
   it("maps a legacy null through to exceptional null (no inversion)", () => {
@@ -77,7 +78,7 @@ describe("mapLtftObjToDto", () => {
       ...mockLtftDraftUpdatedPmFormObjNoSave,
       canGiveCompliantStartDate: null
     };
-    expect(mapLtftObjToDto(legacy).exceptionalReasons.exceptional).toBeNull();
+    expect(mapLtftObjToDto(legacy).exceptionalReasons?.exceptional).toBeNull();
   });
 
   it("maps the exceptional reasons text and date into the nested sub-object", () => {
@@ -105,8 +106,9 @@ describe("mapDtoToLtftObj", () => {
     const dto = {
       ...mockLtftDraftFirstSuccessSaveResponseDto,
       exceptionalReasons: {
-        ...mockLtftDraftFirstSuccessSaveResponseDto.exceptionalReasons,
-        exceptional: true
+        exceptional: true,
+        supportingInformation: null,
+        startDate: null
       }
     };
     expect(mapLtftDtoToObj(dto).canGiveCompliantStartDate).toBe(false);
@@ -116,8 +118,9 @@ describe("mapDtoToLtftObj", () => {
     const dto = {
       ...mockLtftDraftFirstSuccessSaveResponseDto,
       exceptionalReasons: {
-        ...mockLtftDraftFirstSuccessSaveResponseDto.exceptionalReasons,
-        exceptional: false
+        exceptional: false,
+        supportingInformation: null,
+        startDate: null
       }
     };
     expect(mapLtftDtoToObj(dto).canGiveCompliantStartDate).toBe(true);
@@ -144,10 +147,11 @@ describe("mapDtoToLtftObj", () => {
     expect(ltftObj.exceptionalReasonsDate).toBe("2026-03-01");
   });
 
-  it("survives the BE omitting the exceptionalReasons sub-object entirely", () => {
-    const { exceptionalReasons: _omitted, ...dtoWithout } =
-      mockLtftDraftFirstSuccessSaveResponseDto;
-    const ltftObj = mapLtftDtoToObj(dtoWithout as LtftDto);
+  it("survives the BE returning a null exceptionalReasons sub-object", () => {
+    const ltftObj = mapLtftDtoToObj({
+      ...mockLtftDraftFirstSuccessSaveResponseDto,
+      exceptionalReasons: null
+    });
     expect(ltftObj.canGiveCompliantStartDate).toBeNull();
     expect(ltftObj.exceptionalReasons).toBeNull();
     expect(ltftObj.exceptionalReasonsDate).toBeNull();

--- a/utilities/__test__/LtftUtilities.test.ts
+++ b/utilities/__test__/LtftUtilities.test.ts
@@ -1,9 +1,12 @@
+import dayjs from "dayjs";
 import { mockPersonalDetails } from "../../mock-data/trainee-profile";
 import {
   findLatestSubmissionDate,
   mapLtftDtoToObj,
   mapLtftObjToDto,
-  populateLtftDraftNew
+  populateLtftDraftNew,
+  resetLegacyStartDateSection,
+  stampLtftStartDateOnSubmit
 } from "../ltftUtilities";
 import {
   mockLtftDraftFirstSuccessSaveResponseDto,
@@ -50,12 +53,155 @@ describe("mapLtftObjToDto", () => {
 
     expect(mappedDto.change.altStartDate).toBeNull();
   });
+
+  it("maps the No path (canGiveCompliantStartDate false) to isExceptional true", () => {
+    const noPath = {
+      ...mockLtftDraftUpdatedPmFormObjNoSave,
+      canGiveCompliantStartDate: false
+    };
+    expect(mapLtftObjToDto(noPath).change.isExceptional).toBe(true);
+  });
+
+  it("maps the Yes path (canGiveCompliantStartDate true) to isExceptional false", () => {
+    const yesPath = {
+      ...mockLtftDraftUpdatedPmFormObjNoSave,
+      canGiveCompliantStartDate: true
+    };
+    expect(mapLtftObjToDto(yesPath).change.isExceptional).toBe(false);
+  });
+
+  it("maps a legacy null through to isExceptional null (no inversion)", () => {
+    const legacy = {
+      ...mockLtftDraftUpdatedPmFormObjNoSave,
+      canGiveCompliantStartDate: null
+    };
+    expect(mapLtftObjToDto(legacy).change.isExceptional).toBeNull();
+  });
 });
 
 describe("mapDtoToLtftObj", () => {
   it("should map DTO to LtftObj correctly", () => {
     const ltftObj = mapLtftDtoToObj(mockLtftDraftFirstSuccessSaveResponseDto);
     expect(ltftObj).toEqual(mockLtftFormObjAfterFirstSave);
+  });
+
+  it("maps isExceptional true back to canGiveCompliantStartDate false (No path)", () => {
+    const dto = {
+      ...mockLtftDraftFirstSuccessSaveResponseDto,
+      change: {
+        ...mockLtftDraftFirstSuccessSaveResponseDto.change,
+        isExceptional: true
+      }
+    };
+    expect(mapLtftDtoToObj(dto).canGiveCompliantStartDate).toBe(false);
+  });
+
+  it("maps isExceptional false back to canGiveCompliantStartDate true (Yes path)", () => {
+    const dto = {
+      ...mockLtftDraftFirstSuccessSaveResponseDto,
+      change: {
+        ...mockLtftDraftFirstSuccessSaveResponseDto.change,
+        isExceptional: false
+      }
+    };
+    expect(mapLtftDtoToObj(dto).canGiveCompliantStartDate).toBe(true);
+  });
+
+  it("maps a missing/null isExceptional to canGiveCompliantStartDate null (legacy)", () => {
+    expect(
+      mapLtftDtoToObj(mockLtftDraftFirstSuccessSaveResponseDto)
+        .canGiveCompliantStartDate
+    ).toBeNull();
+  });
+});
+
+describe("resetLegacyStartDateSection", () => {
+  it("clears the start-date fields for a legacy DRAFT (canGiveCompliantStartDate null)", () => {
+    const legacyDraft = {
+      ...mockLtftNewFormObj,
+      startDate: "2026-01-01",
+      altStartDate: "2026-06-01",
+      exceptionalReasons: "legacy reason",
+      exceptionalReasonsDate: "2026-02-01"
+    };
+
+    const result = resetLegacyStartDateSection(legacyDraft);
+
+    expect(result.startDate).toBeNull();
+    expect(result.altStartDate).toBeNull();
+    expect(result.exceptionalReasons).toBeNull();
+    expect(result.exceptionalReasonsDate).toBeNull();
+    expect(result.canGiveCompliantStartDate).toBeNull();
+  });
+
+  it("leaves the form untouched once canGiveCompliantStartDate has been answered", () => {
+    const answeredDraft = {
+      ...mockLtftNewFormObj,
+      canGiveCompliantStartDate: true,
+      startDate: "2026-06-01"
+    };
+
+    expect(resetLegacyStartDateSection(answeredDraft)).toBe(answeredDraft);
+  });
+
+  it("leaves non-DRAFT forms untouched even when canGiveCompliantStartDate is null", () => {
+    const submittedLegacy = {
+      ...mockLtftNewFormObj,
+      altStartDate: "2026-06-01",
+      status: {
+        ...mockLtftNewFormObj.status,
+        current: {
+          ...mockLtftNewFormObj.status.current,
+          state: "SUBMITTED" as const
+        }
+      }
+    };
+
+    expect(resetLegacyStartDateSection(submittedLegacy)).toBe(submittedLegacy);
+  });
+});
+
+describe("stampLtftStartDateOnSubmit", () => {
+  const compliantDate = dayjs().add(16, "week").format("YYYY-MM-DD");
+
+  it("stamps the 16-week compliant date onto a No-path form with no startDate", () => {
+    const noPath = {
+      ...mockLtftNewFormObj,
+      canGiveCompliantStartDate: false,
+      startDate: null
+    };
+    const result = stampLtftStartDateOnSubmit(noPath);
+    expect(result.startDate).toBe(compliantDate);
+  });
+
+  it("keeps an already-stamped startDate (re-derivation only follows a clear-on-edit)", () => {
+    const previouslyStamped = dayjs().add(10, "week").format("YYYY-MM-DD");
+    const noPath = {
+      ...mockLtftNewFormObj,
+      canGiveCompliantStartDate: false,
+      startDate: previouslyStamped
+    };
+    const result = stampLtftStartDateOnSubmit(noPath);
+    expect(result).toBe(noPath);
+    expect(result.startDate).toBe(previouslyStamped);
+  });
+
+  it("leaves the Yes path untouched, where startDate is user-entered", () => {
+    const yesPath = {
+      ...mockLtftNewFormObj,
+      canGiveCompliantStartDate: true,
+      startDate: null
+    };
+    expect(stampLtftStartDateOnSubmit(yesPath)).toBe(yesPath);
+  });
+
+  it("leaves a legacy form (canGiveCompliantStartDate null) untouched", () => {
+    const legacy = {
+      ...mockLtftNewFormObj,
+      canGiveCompliantStartDate: null,
+      startDate: null
+    };
+    expect(stampLtftStartDateOnSubmit(legacy)).toBe(legacy);
   });
 });
 

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -6,7 +6,7 @@ import { ProgrammeMembership } from "../models/ProgrammeMembership";
 import { unsubmitLtftForm, withdrawLtftForm } from "../redux/slices/ltftSlice";
 import store from "../redux/store/store";
 import { ACTION_REASONS } from "./Constants";
-import { isFormDeleted } from "./FormBuilderUtilities";
+import { computedValueGenerators, isFormDeleted } from "./FormBuilderUtilities";
 import { ActionState } from "./hooks/useActionState";
 
 export function populateLtftDraftNew(
@@ -22,8 +22,11 @@ export function populateLtftDraftNew(
     designatedBodyCode: "",
     managingDeanery: "",
     type: "LTFT",
+    canGiveCompliantStartDate: null,
     startDate: null,
     altStartDate: null,
+    exceptionalReasons: null,
+    exceptionalReasonsDate: null,
     wteBeforeChange: null,
     wte: null,
     declarations: {
@@ -78,8 +81,14 @@ export const mapLtftObjToDto = (ltftObj: LtftObjNew): LtftDto => {
     name: ltftObj.name ?? null,
     change: {
       type: "LTFT",
+      isExceptional:
+        ltftObj.canGiveCompliantStartDate == null
+          ? null
+          : !ltftObj.canGiveCompliantStartDate, // Note: the persisted DTO field is the inverse (isExceptional). 'No' -> true.
       startDate: ltftObj.startDate,
       altStartDate: ltftObj.altStartDate ? ltftObj.altStartDate : null,
+      exceptionalReasons: ltftObj.exceptionalReasons ?? null,
+      exceptionalReasonsDate: ltftObj.exceptionalReasonsDate ?? null,
       wte: ltftObj.wte ? ltftObj.wte / 100 : 0,
       id: null
     },
@@ -173,8 +182,14 @@ export const mapLtftDtoToObj = (ltftDto: LtftDto): LtftObjNew => {
     designatedBodyCode: ltftDto.programmeMembership.designatedBodyCode ?? "",
     managingDeanery: ltftDto.programmeMembership.managingDeanery ?? "",
     type: ltftDto.change.type,
+    canGiveCompliantStartDate:
+      ltftDto.change.isExceptional == null
+        ? null
+        : !ltftDto.change.isExceptional,
     startDate: ltftDto.change.startDate,
     altStartDate: ltftDto.change.altStartDate ?? null,
+    exceptionalReasons: ltftDto.change.exceptionalReasons ?? null,
+    exceptionalReasonsDate: ltftDto.change.exceptionalReasonsDate ?? null,
     wteBeforeChange: ltftDto.programmeMembership.wte
       ? Math.round(ltftDto.programmeMembership.wte * 100)
       : null,
@@ -240,6 +255,25 @@ export const mapLtftDtoToObj = (ltftDto: LtftDto): LtftObjNew => {
     created: ltftDto.created,
     lastModified: ltftDto.lastModified
   };
+};
+
+// Note: canGiveCompliantStartDate is the trigger
+export const clearStartDateSection = (ltftObj: LtftObjNew): LtftObjNew => ({
+  ...ltftObj,
+  startDate: null,
+  altStartDate: null,
+  exceptionalReasons: null,
+  exceptionalReasonsDate: null
+});
+
+// Note: legacy DRAFT, canGiveCompliantStartDate is null. Its old start date answers no longer fit the new start date flow, so clear and make trainee complete that page from scratch. ('New' drafts that haven't answered the question yet already have these fields null).
+export const resetLegacyStartDateSection = (
+  ltftObj: LtftObjNew
+): LtftObjNew => {
+  const isLegacyDraft =
+    ltftObj.status?.current?.state === "DRAFT" &&
+    ltftObj.canGiveCompliantStartDate === null;
+  return isLegacyDraft ? clearStartDateSection(ltftObj) : ltftObj;
 };
 
 export async function handleLtftSummaryModalSub(
@@ -310,6 +344,17 @@ export function makeValidProgrammeOptions(
   }, [] as { value: string; label: string }[]);
 
   return programmeOptions;
+}
+
+// Note: A date stamped by a previous submission is kept and only cleared if the trainee revisits Start date page while editing unsubmitted.
+export function stampLtftStartDateOnSubmit(formData: LtftObjNew): LtftObjNew {
+  if (formData.canGiveCompliantStartDate !== false || formData.startDate) {
+    return formData;
+  }
+  return {
+    ...formData,
+    startDate: computedValueGenerators.ltft16WeeksNoticeDate()
+  };
 }
 
 export function findLatestSubmissionDate(formData: LtftObjNew): string | null {

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -81,14 +81,8 @@ export const mapLtftObjToDto = (ltftObj: LtftObjNew): LtftDto => {
     name: ltftObj.name ?? null,
     change: {
       type: "LTFT",
-      isExceptional:
-        ltftObj.canGiveCompliantStartDate == null
-          ? null
-          : !ltftObj.canGiveCompliantStartDate, // Note: the persisted DTO field is the inverse (isExceptional). 'No' -> true.
       startDate: ltftObj.startDate,
       altStartDate: ltftObj.altStartDate ? ltftObj.altStartDate : null,
-      exceptionalReasons: ltftObj.exceptionalReasons ?? null,
-      exceptionalReasonsDate: ltftObj.exceptionalReasonsDate ?? null,
       wte: ltftObj.wte ? ltftObj.wte / 100 : 0,
       id: null
     },
@@ -132,6 +126,15 @@ export const mapLtftObjToDto = (ltftObj: LtftObjNew): LtftDto => {
       selected: ltftObj.reasonsSelected || [],
       otherDetail: ltftObj.reasonsOtherDetail ?? "",
       supportingInformation: ltftObj.supportingInformation ?? null
+    },
+    exceptionalReasons: {
+      // Note: the persisted DTO field is the inverse (exceptional). 'No' -> true.
+      exceptional:
+        ltftObj.canGiveCompliantStartDate == null
+          ? null
+          : !ltftObj.canGiveCompliantStartDate,
+      supportingInformation: ltftObj.exceptionalReasons ?? null,
+      startDate: ltftObj.exceptionalReasonsDate ?? null
     },
     status: {
       current: {
@@ -183,13 +186,14 @@ export const mapLtftDtoToObj = (ltftDto: LtftDto): LtftObjNew => {
     managingDeanery: ltftDto.programmeMembership.managingDeanery ?? "",
     type: ltftDto.change.type,
     canGiveCompliantStartDate:
-      ltftDto.change.isExceptional == null
+      ltftDto.exceptionalReasons?.exceptional == null
         ? null
-        : !ltftDto.change.isExceptional,
+        : !ltftDto.exceptionalReasons.exceptional,
     startDate: ltftDto.change.startDate,
     altStartDate: ltftDto.change.altStartDate ?? null,
-    exceptionalReasons: ltftDto.change.exceptionalReasons ?? null,
-    exceptionalReasonsDate: ltftDto.change.exceptionalReasonsDate ?? null,
+    exceptionalReasons:
+      ltftDto.exceptionalReasons?.supportingInformation ?? null,
+    exceptionalReasonsDate: ltftDto.exceptionalReasons?.startDate ?? null,
     wteBeforeChange: ltftDto.programmeMembership.wte
       ? Math.round(ltftDto.programmeMembership.wte * 100)
       : null,

--- a/utilities/ltftUtilities.ts
+++ b/utilities/ltftUtilities.ts
@@ -266,6 +266,10 @@ export const clearStartDateSection = (ltftObj: LtftObjNew): LtftObjNew => ({
   exceptionalReasonsDate: null
 });
 
+export const hasLegacyStartDateData = (ltftObj: LtftObjNew): boolean =>
+  ltftObj.canGiveCompliantStartDate === null &&
+  (ltftObj.startDate != null || ltftObj.altStartDate != null);
+
 // Note: legacy DRAFT, canGiveCompliantStartDate is null. Its old start date answers no longer fit the new start date flow, so clear and make trainee complete that page from scratch. ('New' drafts that haven't answered the question yet already have these fields null).
 export const resetLegacyStartDateSection = (
   ltftObj: LtftObjNew

--- a/utilities/pageGates.ts
+++ b/utilities/pageGates.ts
@@ -1,0 +1,44 @@
+import type { FormData } from "../components/forms/form-builder/FormBuilder";
+import { LtftObjNew } from "../models/LtftTypes";
+import {
+  ltftLegacyStartDateGateCancelBtn,
+  ltftLegacyStartDateGateLabel,
+  ltftLegacyStartDateGateProceedBtn,
+  ltftLegacyStartDateGateSkipBtn,
+  ltftLegacyStartDateGateSkipHint,
+  ltftLegacyStartDateGateText
+} from "./Constants";
+import { clearStartDateSection, hasLegacyStartDateData } from "./ltftUtilities";
+
+// Note: this registry lives here rather than in FormBuilderUtilities because ltftUtilities already imports from FormBuilderUtilities, so a form-specific import in that direction would create a circular dependency.
+
+export type PageGateName = "ltftLegacyStartDate";
+
+export type PageGate = {
+  // Note: when true, the trainee is warned before the page is allowed to become the current page (see FormBuilder goToPage). Holding currentPage is enough to stop the page's fields being applied, and so stops clearHiddenFieldValues wiping values that are no longer visible under the reworked page.
+  shouldGate: (formData: FormData) => boolean;
+  onProceed: (formData: FormData) => FormData;
+  warningLabel: string;
+  warningText: string;
+  proceedBtnText: string;
+  skipBtnText: string;
+  skipHint: string;
+  cancelBtnText: string;
+};
+
+export const pageGates: Record<PageGateName, PageGate> = {
+  ltftLegacyStartDate: {
+    shouldGate: formData => hasLegacyStartDateData(formData as LtftObjNew),
+    onProceed: formData => clearStartDateSection(formData as LtftObjNew),
+    warningLabel: ltftLegacyStartDateGateLabel,
+    warningText: ltftLegacyStartDateGateText,
+    proceedBtnText: ltftLegacyStartDateGateProceedBtn,
+    skipBtnText: ltftLegacyStartDateGateSkipBtn,
+    skipHint: ltftLegacyStartDateGateSkipHint,
+    cancelBtnText: ltftLegacyStartDateGateCancelBtn
+  }
+};
+
+export function getPageGate(gateName?: PageGateName): PageGate | undefined {
+  return gateName ? pageGates[gateName] : undefined;
+}


### PR DESCRIPTION
... with support for legacy forms.

Replace the old "late application / alternative start date" model on the LTFT Start date page with a exceptional reasons-based flow, while keeping legacy submitted forms readable and editable (via UNSUBMITTED status).

New Start date flow (`ltft.json`):
- Add `canGiveCompliantStartDate` radio ("at least 16 weeks' notice?")
- Yes path: `startDate` with an earliest-date info notice (16 weeks from today)
- No path: capture exceptional reason(s) + requested date; the 16-week notice date is stamped as `startDate` on submission (`stampLtftStartDateOnSubmit`)
- Remove `altStartDate`/late-application warnings and supporting-info warning

Form builder changes:
- New "info" field type + `InfoText` component with read-only inset text plus {value} token (see `computedValueGenerators` - `ltft16WeeksNoticeDate`)
- Field flags `hideInViewWhenEmpty` and `showInViewWhenPopulated`, resolved via `getFieldViewState` (hidden/editable/readOnly) in FormViewBuilder
- `pageNotices` support in `FormViewBuilder` for per-page notices (e.g. dealing with legacy `UNSUBMITTED` forms in `FormView.tsx`)
- Extract `clearHiddenFieldValues` from `FormContext`; skip schema-less (e.g. `info`) fields in `validateFields`

FE/BE mapping:
- Map `exceptionalReasons.exceptional` <-> `canGiveCompliantStartDate` (inverse) in FE DTO for BE persistence

Legacy backwards compatibility:
- Legacy `SUBMITTED` forms: read-only start-date notice in `LtftFormView`
- Legacy `SUBMITTED` -> `UNSUBMITTED`: editing another page leaves the old start date untouched; editing the start date section clears it (via modal + `clearStartDateSection`) so it's re-entered in the new format
- Legacy `DRAFT` forms reset the start date section on load (see `resetLegacyStartDateSection`)

(see [ticket description](https://hee-tis.atlassian.net/browse/TIS21-8853) for a 'new vs legacy' QA checklist)

TIS21-8853

